### PR TITLE
Improved Autodiscover

### DIFF
--- a/data/web/autodiscover.php
+++ b/data/web/autodiscover.php
@@ -1,6 +1,4 @@
 <?php
-header("Content-Type: application/xml");
-require_once "inc/vars.inc.php";
 $config = array(
      'useEASforOutlook' => 'yes',
      'autodiscoverType' => 'activesync',
@@ -15,22 +13,43 @@ $config = array(
        'ssl' => 'on'
      ),
      'activesync' => array(
-       'url' => 'https://' . $mailcow_hostname . '/Microsoft-Server-ActiveSync'
+       'url' => 'https://'.$mailcow_hostname.'/Microsoft-Server-ActiveSync'
      )
 );
-// If useEASforOutlook == no, the autodiscoverType option will be replaced to imap.
+
+/* ---------- DO NOT MODIFY ANYTHING BEYOND THIS LINE. IGNORE AT YOUR OWN RISK. ---------- */
+
 if ($config['useEASforOutlook'] == 'no') {
 	if (strpos($_SERVER['HTTP_USER_AGENT'], 'Outlook')) {
 		$config['autodiscoverType'] = 'imap';
 	}
 }
-// Workaround for short open tags
-echo '<?xml version="1.0" encoding="utf-8" ?>';
-?>
-<Autodiscover xmlns="http://schemas.microsoft.com/exchange/autodiscover/responseschema/2006">
-<?php
-$data = trim(file_get_contents("php://input"));
-if(!$data) {
+require_once 'inc/vars.inc.php';
+include_once 'inc/vars.local.inc.php';
+require_once 'inc/functions.inc.php';
+
+$dsn = "$database_type:host=$database_host;dbname=$database_name";
+$opt = [
+		PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+		PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+		PDO::ATTR_EMULATE_PREPARES   => false,
+];
+$pdo = new PDO($dsn, $database_user, $database_pass, $opt);
+$login_user = strtolower(trim($_SERVER['PHP_AUTH_USER']));
+$as = check_login($login_user, $_SERVER['PHP_AUTH_PW']);
+
+if (!isset($_SERVER['PHP_AUTH_USER']) OR $as !== "user") {
+	header('WWW-Authenticate: Basic realm=""');
+	header('HTTP/1.0 401 Unauthorized');
+	exit;
+} else {
+	if (isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {
+		if ($as === "user") {
+      header("Content-Type: application/xml");
+      echo '<?xml version="1.0" encoding="utf-8" ?><Autodiscover xmlns="http://schemas.microsoft.com/exchange/autodiscover/responseschema/2006">';
+
+      $data = trim(file_get_contents("php://input"));
+      if(!$data) {
         list($usec, $sec) = explode(' ', microtime());
         echo '<Response>';
         echo '<Error Time="' . date('H:i:s', $sec) . substr($usec, 0, strlen($usec) - 2) . '" Id="2477272013">';
@@ -38,84 +57,81 @@ if(!$data) {
         echo '</Response>';
         echo '</Autodiscover>';
         exit(0);
-}
+      }
+      $discover = new SimpleXMLElement($data);
+      $email = $discover->Request->EMailAddress;
 
-$discover = new SimpleXMLElement($data);
-$email = $discover->Request->EMailAddress;
-
-if ($config['autodiscoverType'] == 'imap') {
-?>
-<Response xmlns="http://schemas.microsoft.com/exchange/autodiscover/outlook/responseschema/2006a">
-    <Account>
-        <AccountType>email</AccountType>
-        <Action>settings</Action>
-        <Protocol>
-            <Type>IMAP</Type>
-            <Server><?php echo $config['imap']['server']; ?></Server>
-            <Port><?php echo $config['imap']['port']; ?></Port>
-            <DomainRequired>off</DomainRequired>
-            <LoginName><?php echo $email; ?></LoginName>
-            <SPA>off</SPA>
-            <SSL><?php echo $config['imap']['ssl']; ?></SSL>
-            <AuthRequired>on</AuthRequired>
-        </Protocol>
-        <Protocol>
-            <Type>SMTP</Type>
-            <Server><?php echo $config['smtp']['server']; ?></Server>
-            <Port><?php echo $config['smtp']['port']; ?></Port>
-            <DomainRequired>off</DomainRequired>
-            <LoginName><?php echo $email; ?></LoginName>
-            <SPA>off</SPA>
-            <SSL><?php echo $config['smtp']['ssl']; ?></SSL>
-            <AuthRequired>on</AuthRequired>
-            <UsePOPAuth>on</UsePOPAuth>
-            <SMTPLast>off</SMTPLast>
-        </Protocol>
-    </Account>
-</Response>
-<?php
-}
-else if ($config['autodiscoverType'] == 'activesync') {
-	$dsn = "$database_type:host=$database_host;dbname=$database_name";
-	$opt = [
-	    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-	    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-	    PDO::ATTR_EMULATE_PREPARES   => false,
-	];
-	$pdo = new PDO($dsn, $database_user, $database_pass, $opt);
-	$username = trim($email);
-	try {
-		$stmt = $pdo->prepare("SELECT `name` FROM `mailbox` WHERE `username`= :username");
-		$stmt->execute(array(':username' => $username));
-		$MailboxData = $stmt->fetch(PDO::FETCH_ASSOC);
-	}
-	catch(PDOException $e) {
-		die("Failed to determine name from SQL");
-	}
-	if (!empty($MailboxData['name'])) {
-		$displayname = utf8_encode($MailboxData['name']);
-	}
-	else {
-		$displayname = $email;
-	}
-?>
-<Response xmlns="http://schemas.microsoft.com/exchange/autodiscover/mobilesync/responseschema/2006">
-    <Culture>en:en</Culture>
-    <User>
-        <DisplayName><?php echo $displayname; ?></DisplayName>
-        <EMailAddress><?php echo $email; ?></EMailAddress>
-    </User>
-    <Action>
-        <Settings>
-            <Server>
-                <Type>MobileSync</Type>
-                <Url><?php echo $config['activesync']['url']; ?></Url>
-                <Name><?php echo $config['activesync']['url']; ?></Name>
-            </Server>
-        </Settings>
-    </Action>
-</Response>
-<?php
-}
-?>
+      if ($config['autodiscoverType'] == 'imap') {
+      ?>
+  <Response xmlns="http://schemas.microsoft.com/exchange/autodiscover/outlook/responseschema/2006a">
+      <Account>
+          <AccountType>email</AccountType>
+          <Action>settings</Action>
+          <Protocol>
+              <Type>IMAP</Type>
+              <Server><?php echo $config['imap']['server']; ?></Server>
+              <Port><?php echo $config['imap']['port']; ?></Port>
+              <DomainRequired>off</DomainRequired>
+              <LoginName><?php echo $email; ?></LoginName>
+              <SPA>off</SPA>
+              <SSL><?php echo $config['imap']['ssl']; ?></SSL>
+              <AuthRequired>on</AuthRequired>
+          </Protocol>
+          <Protocol>
+              <Type>SMTP</Type>
+              <Server><?php echo $config['smtp']['server']; ?></Server>
+              <Port><?php echo $config['smtp']['port']; ?></Port>
+              <DomainRequired>off</DomainRequired>
+              <LoginName><?php echo $email; ?></LoginName>
+              <SPA>off</SPA>
+              <SSL><?php echo $config['smtp']['ssl']; ?></SSL>
+              <AuthRequired>on</AuthRequired>
+              <UsePOPAuth>on</UsePOPAuth>
+              <SMTPLast>off</SMTPLast>
+          </Protocol>
+      </Account>
+  </Response>
+      <?php
+      }
+      else if ($config['autodiscoverType'] == 'activesync') {
+        $username = trim($email);
+        try {
+          $stmt = $pdo->prepare("SELECT `name` FROM `mailbox` WHERE `username`= :username");
+          $stmt->execute(array(':username' => $username));
+          $MailboxData = $stmt->fetch(PDO::FETCH_ASSOC);
+        }
+        catch(PDOException $e) {
+          die("Failed to determine name from SQL");
+        }
+        if (!empty($MailboxData['name'])) {
+          $displayname = utf8_encode($MailboxData['name']);
+        }
+        else {
+          $displayname = $email;
+        }
+      ?>
+  <Response xmlns="http://schemas.microsoft.com/exchange/autodiscover/mobilesync/responseschema/2006">
+      <Culture>en:en</Culture>
+      <User>
+          <DisplayName><?php echo $displayname; ?></DisplayName>
+          <EMailAddress><?php echo $email; ?></EMailAddress>
+      </User>
+      <Action>
+          <Settings>
+              <Server>
+                  <Type>MobileSync</Type>
+                  <Url><?php echo $config['activesync']['url']; ?></Url>
+                  <Name><?php echo $config['activesync']['url']; ?></Name>
+              </Server>
+          </Settings>
+      </Action>
+  </Response>
+      <?php
+      }
+      ?>
 </Autodiscover>
+<?php
+		}
+	}
+}
+?>


### PR DESCRIPTION
Hi Andre,

I have noticed that the current autodiscover code reveals the owner's full name without any prior authentication, particularly this [line](https://github.com/andryyy/mailcow-dockerized/blob/master/data/web/autodiscover.php#L105). Which I believe as a **SECURITY ISSUE**. So, as a solution, I have implemented a basic authentication process in mailcow's autodiscover config file, just like what Microsoft Outlook did in their [autodiscover config](https://outlook.live.com/autodiscover/autodiscover.xml) (See Figure 1 and Figure 2 below). I have also tested this in Microsoft's official [Connectivity Tester/Analyzer](https://testconnectivity.microsoft.com/), Microsoft Outlook 2013 and Stock Android Client. And, so far my tests were successful (See Figure 3 and Figure 4 below). Theoretically, this should not be a bottleneck on most cases (if not all), because Basic Authentication is supported by most (if not all) email clients with autodiscover functionality. And that this should prevent unauthorized users from viewing personal information (E.g. mailbox owner's full name) in mailcow's autodiscover functionality.

> ![capture](https://cloud.githubusercontent.com/assets/9730242/22851499/468cf0d2-f05e-11e6-9d7a-d13c31dd5a99.PNG) **Figure 1**: Microsoft Outlook's Autodiscover Basic Authentication

> ![capture](https://cloud.githubusercontent.com/assets/9730242/22851506/b6bc55c8-f05e-11e6-920b-acc15911b50a.PNG) **Figure 2**: mailcow's Autodiscover Basic Authentication

> ![virtualbox_windows 10_11_02_2017_17_30_39](https://cloud.githubusercontent.com/assets/9730242/22852956/135e4e52-f083-11e6-9016-260947e764f3.jpg) **Figure 3**: Test result of IMAP Autodiscover in Outlook 2013

> ![virtualbox_windows 10_11_02_2017_17_31_21](https://cloud.githubusercontent.com/assets/9730242/22852957/17d70f8c-f083-11e6-8883-d6a84fb16917.jpg) **Figure 4**: Test result of EAS Autodiscover in Outlook 2013