### PR TITLE
Remember Username feature

### DIFF
--- a/data/web/inc/footer.inc.php
+++ b/data/web/inc/footer.inc.php
@@ -29,11 +29,29 @@ endif;
 <script src="/js/bootstrap-select.min.js"></script>
 <script src="/js/u2f-api.js"></script>
 <script>
-// Select language and reopen active URL without POST
-function setLang(sel) {
-	$.post( "<?=$_SERVER['REQUEST_URI'];?>", {lang: sel} );
-	window.location.href = window.location.pathname + window.location.search;
-}
+$(document).ready(function(){
+    $('[data-toggle="tooltip"]').tooltip();
+});
+	
+$('.nav-tabs > li > #domainadmin').click(function(event){
+	if(document.getElementById('admin_un_cache').value != document.getElementById('login_user').value) {
+		$('#user_un_cache').val(document.getElementById('login_user').value);
+		$('#login_user').val(document.getElementById('admin_un_cache').value);
+		$('#user_pw_cache').val(document.getElementById('pass_user').value);
+		$('#pass_user').val(document.getElementById('admin_pw_cache').value);
+	}
+	$('#login_role').val(event.target.id);
+});
+
+$('.nav-tabs > li > #mailboxuser').click(function(event){
+	if(document.getElementById('user_un_cache').value != document.getElementById('login_user').value) {
+		$('#admin_un_cache').val(document.getElementById('login_user').value);
+		$('#login_user').val(document.getElementById('user_un_cache').value);
+		$('#admin_pw_cache').val(document.getElementById('pass_user').value);
+		$('#pass_user').val(document.getElementById('user_pw_cache').value);
+	}
+	$('#login_role').val(event.target.id);
+});
 
 $(document).ready(function() {
   // Confirm TFA modal

--- a/data/web/inc/header.inc.php
+++ b/data/web/inc/header.inc.php
@@ -24,6 +24,7 @@
 <link rel="icon" href="/favicon.png" type="image/png">
 </head>
 <body style="padding-top:70px">
+<?php if(basename($_SERVER["SCRIPT_FILENAME"]) !== "index.php"): ?>
 <nav class="navbar navbar-default navbar-fixed-top"  role="navigation">
 	<div class="container-fluid">
 		<div class="navbar-header">
@@ -101,4 +102,5 @@
 		</div><!--/.nav-collapse -->
 	</div><!--/.container-fluid -->
 </nav>
+<?php endif; ?>
 <form action="/" method="post" id="logout"><input type="hidden" name="logout"></form>

--- a/data/web/inc/prerequisites.inc.php
+++ b/data/web/inc/prerequisites.inc.php
@@ -43,6 +43,7 @@ catch (PDOException $e) {
 ?>
 <center style='font-family: "Lucida Sans Unicode", "Lucida Grande", Verdana, Arial, Helvetica, sans-serif;'>🐮 Connection failed, database may be in warm-up state, please try again later.<br /><br />The following error was reported:<br/>  <?=$e->getMessage();?></center>
 <?php
+exit;
 }
 
 if(isset($_COOKIE['admin']))	{

--- a/data/web/inc/prerequisites.inc.php
+++ b/data/web/inc/prerequisites.inc.php
@@ -45,6 +45,17 @@ catch (PDOException $e) {
 <?php
 }
 
+if(isset($_COOKIE['admin']))	{
+	$AdminLogin = $_COOKIE['admin'];
+} else {
+	$AdminLogin = '';
+}
+if(isset($_COOKIE['user']))	{
+	$UserLogin = $_COOKIE['user'];
+} else {
+	$UserLogin = '';
+}
+
 $_SESSION['mailcow_locale'] = strtolower(trim($DEFAULT_LANG));
 setcookie('language', $DEFAULT_LANG);
 if (isset($_COOKIE['language'])) {

--- a/data/web/inc/triggers.inc.php
+++ b/data/web/inc/triggers.inc.php
@@ -13,19 +13,28 @@ if (isset($_POST["verify_tfa_login"])) {
 if (isset($_POST["login_user"]) && isset($_POST["pass_user"])) {
 	$login_user = strtolower(trim($_POST["login_user"]));
 	$as = check_login($login_user, $_POST["pass_user"]);
-	if ($as == "admin") {
+	if ($as == "admin" && "domainadmin" == $_POST["login_role"]) {
 		$_SESSION['mailcow_cc_username'] = $login_user;
 		$_SESSION['mailcow_cc_role'] = "admin";
+		if(isset($_POST["remember_user"]) && $_POST["remember_user"]) {
+ 			setcookie("admin", $login_user, time() + (86400 * 5));
+ 		}
 		header("Location: /admin.php");
 	}
-	elseif ($as == "domainadmin") {
+	elseif ($as == "domainadmin" && "domainadmin" == $_POST["login_role"]) {
 		$_SESSION['mailcow_cc_username'] = $login_user;
 		$_SESSION['mailcow_cc_role'] = "domainadmin";
+		if(isset($_POST["remember_user"]) && $_POST["remember_user"]) {
+ 			setcookie("admin", $login_user, time() + (86400 * 5));
+ 		}
 		header("Location: /mailbox.php");
 	}
-	elseif ($as == "user") {
+	elseif ($as == "user" && "mailboxuser" == $_POST["login_role"]) {
 		$_SESSION['mailcow_cc_username'] = $login_user;
 		$_SESSION['mailcow_cc_role'] = "user";
+		if(isset($_POST["remember_user"]) && $_POST["remember_user"]) {
+ 			setcookie("user", $login_user, time() + (86400 * 5));
+		}
 		header("Location: /user.php");
 	}
 	elseif ($as != "pending") {

--- a/data/web/index.php
+++ b/data/web/index.php
@@ -50,7 +50,7 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
 						</div>
 						<div class="form-group">
 							<div class="checkbox">
- 								<label><input data-toggle="tooltip" title="Remember username for 5 days" type="checkbox" name="remember_user"> Remember me</label>
+ 								<label><input data-toggle="tooltip" title="<?=$lang['login']['remember_me_tooltip'];?>" type="checkbox" name="remember_user"> <?=$lang['login']['remember_me'];?></label>
  							</div>
  						</div>
  						<div class="form-group">

--- a/data/web/index.php
+++ b/data/web/index.php
@@ -24,22 +24,37 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
 				<div class="panel-body">
 				  <center><img style="max-width:250px" src="/img/cow_mailcow.svg" alt="mailcow"></center>
 					<legend>mailcow UI</legend>
+					<ul class="nav nav-tabs">
+						<li class="active"><a data-toggle="tab" href="" id="domainadmin" aria-expanded="true">Domain administrator</a></li>
+						<li class=""><a data-toggle="tab" href="" id="mailboxuser" aria-expanded="false">Mailbox user</a></li>
+					</ul>
+ 						<br>
 						<form method="post" autofill="off">
 						<div class="form-group">
 							<label class="sr-only" for="login_user"><?=$lang['login']['username'];?></label>
 							<div class="input-group">
 								<div class="input-group-addon"><i class="glyphicon glyphicon-user"></i></div>
-								<input name="login_user" autocorrect="off" autocapitalize="none" type="name" id="login_user" class="form-control" placeholder="<?=$lang['login']['username'];?>" required="" autofocus="">
+								<input type="hidden" id="admin_un_cache" value="<?=$AdminLogin?>">
+								<input type="hidden" id="user_un_cache" value="<?=$UserLogin?>">
+								<input name="login_user" value="<?=$AdminLogin?>" autocorrect="off" autocapitalize="none" type="name" id="login_user" class="form-control" placeholder="<?=$lang['login']['username'];?>" required="" autofocus="">
 							</div>
 						</div>
 						<div class="form-group">
 							<label class="sr-only" for="pass_user"><?=$lang['login']['password'];?></label>
 							<div class="input-group">
 								<div class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></div>
+								<input type="hidden" id="admin_pw_cache">
+								<input type="hidden" id="user_pw_cache">
 								<input name="pass_user" type="password" id="pass_user" class="form-control" placeholder="<?=$lang['login']['password'];?>" required="">
 							</div>
 						</div>
 						<div class="form-group">
+							<div class="checkbox">
+ 								<label><input data-toggle="tooltip" title="Remember username for 5 days" type="checkbox" name="remember_user"> Remember me</label>
+ 							</div>
+ 						</div>
+ 						<div class="form-group">
+							<input type="hidden" id="login_role" name="login_role" value="domainadmin">
 							<button type="submit" class="btn btn-success" value="Login"><?=$lang['login']['login'];?></button>
 							<div class="btn-group pull-right">
 								<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/data/web/lang/lang.en.php
+++ b/data/web/lang/lang.en.php
@@ -374,6 +374,8 @@ $lang['login']['reset_password'] = 'Reset my password';
 $lang['login']['login'] = 'Login';
 $lang['login']['previous'] = "Previous page";
 $lang['login']['delayed'] = 'Login was delayed by %s seconds.';
+$lang['login']['domain_admin'] = "Domain administrator";
+$lang['login']['mailbox_user'] = "Mailbox user";
 $lang['login']['remember_me'] = "Remember me";
 $lang['login']['remember_me_tooltip'] = "Remember username for 5 days";
 
@@ -385,7 +387,7 @@ $lang['tfa']['api_register'] = 'mailcow uses the Yubico Cloud API. Please get an
 $lang['tfa']['u2f'] = "U2F authentication";
 $lang['tfa']['hotp'] = "HOTP authentication";
 $lang['tfa']['totp'] = "TOTP authentication";
-$lang['tfa']['none'] = "Deaktiviert";
+$lang['tfa']['none'] = "Deactivate";
 $lang['tfa']['delete_tfa'] = "Disable TFA";
 $lang['tfa']['disable_tfa'] = "Disable TFA until next successful login";
 $lang['tfa']['confirm_tfa'] = "Please confirm your one-time password in the below field";

--- a/data/web/lang/lang.en.php
+++ b/data/web/lang/lang.en.php
@@ -374,6 +374,8 @@ $lang['login']['reset_password'] = 'Reset my password';
 $lang['login']['login'] = 'Login';
 $lang['login']['previous'] = "Previous page";
 $lang['login']['delayed'] = 'Login was delayed by %s seconds.';
+$lang['login']['remember_me'] = "Remember me";
+$lang['login']['remember_me_tooltip'] = "Remember username for 5 days";
 
 $lang['tfa']['tfa'] = "Two-factor authentication";
 $lang['tfa']['set_tfa'] = "Set two-factor authentication method";


### PR DESCRIPTION
This feature allows the `mailbox` and `*admin` users to save a cookie of their username ( in their web browser for 5 days)  on every successful logins. This makes logging in simpler.
* Tabbed remember me feature
* Fixed some missing translation strings.
* HTML improved
* Fixed some PHP errors and Warnings when DB is N/A



![untitled](https://cloud.githubusercontent.com/assets/9730242/23326882/519cd65a-fb3e-11e6-9fc6-4e4a00a5317d.jpg)
