### PR TITLE
Turning autocomplete off for Yubi Tokens

### DIFF
--- a/data/web/inc/tfa_modals.php
+++ b/data/web/inc/tfa_modals.php
@@ -135,7 +135,7 @@ if (isset($_SESSION['pending_tfa_method'])):
           <div class="form-group">
             <div class="input-group">
               <span class="input-group-addon" id="yubi-addon"><img alt="Yubicon Icon" src="/img/yubi.ico"></span>
-              <input type="text" name="token" id="token" class="form-control" placeholder="Touch Yubikey" aria-describedby="yubi-addon">
+              <input type="text" name="token" id="token" class="form-control" autocomplete="off" placeholder="Touch Yubikey" aria-describedby="yubi-addon">
               <input type="hidden" name="tfa_method" value="yubi_otp">
             </div>
           </div>


### PR DESCRIPTION
Autocomplete was on for Yubi Token auth prompt. This made multiple "historical" tokens pop up which is a small annoyance and is not necessary/best practice to have one time tokens recorded/kept in this manner :)