### PR TITLE
fix broken autodiscover

### DIFF
--- a/data/web/autodiscover.php
+++ b/data/web/autodiscover.php
@@ -1,4 +1,7 @@
+<?php
 require_once 'inc/vars.inc.php';
+require_once 'inc/functions.inc.php';
+
 ini_set('error_reporting', '0');
 $config = array(
      'useEASforOutlook' => 'yes',


### PR DESCRIPTION
Moin,

I just tested autodiscovery but this did not work.

```
➜ basti@xxxx-xxxxxx  ~  curl https://autodiscover.example.com
<br />
<b>Parse error</b>:  syntax error, unexpected 'version' (T_STRING) in <b>/web/autodiscover.php</b> on line <b>51</b><br />
```

Adding the opening php-tag solved this.

But then there was only an empty response so i needed to reinclude the `functions.inc.php` again.

```
➜ basti@xxxx-xxxxxx  ~  curl -k https://autodiscover.example.com
* Rebuilt URL to: https://autodiscover.example.com
*   Trying ipv6_bla_bla
* TCP_NODELAY set
* Connected to autodiscover.example.com (ipv6_bla_bla) port 443 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
*   CAfile: /etc/pki/tls/certs/ca-bundle.crt
  CApath: none
* ALPN/NPN, server did not agree to a protocol
* SSL connection using TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
* Server certificate:
* 	subject: CN=xxx
* 	start date: Feb 16 12:03:00 2017 GMT
* 	expire date: May 17 12:03:00 2017 GMT
* 	common name: xxx
* 	issuer: CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US
> GET / HTTP/1.1
> Host: autodiscover.example.com
> User-Agent: curl/7.51.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: nginx/1.11.10
< Date: Thu, 16 Feb 2017 13:20:46 GMT
< Content-Type: text/html; charset=utf-8
< Transfer-Encoding: chunked
< Connection: keep-alive
< X-Powered-By: PHP/7.1.1
< Strict-Transport-Security: max-age=15768000; includeSubDomains
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-XSS-Protection: 1; mode=block
< 
* Curl_http_done: called premature == 0
* Connection #0 to host autodiscover.example.com left intact
```