### PR TITLE
Update autodiscover.php

### DIFF
--- a/data/web/autodiscover.php
+++ b/data/web/autodiscover.php
@@ -1,9 +1,7 @@
 <?php
 require_once 'inc/vars.inc.php';
-if(file_exists('inc/vars.local.inc.php')) {
-	include_once 'inc/vars.local.inc.php';
-}
 ini_set('error_reporting', '0');
+
 $config = array(
      'useEASforOutlook' => 'yes',
      'autodiscoverType' => 'activesync',
@@ -23,6 +21,9 @@ $config = array(
 );
 
 /* ---------- DO NOT MODIFY ANYTHING BEYOND THIS LINE. IGNORE AT YOUR OWN RISK. ---------- */
+if(file_exists('inc/vars.local.inc.php')) {
+	include_once 'inc/vars.local.inc.php';
+}
 
 if ($config['useEASforOutlook'] == 'no') {
 	if (strpos($_SERVER['HTTP_USER_AGENT'], 'Outlook')) {


### PR DESCRIPTION
I guess we should leave the 'inc/vars.local.inc.php' below the config array so that the user can override the values of the array without loosing modifications everytime he/she updates.

However, I think things were different in the dockerized version, so maybe, ignore this PR if needed.