### PR TITLE
Fixed some PHP Errors and PHP Warnings

### DIFF
--- a/data/web/inc/prerequisites.inc.php
+++ b/data/web/inc/prerequisites.inc.php
@@ -43,6 +43,7 @@ catch (PDOException $e) {
 ?>
 <center style='font-family: "Lucida Sans Unicode", "Lucida Grande", Verdana, Arial, Helvetica, sans-serif;'>🐮 Connection failed, database may be in warm-up state, please try again later.<br /><br />The following error was reported:<br/>  <?=$e->getMessage();?></center>
 <?php
+exit;
 }
 
 $_SESSION['mailcow_locale'] = strtolower(trim($DEFAULT_LANG));


### PR DESCRIPTION
Hi @andryyy,
We should stop the PHP code execution if we can't connect to the database, otherwise we'll be greeted with PHP warning and fatal erros.
![capture](https://cloud.githubusercontent.com/assets/9730242/23327272/1e4d03e6-fb44-11e6-9935-3f753ab4db46.PNG)

See the fixed version below:
![capture2](https://cloud.githubusercontent.com/assets/9730242/23327288/81d383ea-fb44-11e6-82a1-308d09ccfaf0.PNG)


I have tested this in a 512 MB RAM machine, which is enough to render the database server out of memory and unable to start.