### PR TITLE
Allow adding aliases to alias domains

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -2678,7 +2678,7 @@ function mailbox_add_alias($postarray) {
 		$address      = $local_part.'@'.$domain;
 
     $domaindata = mailbox_get_domain_details($domain);
-    if ($domaindata['aliases_left'] == 0) {
+    if (is_array($domaindata) && $domaindata['aliases_left'] == 0) {
       $_SESSION['return'] = array(
         'type' => 'danger',
         'msg' => sprintf($lang['danger']['max_alias_exceeded'])


### PR DESCRIPTION
Currently, one always gets "Max aliases exceeded" when attempting to add an alias that redirects alias@alias-domain to user@domain. This is because alias domains are listed in a separate SQL table that doesn't even have a column that specifies the maximum number of aliases.

The [documentation](https://andryyy.github.io/mailcow-dockerized/first_steps/#sender-and-receiver-model) even says that this should work:
> It is important to know, that you are not able to receive mail for my-alias@my-alias-domain.tld. You would need to create this particular alias.

However, what the documentation suggests cannot currently be done due to the error message above.

My pull request simply prevents the number of aliases from being checked on alias domains.