### PR TITLE
SOGo UI: per-user authentication failure rate-limiting

### DIFF
--- a/data/conf/sogo/sogo.conf
+++ b/data/conf/sogo/sogo.conf
@@ -63,6 +63,11 @@
     SOGoTrashFolderName = "Trash";
     SOGoVacationEnabled = YES;
 
+    SOGoCacheCleanupInterval = 900;
+    SOGoMaximumFailedLoginCount = 10;
+    SOGoMaximumFailedLoginInterval = 900;
+    SOGoFailedLoginBlockInterval = 900;
+
     MySQL4Encoding = "utf8mb4";
   //SOGoDebugRequests = YES;
   //SoDebugBaseURL = YES;


### PR DESCRIPTION
#311 from a few days ago did not cover CalDAV/CardDAV and Exchange ActiveSync logins to SOGo. They are unfortunately reported through a different log message which does not contain the client IP address, which means we cannot handle them through the fail2ban-like mechanism:

```
<0x0x5614a9d44580[SOGoDAVAuthenticator]> tried wrong password for user 'test@example.com'!
```

Luckily however, SOGo has its own built-in rate limiting. According to the [docs](https://github.com/inverse-inc/sogo/blob/9d6ab2df3364e8863c94b6a4c4cd2f239399a7f8/Documentation/SOGoInstallationGuide.asciidoc#general-preferences):
> [_SOGoMaximumFailedLoginCount_ is] used to control the number of failed login attempts required during _SOGoMaximumFailedLoginInterval_ seconds or more. If conditions are met, the account will be blocked for _SOGoFailedLoginBlockInterval_ seconds since the first failed login attempt. [...] Note that _SOGoCacheCleanupInterval_ must be set to a value equal or higher than _SOGoFailedLoginBlockInterval_.

This pull request enables the necessary configuration options. I decided to go with a limit of 10 failed attempts per 15 minutes per user. It also applies to the SOGo web interface, so it should be set reasonably high as users regularly enter their password manually there (unlike the other services, Dovecot, Postfix, etc.) and we don't want to lock their account already if they attempt to enter their password five times with Caps Lock on before they notice.