### PR TITLE
IPv6 support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -265,6 +265,14 @@ services:
           aliases:
             - nginx
 
+    ipv6nat:
+      image: robbertkl/ipv6nat
+      restart: always
+      privileged: true
+      network_mode: "host"
+      volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
 networks:
   mailcow-network:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -268,10 +268,12 @@ services:
 networks:
   mailcow-network:
     driver: bridge
+    enable_ipv6: true
     ipam:
       driver: default
       config:
         - subnet: 172.22.1.0/24
+        - subnet: fd4d:6169:6c63:6f77::/64
 
 volumes:
   vmail-vol-1:


### PR DESCRIPTION
Partial fix for #202 

To actually get IPv6 support, you additionally need https://github.com/robbertkl/docker-ipv6nat .

While ipv6nat can be run from a Docker container, there appears to be a bug (at least in my Debian 8 setup) that removes all IPv6 addresses from all interfaces on the host: https://github.com/robbertkl/docker-ipv6nat/issues/10 . Once that bug is fixed, I will update _docker-compose.yml_ to include the container. It should be enabled by default because we are in the year 2017 and IPv6 is no longer optional. Until then, I recommend the following:
```
curl -Lo docker-ipv6nat https://github.com/robbertkl/docker-ipv6nat/releases/download/v0.2.3/docker-ipv6nat.amd64
chmod +x docker-ipv6nat
./docker-ipv6nat
```
