### PR TITLE
Added temporary alias count

### DIFF
--- a/data/web/lang/lang.en.php
+++ b/data/web/lang/lang.en.php
@@ -245,6 +245,7 @@ $lang['mailbox']['add_domain_alias'] = 'Add domain alias';
 $lang['mailbox']['add_mailbox'] = 'Add mailbox';
 $lang['mailbox']['add_resource'] = 'Add resource';
 $lang['mailbox']['add_alias'] = 'Add alias';
+$lang['mailbox']['temp_aliases'] = 'Temp. aliases';
 
 $lang['info']['no_action'] = 'No action applicable';
 

--- a/data/web/mailbox.php
+++ b/data/web/mailbox.php
@@ -151,24 +151,24 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
               if (!empty($mailboxes)) {
                 foreach ($mailboxes as $mailbox) {
                   $mailboxdata = mailbox_get_mailbox_details($mailbox);
-									try {
-										$stmt = $pdo->prepare("SELECT IFNULL(COUNT(`address`), 0) AS `spamalias`
-														FROM `spamalias`
-															WHERE `goto` = :username
-																AND `validity` >= :unixnow");
-										$stmt->execute(array(
-											':username' => $mailboxdata['username'],
-											':unixnow' => time()
-										));
-										$temp_alias = $stmt->fetchAll(PDO::FETCH_ASSOC);
-									} catch (PDOException $e) {
-										$_SESSION['return'] = array(
-											'type' => 'danger',
-											'msg' => 'MySQL: '.$e
-										);
-										return false;
-									}
-						?>
+                  try {
+                    $stmt = $pdo->prepare("SELECT IFNULL(COUNT(`address`), 0) AS `spamalias`
+                      FROM `spamalias`
+                      WHERE `goto` = :username
+                      AND `validity` >= :unixnow");
+                    $stmt->execute(array(
+                      ':username' => $mailboxdata['username'],
+                      ':unixnow' => time()
+                    ));
+                    $temp_alias = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                  } catch (PDOException $e) {
+                    $_SESSION['return'] = array(
+                      'type' => 'danger',
+                      'msg' => 'MySQL: '.$e
+                    );
+                    return false;
+                  }
+                  ?>
 						<tr id="data">
 							<td><?=($mailboxdata['is_relayed'] == "0") ? htmlspecialchars($mailboxdata['username']) : '<span data-toggle="tooltip" title="Relayed"><i class="glyphicon glyphicon-forward"></i>' . htmlspecialchars($mailboxdata['username']) . '</span>';?></td>
 							<td><?=htmlspecialchars($mailboxdata['name'], ENT_QUOTES, 'UTF-8');?></td>

--- a/data/web/mailbox.php
+++ b/data/web/mailbox.php
@@ -199,7 +199,7 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
               }
               else {
                   ?>
-                  <tr id="no-data"><td colspan="8" style="text-align: center; font-style: italic;"><?=sprintf($lang['mailbox']['no_record'], $domain);?></td></tr>
+                  <tr id="no-data"><td colspan="9" style="text-align: center; font-style: italic;"><?=sprintf($lang['mailbox']['no_record'], $domain);?></td></tr>
                   <?php
               }
             }
@@ -207,7 +207,7 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
 					</tbody>
 					<tfoot>
 						<tr id="no-data">
-							<td colspan="8" style="text-align: center; border-top: 1px solid #e7e7e7;">
+							<td colspan="9" style="text-align: center; border-top: 1px solid #e7e7e7;">
 								<a href="/add.php?mailbox"><?=$lang['mailbox']['add_mailbox'];?></a>
 							</td>
 						</tr>

--- a/data/web/mailbox.php
+++ b/data/web/mailbox.php
@@ -153,9 +153,9 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
                   $mailboxdata = mailbox_get_mailbox_details($mailbox);
                   try {
                     $stmt = $pdo->prepare("SELECT IFNULL(COUNT(`address`), 0) AS `spamalias`
-                      FROM `spamalias`
-                      WHERE `goto` = :username
-                      AND `validity` >= :unixnow");
+                        FROM `spamalias`
+                          WHERE `goto` = :username
+                            AND `validity` >= :unixnow");
                     $stmt->execute(array(
                       ':username' => $mailboxdata['username'],
                       ':unixnow' => time()


### PR DESCRIPTION
Hi,

This feature should tell the domain admin how many **temporary aliases** did a mailbox user created. <strike>Since mailcow now supports dual-login, I don't think there's a need to limit the creation of temporary aliases.</strike>
![capture](https://cloud.githubusercontent.com/assets/9730242/23089077/9536c5a4-f5be-11e6-850d-7470385cf13b.PNG)
