### PR TITLE
ClamAV virus scanning

### DIFF
--- a/data/Dockerfiles/clamav/Dockerfile
+++ b/data/Dockerfiles/clamav/Dockerfile
@@ -33,9 +33,6 @@ RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
     sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 
-# volume provision
-VOLUME ["/var/lib/clamav"]
-
 # port provision
 EXPOSE 3310
 

--- a/data/Dockerfiles/clamav/bootstrap.sh
+++ b/data/Dockerfiles/clamav/bootstrap.sh
@@ -15,7 +15,7 @@ latest_exit=0
 
 # define shutdown helper
 function shutdown() {
-    trap "" SUBS
+    trap "" EXIT
 
     for single in $pidlist; do
         if ! kill -0 $pidlist 2>/dev/null; then
@@ -28,7 +28,7 @@ function shutdown() {
 }
 
 # run shutdown
-trap terminate SUBS
+trap terminate EXIT
 wait
 
 # return received result

--- a/data/conf/rspamd/local.d/antivirus.conf
+++ b/data/conf/rspamd/local.d/antivirus.conf
@@ -1,0 +1,19 @@
+clamav {
+  # If set force this action if any virus is found (default unset: no action is forced)
+  action = "reject";
+  # if `true` only messages with non-image attachments will be checked (default true)
+  attachments_only = true;
+  # If `max_size` is set, messages > n bytes in size are not scanned
+  #max_size = 20000000;
+  # symbol to add (add it to metric if you want non-zero weight)
+  symbol = "CLAM_VIRUS";
+  # type of scanner: "clamav", "fprot", "sophos" or "savapi"
+  type = "clamav";
+  # If set true, log message is emitted for clean messages
+  #log_clean = false;
+  # servers to query (if port is unspecified, scanner-specific default is used)
+  # can be specified multiple times to pool servers
+  # can be set to a path to a unix socket
+  servers = "clamav:3310";
+  timeout = 5;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,6 +253,22 @@ services:
           aliases:
             - nginx
 
+    clamav-mailcow:
+      image: mailcow/clamav
+      depends_on:
+        - bind9-mailcow
+      build: ./data/Dockerfiles/clamav
+      volumes:
+        - clamav-vol-1:/var/lib/clamav
+      restart: always
+      dns:
+        - 172.22.1.254
+      dns_search: mailcow-network
+      networks:
+        mailcow-network:
+          aliases:
+            - clamav
+
 networks:
   mailcow-network:
     driver: bridge
@@ -269,3 +285,4 @@ volumes:
   rspamd-vol-1:
   postfix-vol-1:
   crypt-vol-1:
+  clamav-vol-1:


### PR DESCRIPTION
This pull request integrates ClamAV virus scanning.
Please set up the clamav Dockerfile for an auto-build on Docker Hub after merging.

For those who don't want to have virus scanning on the server-side, simply remove the service from _docker-compose.yml_. If the three seconds for the connection attempt to ClamAV are too long, just delete _data/conf/rspamd/local.d/antivirus.conf_.

Closes #58 
