### PR TITLE
Authentication rate limiting for Mailcow UI

### DIFF
--- a/data/Dockerfiles/fail2ban/logwatch.py
+++ b/data/Dockerfiles/fail2ban/logwatch.py
@@ -13,6 +13,7 @@ RULES = {
 	'mailcowdockerized_postfix-mailcow_1': 'warning: .*\[([0-9a-f\.:]+)\]: SASL .* authentication failed',
 	'mailcowdockerized_dovecot-mailcow_1': '-login: Disconnected \(auth failed, .*\): user=.*, method=.*, rip=([0-9a-f\.:]+),',
 	'mailcowdockerized_sogo-mailcow_1': 'SOGo.* Login from \'([0-9a-f\.:]+)\' for user .* might not have worked',
+	'mailcowdockerized_php-fpm-mailcow_1': 'Mailcow UI: Invalid password for .* by ([0-9a-f\.:]+)',
 }
 BAN_TIME = 1800
 MAX_ATTEMPTS = 10
@@ -22,6 +23,9 @@ quit_now = False
 
 def ban(address):
 	ip = ipaddress.ip_address(address.decode('ascii'))
+	if type(ip) is ipaddress.IPv6Address and ip.ipv4_mapped:
+		ip = ip.ipv4_mapped
+		address = str(ip)
 	if ip.is_private or ip.is_loopback:
 		return
 	

--- a/data/Dockerfiles/php-fpm/Dockerfile
+++ b/data/Dockerfiles/php-fpm/Dockerfile
@@ -8,6 +8,7 @@ RUN docker-php-ext-install intl pdo pdo_mysql xmlrpc
 RUN docker-php-ext-enable redis
 RUN pear install channel://pear.php.net/Net_IDNA2-0.1.1 Auth_SASL Net_IMAP NET_SMTP Net_IDNA2 Mail_mime
 RUN apk del autoconf g++ make libxml2-dev icu-dev
+RUN echo 'php_admin_flag[log_errors] = on' >> /usr/local/etc/php-fpm.d/www.conf
 
 COPY ./docker-entrypoint.sh /
 

--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -169,6 +169,11 @@ function check_login($user, $pass) {
 	}
 	elseif (!isset($_SESSION['mailcow_cc_username'])) {
 		$_SESSION['ldelay'] = $_SESSION['ldelay']+0.5;
+		$err = error_reporting(E_ALL);
+		ini_set('display_errors', 'off');
+		trigger_error("Mailcow UI: Invalid password for " . $user . " by " . $_SERVER['REMOTE_ADDR'], E_USER_WARNING);
+		ini_set('display_errors', 'on');
+		error_reporting($err);
 	}
 	sleep($_SESSION['ldelay']);
 }

--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -169,11 +169,7 @@ function check_login($user, $pass) {
 	}
 	elseif (!isset($_SESSION['mailcow_cc_username'])) {
 		$_SESSION['ldelay'] = $_SESSION['ldelay']+0.5;
-		$err = error_reporting(E_ALL);
-		ini_set('display_errors', 'off');
-		trigger_error("Mailcow UI: Invalid password for " . $user . " by " . $_SERVER['REMOTE_ADDR'], E_USER_WARNING);
-		ini_set('display_errors', 'on');
-		error_reporting($err);
+		error_log("Mailcow UI: Invalid password for " . $user . " by " . $_SERVER['REMOTE_ADDR']);
 	}
 	sleep($_SESSION['ldelay']);
 }


### PR DESCRIPTION
I had to turn on error logging for the PHP-FPM container to be able to log messages from the Mailcow UI. Also, I noticed that IPv4-mapped IPv6 addresses (like ::ffff:192.0.2.1) weren't dealt with correctly, but that is fixed now.

Follow-up to #311.