### PR TITLE
ipv6nat: automatically load kernel modules if needed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,6 +272,7 @@ services:
       network_mode: "host"
       volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /lib/modules:/lib/modules:ro
 
 networks:
   mailcow-network:


### PR DESCRIPTION
@K2rool reported on #203 that certain systems (like CentOS 7) don't have the necessary kernel modules loaded by default for IPv6 NAT to work. https://github.com/robbertkl/docker-ipv6nat mentions that problem and states that passing /lib/modules into the container is sufficient for the module to be loaded on demand.

Since this is a bug fix and not a new feature, I'm proposing the PR against master and not dev.