### PR TITLE
Warn the user about installing mailcow on Debian 8

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,5 +1,7 @@
 ## Install mailcow
 
+**WARNING**: Please use Ubuntu 16.04 instead of Debian 8 or [switch to the kernel 4.9 from jessie backports](https://packages.debian.org/jessie-backports/linux-image-amd64) because there is a bug (kernel panic) with the kernel 3.16 when running docker containers with healthchecks! Full details here: [github.com/docker/docker/issues/30402](https://github.com/docker/docker/issues/30402) and [forum.mailcow.email/t/solved-mailcow-docker-causes-kernel-panic-edit/448](https://forum.mailcow.email/t/solved-mailcow-docker-causes-kernel-panic-edit/448)
+
 You need Docker and Docker Compose.
 
 1\. Learn how to install [Docker](https://docs.docker.com/engine/installation/linux/) and [Docker Compose](https://docs.docker.com/compose/install/).


### PR DESCRIPTION
I don't know if it's the right place to warn the user about running mailcow with Docker on Debian 8.
I do this as a prevention because this happened to me and I've to wait for Debian 9 or reinstall my VPS to Ubuntu 16.04, this is really annoying.