### PR TITLE
DKIM redis migration: store private key correctly

### DIFF
--- a/data/Dockerfiles/php-fpm/docker-entrypoint.sh
+++ b/data/Dockerfiles/php-fpm/docker-entrypoint.sh
@@ -51,7 +51,7 @@ for file in $(ls /data/dkim/keys/); do
   domain=${file%.dkim}
   if [[ -f /data/dkim/txt/${file} ]]; then
     redis-cli -h redis-mailcow HSET DKIM_PUB_KEYS "${domain}" "$(cat /data/dkim/txt/${file})"
-    redis-cli -h redis-mailcow HSET DKIM_PRIV_KEYS "${domain}" "$(cat /data/dkim/keys/${file})"
+    redis-cli -h redis-mailcow HSET DKIM_PRIV_KEYS "dkim.${domain}" "$(cat /data/dkim/keys/${file})"
     redis-cli -h redis-mailcow HSET DKIM_SELECTORS "${domain}" "dkim"
   fi
   rm /data/dkim/{keys,txt}/${file}


### PR DESCRIPTION
Even after the past weekend's fixes to the broken SQL-to-Redis migration for the DKIM keys (see #272), it still wasn't working for me. I was getting errors like the following in the rspamd logs:

```
dkim_signing.lua:179: cannot make request to load DKIM key for dkim.my-domain.com: nil
```

When comparing [`dkim_add_key()`](https://github.com/mailcow/mailcow-dockerized/blob/0cfd0b55bd88a7d682cae32fd63b2e03db0d93cb/data/web/inc/functions.inc.php#L2403) in the PHP code with the [migration script](https://github.com/mailcow/mailcow-dockerized/blob/e795898b80fabad951f70b25bca5a50062af1961/data/Dockerfiles/php-fpm/docker-entrypoint.sh#L53) or the [rspamd source code](https://github.com/vstakhov/rspamd/blob/ab587d5/src/plugins/lua/dkim_signing.lua#L187), it is clear that the problem is that the private key wasn't stored with the selector -- it was being stored as my-domain.com instead of as dkim.my-domain.com.

#281 could potentially be related to this.

If you have already upgraded, you will need to manually fix things as follows:
Run `source mailcow.conf ; docker-compose exec redis-mailcow redis-cli` in the mailcow-dockerized directory and get the private key as follows:
```
HGET DKIM_PRIV_KEYS my-domain.com
```
Now store that private key again with the selector prefixed to the domain:
```
HSET DKIM_PRIV_KEYS dkim.my-domain.com "-----BEGIN PRIVATE KEY-----[...]\n-----END PRIVATE KEY-----"
```