### PR TITLE
GUI improvements: collapsible tables & password manager compatible login form

### DIFF
--- a/data/web/index.php
+++ b/data/web/index.php
@@ -29,7 +29,7 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
 							<label class="sr-only" for="login_user"><?=$lang['login']['username'];?></label>
 							<div class="input-group">
 								<div class="input-group-addon"><i class="glyphicon glyphicon-user"></i></div>
-								<input name="login_user" autocorrect="off" autocapitalize="none" type="name" id="login_user" class="form-control" placeholder="<?=$lang['login']['username'];?>" required="" autofocus="">
+								<input name="login_user" autocorrect="off" autocapitalize="none" type="text" id="login_user" class="form-control" placeholder="<?=$lang['login']['username'];?>" required="" autofocus="">
 							</div>
 						</div>
 						<div class="form-group">

--- a/data/web/js/mailbox.js
+++ b/data/web/js/mailbox.js
@@ -51,4 +51,16 @@ $(document).ready(function() {
 			$panel.find('.panel-body input').focus();
 		}
 	});
+	$('.container').on('click', '.panel-heading .panel-title', function(e){
+		var $this = $(this),
+			$panel = $this.parents('.panel');
+		$panel.find('.table-responsive').slideToggle("fast");
+	});
+	$('.panel-heading .panel-title').addClass('clickable');
+	$('.panel .table-responsive').each(function() {
+		if ($(this).height() > 550) {
+			// If one is too large initially hide all
+			$('.panel .table-responsive').slideUp("fast");
+		}
+	})
 });


### PR DESCRIPTION
Two little improvements which could be generally interesting:

- Changed the type of the user field on the login form from "name" to "text" as afaik "name" is no valid HTML and some password managers do not recognize it correctly.
- Added some JavaScript for the mailbox view which makes the tables collapsible, which is very handy when they get very long. They also are collapsed per default when there is at least one table which is higher than 550 pixel (which means in total the page height already will be very big).