### PR TITLE
admin user is not being created

### DIFF
--- a/data/web/inc/init.sql
+++ b/data/web/inc/init.sql
@@ -276,6 +276,6 @@ CREATE TABLE IF NOT EXISTS sogo_user_profile (
 	PRIMARY KEY (c_uid)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 
-INSERT INTO `admin` (username, password, superadmin, created, modified, active) SELECT 'admin', '{SSHA256}K8eVJ6YsZbQCfuJvSUbaQRLr0HPLz5rC9IAp0PAFl0tmNDBkMDc0NDAyOTAxN2Rk', 1, NOW(), NOW(), 1 FROM `admin` WHERE NOT EXISTS (SELECT * FROM `admin`);
+INSERT INTO `admin` (username, password, superadmin, created, modified, active) SELECT 'admin', '{SSHA256}K8eVJ6YsZbQCfuJvSUbaQRLr0HPLz5rC9IAp0PAFl0tmNDBkMDc0NDAyOTAxN2Rk', 1, NOW(), NOW(), 1 WHERE NOT EXISTS (SELECT * FROM `admin`);
 DELETE FROM `domain_admins`;
 INSERT INTO `domain_admins` (username, domain, created, active) SELECT `username`, 'ALL', NOW(), 1 FROM `admin` WHERE superadmin='1' AND `username` NOT IN (SELECT `username` FROM `domain_admins`);


### PR DESCRIPTION
Moin,

I just tried a fresh setup and it did not create the admin user therefore I was not able to login.

```sql
MariaDB [mailcow]> select * from admin;
Empty set (0.01 sec)
```

Please have a look, this might fix the problem.

cheers,
carazzim0