### PR TITLE
Move to Alpine Nginx image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,13 +233,13 @@ services:
       depends_on:
         - sogo-mailcow
         - php-fpm-mailcow
-      image: nginx:mainline
+      image: nginx:mainline-alpine
       healthcheck:
         test: ["CMD", "ping", "php-fpm-mailcow", "-c", "10"]
         interval: 10s
         timeout: 30s
         retries: 5
-      command: /bin/bash -c "envsubst < /etc/nginx/conf.d/templates/listen_plain.template > /etc/nginx/conf.d/listen_plain.active &&
+      command: /bin/sh -c "envsubst < /etc/nginx/conf.d/templates/listen_plain.template > /etc/nginx/conf.d/listen_plain.active &&
         envsubst < /etc/nginx/conf.d/templates/listen_ssl.template > /etc/nginx/conf.d/listen_ssl.active &&
         envsubst < /etc/nginx/conf.d/templates/server_name.template > /etc/nginx/conf.d/server_name.active &&
         nginx -g 'daemon off;'"


### PR DESCRIPTION
Hi, i recently migrate from older non docker version of Mailcow few days back quite liking it compered to the normal version.

One of the downsides of this version is the amount of disk space it is using for the 12 containers the image's are taking up 3,421.5MB which could be a issue for user running it on vps with small disk's.

If you switch Nginx  nginx:mainline-alpine (109MB to 15.5MB),Memcached  memcached:alpine (83.7MB to 6.9MB) and Redis redis:alpine (184MB to 19.8MB) to the Alpine version of the image you can save 334MB.

I've not tested if the Alpine version of Memcached or Redis work's properly as i don't have any experience of using Memcached or Redis , but the Alpine based image for nginx work's perfectly.

Am thinking the Mailcow image's could be rebased to Alpine as Alpine based image's are generally smaller but might cause more issue that it worth to just save some disk space.

Am not 100% sure if this changed should be merge but i will leave that to you andryyy to decide.

Ryan 