### PR TITLE
Remove rspamd size limit

### DIFF
--- a/data/conf/rmilter/rmilter.conf
+++ b/data/conf/rmilter/rmilter.conf
@@ -28,7 +28,6 @@ redis {
 };
 tempdir = /tmp;
 tempfiles_mode = 00600;
-max_size = 20M;
 strict_auth = yes;
 use_dcc = no;
 limits {

--- a/data/conf/rspamd/local.d/antivirus.conf
+++ b/data/conf/rspamd/local.d/antivirus.conf
@@ -1,6 +1,5 @@
 clamav {
   attachments_only = false;
-  max_size = 20000000;
   symbol = "CLAM_VIRUS";
   type = "clamav";
   log_clean = true;


### PR DESCRIPTION
This ensures that the spam and antivirus filters cannot be evaded by large messages.
Rmilter/rspamd/ClamAV do not need a size limit on their own (e.g. for DoS protection) as Postfix already has a size limit (`message_size_limit = 26214400`).

Note that Rmilter and Postfix have a different concept of size than Rspamd's antivirus plugin: the former two consider the MIME-encoded message's size, while the latter only cares about the actual binary attachment's size. If you assume base64 encoding (which has 33% encoding overhead), no messages larger than 18.75MB would make it to rspamd anyway -- however, there are other possible encodings! A carefully-crafted message could use quoted-printable encoding (which has 200% overhead for non-ASCII bytes but 0% for ASCII bytes) to get over the rspamd limit but stay under the Postfix limit. Or even easier: modern mailservers support the 8BITMIME or BINARYMIME  extensions, which allow for direct transmission of binary data without encoding overhead.

This is the last missing piece of #199.

Closes #199 and #58.