### PR TITLE
Switch debian:testing to debian:stretch

### DIFF
--- a/data/Dockerfiles/postfix/Dockerfile
+++ b/data/Dockerfiles/postfix/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:testing-slim
+FROM debian:stretch-slim
 MAINTAINER Andre Peters <andre.peters@servercow.de>
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
This is in preparation of the Debian 9 release, coming up in a few weeks. At that point, stretch will graduate from testing to stable and testing will start pointing at buster. Since we wouldn't want to automatically be switched to a highly unstable version, this change explicitly uses stretch in all Dockerfiles.