### PR TITLE
Enable portainer (container monitoring)

### DIFF
--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -1,4 +1,14 @@
 proxy_cache_path /tmp levels=1:2 keys_zone=sogo:10m inactive=24h  max_size=1g;
+
+upstream portainer {
+  server portainer-mailcow:9000;
+}
+
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
 server {
   include /etc/nginx/conf.d/listen.active;
   include /etc/nginx/mime.types;

--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -132,5 +132,24 @@ server {
     proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
     #alias /usr/lib/GNUstep/SOGo/$1.SOGo/Resources/$2;
   }
+  
+  location /portainer/ {
+    proxy_http_version 1.1;
+    proxy_set_header Host              $http_host;   # required for docker client's sake
+    proxy_set_header X-Real-IP         $remote_addr; # pass on real client's IP
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout                 900;
+
+    proxy_set_header Connection "";
+    proxy_buffers 32 4k;
+    proxy_pass http://portainer/;   }
+
+  location /portainer/api/websocket/ {
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_pass http://portainer/api/websocket/;
+  }
 
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,19 @@ services:
           aliases:
             - pdns
 
+    portainer-mailcow:
+      image: portainer/portainer
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+      restart: always
+      dns:
+        - 172.22.1.254
+      dns_search: mailcow-network
+      networks:
+        mailcow-network:
+          aliases:
+            - portainer
+
     mysql-mailcow:
       image: mariadb:10.1
       healthcheck:


### PR DESCRIPTION
Updated the docker-compose and added 2 section blocks to the nginx site.conf to enable portainer to be integrated

can then be accessed at: https://{MAILCOW_HOSTNAME}/portainer/