### PR TITLE
Remove un-named docker volume for sogo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       dns_search: mailcow-network
       volumes:
         - ./data/conf/sogo/:/etc/sogo/
-        - /usr/lib/GNUstep/SOGo/WebServerResources/
+        - sogo-vol-1:/usr/lib/GNUstep/SOGo/WebServerResources/
       restart: always
       networks:
         mailcow-network:
@@ -281,3 +281,4 @@ volumes:
   rspamd-vol-1:
   postfix-vol-1:
   crypt-vol-1:
+  sogo-vol-1:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,6 @@ services:
       dns_search: mailcow-network
       volumes:
         - ./data/conf/sogo/:/etc/sogo/
-        - sogo-vol-1:/usr/lib/GNUstep/SOGo/WebServerResources/
       restart: always
       networks:
         mailcow-network:
@@ -281,4 +280,3 @@ volumes:
   rspamd-vol-1:
   postfix-vol-1:
   crypt-vol-1:
-  sogo-vol-1:


### PR DESCRIPTION
This is the only un-named docker volume used in the compose file.