### PR TITLE
Prevent accidental text-highlighting

### DIFF
--- a/data/web/css/mailcow.css
+++ b/data/web/css/mailcow.css
@@ -44,3 +44,9 @@
     }
 }
 pre{white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space:-o-pre-wrap;word-wrap:break-word;}
+.footable-sortable {
+	 -webkit-user-select: none;  
+  -moz-user-select: none;    
+  -ms-user-select: none;      
+  user-select: none;
+}


### PR DESCRIPTION
Double-clicking on the column header of the table often induces text-highlighting. Which I think is not good looking.. But this PR fixes it. 😉 

![untitled](https://cloud.githubusercontent.com/assets/9730242/24326772/20a3d714-11f1-11e7-8a8f-4e1d3f82802b.jpg)
