### PR TITLE
Fix CalDAV/CardDAV URLs displayed in SOGo web interface when used behind reverse proxy

### DIFF
--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -1,4 +1,23 @@
 proxy_cache_path /tmp levels=1:2 keys_zone=sogo:10m inactive=24h  max_size=1g;
+
+# use the non-standard X-Forwarded-* headers for WebObjects
+map $http_x_forwarded_proto $maybe_real_scheme {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+map $http_x_forwarded_port $maybe_real_port {
+  default $http_x_forwarded_port;
+  ''      $server_port;
+}
+map $realip_remote_addr $real_scheme {
+  default $scheme;
+  172.22.1.1 $maybe_real_scheme;
+}
+map $realip_remote_addr $real_port {
+  default $server_port;
+  172.22.1.1 $maybe_real_port;
+}
+
 server {
   include /etc/nginx/conf.d/listen_ssl.active;
   include /etc/nginx/mime.types;
@@ -34,7 +53,7 @@ server {
   real_ip_recursive on;
 
   location = /principals/ {
-    rewrite ^ $scheme://$host:$server_port/SOGo/dav;
+    rewrite ^ $real_scheme://$host:$real_port/SOGo/dav;
     allow all;
   }
 
@@ -100,8 +119,8 @@ server {
     proxy_set_header x-webobjects-server-protocol HTTP/1.0;
     proxy_set_header x-webobjects-remote-host $remote_addr;
     proxy_set_header x-webobjects-server-name $server_name;
-    proxy_set_header x-webobjects-server-url $scheme://$host:$server_port;
-    proxy_set_header x-webobjects-server-port $server_port;
+    proxy_set_header x-webobjects-server-url $real_scheme://$host:$real_port;
+    proxy_set_header x-webobjects-server-port $real_port;
     client_body_buffer_size 128k;
     client_max_body_size 100m;
   }
@@ -114,8 +133,8 @@ server {
     proxy_set_header x-webobjects-server-protocol HTTP/1.0;
     proxy_set_header x-webobjects-remote-host $remote_addr;
     proxy_set_header x-webobjects-server-name $server_name;
-    proxy_set_header x-webobjects-server-url $scheme://$host:$server_port;
-    proxy_set_header x-webobjects-server-port $server_port;
+    proxy_set_header x-webobjects-server-url $real_scheme://$host:$real_port;
+    proxy_set_header x-webobjects-server-port $real_port;
     client_body_buffer_size 128k;
     client_max_body_size 100m;
     break;
@@ -187,7 +206,7 @@ server {
   real_ip_recursive on;
 
   location = /principals/ {
-    rewrite ^ $scheme://$host:$server_port/SOGo/dav;
+    rewrite ^ $real_scheme://$host:$real_port/SOGo/dav;
     allow all;
   }
 
@@ -253,8 +272,8 @@ server {
     proxy_set_header x-webobjects-server-protocol HTTP/1.0;
     proxy_set_header x-webobjects-remote-host $remote_addr;
     proxy_set_header x-webobjects-server-name $server_name;
-    proxy_set_header x-webobjects-server-url $scheme://$host:$server_port;
-    proxy_set_header x-webobjects-server-port $server_port;
+    proxy_set_header x-webobjects-server-url $real_scheme://$host:$real_port;
+    proxy_set_header x-webobjects-server-port $real_port;
     client_body_buffer_size 128k;
     client_max_body_size 100m;
   }
@@ -267,8 +286,8 @@ server {
     proxy_set_header x-webobjects-server-protocol HTTP/1.0;
     proxy_set_header x-webobjects-remote-host $remote_addr;
     proxy_set_header x-webobjects-server-name $server_name;
-    proxy_set_header x-webobjects-server-url $scheme://$host:$server_port;
-    proxy_set_header x-webobjects-server-port $server_port;
+    proxy_set_header x-webobjects-server-url $real_scheme://$host:$real_port;
+    proxy_set_header x-webobjects-server-port $real_port;
     client_body_buffer_size 128k;
     client_max_body_size 100m;
     break;


### PR DESCRIPTION
The `X-Forwarded-Proto` and `X-Forwarded-Port` headers are now used to pass the correct parameters to SOGo. Of course, they needed to be limited to trusted hosts, and since `if`s are not recommended in Nginx's configuration for performance reasons, I had to resort to `map`s. These can only exist in the `http` scope of the configuration and cannot contain boolean logic on the condition, so it's 20 lines, but easy to understand.

I have updated the documentation accordingly (Nginx now doesn't need `proxy_redirect` anymore; technically Apache also wouldn't need `ProxyPassReverse`, but I couldn't test that) and I have added a section about how to do it with HAProxy.

Fixes #207 