### PR TITLE
Fix SOGo URLs behind reverse proxy again

### DIFF
--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -1,4 +1,31 @@
 proxy_cache_path /tmp levels=1:2 keys_zone=sogo:10m inactive=24h  max_size=1g;
+
+# use the non-standard X-Forwarded-* headers for WebObjects
+map $http_x_forwarded_proto $maybe_real_scheme {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+map $http_x_forwarded_port $maybe_real_port {
+  default $http_x_forwarded_port;
+  ''      $server_port;
+}
+map $http_x_forwarded_host $maybe_real_host {
+  default $http_x_forwarded_host;
+  ''      $host:$real_port;
+}
+map $realip_remote_addr $real_scheme {
+  default $scheme;
+  172.22.1.1 $maybe_real_scheme;
+}
+map $realip_remote_addr $real_port {
+  default $server_port;
+  172.22.1.1 $maybe_real_port;
+}
+map $realip_remote_addr $real_host {
+  default $host:$real_port;
+  172.22.1.1 $maybe_real_host;
+}
+
 server {
   include /etc/nginx/conf.d/listen_ssl.active;
   include /etc/nginx/mime.types;
@@ -34,7 +61,7 @@ server {
   real_ip_recursive on;
 
   location = /principals/ {
-    rewrite ^ $scheme://$host:$server_port/SOGo/dav;
+    rewrite ^ $real_scheme://$real_host/SOGo/dav;
     allow all;
   }
 
@@ -96,8 +123,8 @@ server {
     proxy_set_header x-webobjects-server-protocol HTTP/1.0;
     proxy_set_header x-webobjects-remote-host $remote_addr;
     proxy_set_header x-webobjects-server-name $server_name;
-    proxy_set_header x-webobjects-server-url $scheme://$host:$server_port;
-    proxy_set_header x-webobjects-server-port $server_port;
+    proxy_set_header x-webobjects-server-url $real_scheme://$real_host;
+    proxy_set_header x-webobjects-server-port $real_port;
     client_body_buffer_size 128k;
     client_max_body_size 100m;
   }
@@ -110,8 +137,8 @@ server {
     proxy_set_header x-webobjects-server-protocol HTTP/1.0;
     proxy_set_header x-webobjects-remote-host $remote_addr;
     proxy_set_header x-webobjects-server-name $server_name;
-    proxy_set_header x-webobjects-server-url $scheme://$host:$server_port;
-    proxy_set_header x-webobjects-server-port $server_port;
+    proxy_set_header x-webobjects-server-url $real_scheme://$real_host;
+    proxy_set_header x-webobjects-server-port $real_port;
     client_body_buffer_size 128k;
     client_max_body_size 100m;
     break;
@@ -183,7 +210,7 @@ server {
   real_ip_recursive on;
 
   location = /principals/ {
-    rewrite ^ $scheme://$host:$server_port/SOGo/dav;
+    rewrite ^ $real_scheme://$real_host/SOGo/dav;
     allow all;
   }
 
@@ -249,8 +276,8 @@ server {
     proxy_set_header x-webobjects-server-protocol HTTP/1.0;
     proxy_set_header x-webobjects-remote-host $remote_addr;
     proxy_set_header x-webobjects-server-name $server_name;
-    proxy_set_header x-webobjects-server-url $scheme://$host:$server_port;
-    proxy_set_header x-webobjects-server-port $server_port;
+    proxy_set_header x-webobjects-server-url $real_scheme://$real_host;
+    proxy_set_header x-webobjects-server-port $real_port;
     client_body_buffer_size 128k;
     client_max_body_size 100m;
   }
@@ -263,8 +290,8 @@ server {
     proxy_set_header x-webobjects-server-protocol HTTP/1.0;
     proxy_set_header x-webobjects-remote-host $remote_addr;
     proxy_set_header x-webobjects-server-name $server_name;
-    proxy_set_header x-webobjects-server-url $scheme://$host:$server_port;
-    proxy_set_header x-webobjects-server-port $server_port;
+    proxy_set_header x-webobjects-server-url $real_scheme://$real_host;
+    proxy_set_header x-webobjects-server-port $real_port;
     client_body_buffer_size 128k;
     client_max_body_size 100m;
     break;


### PR DESCRIPTION
Fixes the URL that SOGo considers itself to be running under in reverse proxy setups and leaves them unaffected in direct connections. This is a resubmission of #212, which broke the latter and was therefore reverted.

@andryyy, I'm re-publishing this here because I'm sure some other people will find it useful. If you [don't want to merge it anymore](https://github.com/andryyy/mailcow-dockerized/pull/212#issuecomment-296961413), that's fine, but then please leave the PR open so people can find it and please update the documentation to indicate that reverse proxy setups report incorrect URLs without my patch.

I did extensive testing of all three documented reverse proxy servers in #212 and have now fixed the trivial config error that broke direct connections. Please test it yourself and let me know if there are any remaining problems. This is unlikely, but I can't guarantee that I covered all edge cases.

Fixes #207