### PR TITLE
Consistent symbol names for forwarding hosts

### DIFF
--- a/data/conf/rspamd/local.d/force_actions.conf
+++ b/data/conf/rspamd/local.d/force_actions.conf
@@ -11,12 +11,12 @@ rules {
   }
   WHITELIST_FORWARDING_HOST_NO_REJECT {
     action = "add header";
-    expression = "WHITELIST_FORWARDING_HOST";
+    expression = "WHITELISTED_FWD_HOST";
     require_action = ["soft reject", "reject"];
   }
   WHITELIST_FORWARDING_HOST_NO_GREYLIST {
     action = "no action";
-    expression = "WHITELIST_FORWARDING_HOST";
+    expression = "WHITELISTED_FWD_HOST";
     require_action = ["greylist"];
   }
 }


### PR DESCRIPTION
After reading d64ed65575e3a287a78ba7f976b96dd1006f7a9a, it seemed like multimap.conf and force_actions.conf need to refer to forwarding hosts by the same symbol name but didn't. Please check whether this is really the case or due to my misunderstanding. I could not tested this change yet.