### PR TITLE
Remove REMOTE_ADDR check

### DIFF
--- a/data/web/inc/sessions.inc.php
+++ b/data/web/inc/sessions.inc.php
@@ -19,20 +19,14 @@ if (!isset($_SESSION['CSRF']['TOKEN'])) {
   $_SESSION['CSRF']['TOKEN'] = bin2hex(random_bytes(32));
 }
 
-// Set session IP and UA
-if (!isset($_SESSION['SESS_REMOTE_IP'])) {
-  $_SESSION['SESS_REMOTE_IP'] = $_SERVER['REMOTE_ADDR'];
-}
+// Set session UA
 if (!isset($_SESSION['SESS_REMOTE_UA'])) {
   $_SESSION['SESS_REMOTE_UA'] = $_SERVER['HTTP_USER_AGENT'];
 }
 
 // Check session
 function session_check() {
-  if (!isset($_SESSION['SESS_REMOTE_IP']) || !isset($_SESSION['SESS_REMOTE_UA'])) {
-    return false;
-  }
-  if ($_SESSION['SESS_REMOTE_IP'] != $_SERVER['REMOTE_ADDR']) {
+  if (!isset($_SESSION['SESS_REMOTE_UA'])) {
     return false;
   }
   if ($_SESSION['SESS_REMOTE_UA'] != $_SERVER['HTTP_USER_AGENT']) {


### PR DESCRIPTION
Nowadays it can no longer be assumed that the client's IP address stays constant over the course of a session. For example, web browsers on IPv4/IPv6 dual-stacked client machines employ an algorithm called [Happy Eyeballs](https://tools.ietf.org/html/rfc6555) where it is dynamically determined whether a connection is established over IPv4 or IPv6. This can result in a session repeatedly moving between protocols. In the web server's log (reverse proxy in my case, but it's no different in a direct connection as the protocol decision is made by the client), this can look like this:
```
May 18 18:44:26 mailcow haproxy[24822]: 2001:db8::1:55431 [18/May/2017:18:44:24.972] https-in~ mailcow/mailcow 207/0/0/78/1587 200 38015 - - ---- 7/7/0/1/0 0/0 "GET /admin.php HTTP/1.1"
May 18 18:44:26 mailcow haproxy[24822]: ::ffff:192.0.2.1:55437 [18/May/2017:18:44:25.487] https-in~ mailcow/mailcow 1251/0/0/85/1365 200 192821 - - ---- 7/7/4/5/0 0/0 "GET /api/v1/get/logs/sogo/1000 HTTP/1.1"
```
Other projects have run into the same issue (e.g. [Shibboleth](http://shibboleth.1660669.n2.nabble.com/consistentAddress-IPv6-and-Happy-Eyeballs-td7494843.html)) and the only workarounds are to either disable IPv6 or to stop checking IP addresses. Most web software I have seen in recent years has stopped checking IP addresses, so I propose we do the same here.

This problem is not even limited to IPv6: if you log into Mailcow on your smartphone while outside and then enter your house where Wi-Fi is available, your client IP changes and your Mailcow session would be terminated. So even in a IPv4-only world, this is a problem that needs to be fixed.

As the client IP check does not bring much of a security benefit anyway (an intruder would need to steal a session cookie to even get to that check), we should just remove it.