### PR TITLE
Disable greylisting for forwarding hosts

### DIFF
--- a/data/conf/rspamd/dynmaps/settings.php
+++ b/data/conf/rspamd/dynmaps/settings.php
@@ -58,6 +58,7 @@ endforeach;
 		apply "default" {
 			actions {
 				reject = 999.9;
+				greylist = 999.8;
 			}
 		}
 		symbols [


### PR DESCRIPTION
The help text already stated that greylisting is disabled for the trusted forwarding hosts, but I seem to have forgotten to add the appropriate rule in #205.