### PR TITLE
php-fpm dockerfile simplification

### DIFF
--- a/data/Dockerfiles/php-fpm/Dockerfile
+++ b/data/Dockerfiles/php-fpm/Dockerfile
@@ -1,17 +1,52 @@
-FROM php:7.1-fpm-alpine
+FROM alpine:3.6
+
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
-RUN apk add -U --no-cache libxml2-dev icu-dev icu-libs redis mysql-client bash autoconf g++ make openssl
-RUN pecl install redis && pecl clear-cache
-RUN docker-php-ext-configure intl
-RUN docker-php-ext-install intl pdo pdo_mysql xmlrpc
-RUN docker-php-ext-enable redis
-RUN pear install channel://pear.php.net/Net_IDNA2-0.1.1 Auth_SASL Net_IMAP NET_SMTP Net_IDNA2 Mail_mime
-RUN apk del autoconf g++ make libxml2-dev icu-dev
+# Add script
+COPY docker-entrypoint.sh /
 
-COPY ./docker-entrypoint.sh /
+# Add group + user - 82 is the standard uid/gid for "www-data" in Alpine
+RUN set -x \
+&& addgroup -g 82 -S www-data \
+&& adduser -u 82 -D -S -G www-data www-data \
+\
+# Install Dependencies 
+&& apk add --update \
+&& apk add --no-cache bash php7-fpm php7-intl php7-pdo php7-pdo_mysql php7-xmlrpc php7-redis php7-pear \
+php7-pear-auth_sasl php7-pear-net_smtp php7-pear-net_idna2 php7-pear-mail_mime \
+&& pear install Net_IMAP \
+# MISSING apk for php7-pear-net_imap - can be installed once https://github.com/alpinelinux/aports/pull/1359 is merged.
+\
+# Configuring php-fpm
+&& set -ex \
+&& cd /etc/php7/ \
+# Change the setting so the daemon runs in the foreground and as www-data:www-data
+#&& sed -i 's/^;daemonize .*$/daemonize = no/g' /etc/php7/php-fpm.conf \
+&& sed -i 's/^user = .*/user = www-data/' /etc/php7/php-fpm.d/www.conf \
+&& sed -i 's/^group = .*/group = www-data/' /etc/php7/php-fpm.d/www.conf \
+&& { \
+    echo '[global]'; \
+    echo 'error_log = /proc/self/fd/2'; \
+    echo; \
+    echo '[www]'; \
+    echo '; if we send this to /proc/self/fd/1, it never appears'; \
+    echo 'access.log = /proc/self/fd/2'; \
+    echo; \
+    echo 'clear_env = no'; \
+    echo; \
+    echo '; Ensure worker stdout and stderr are sent to the main error log.'; \
+    echo 'catch_workers_output = yes'; \
+} | tee php-fpm.d/docker.conf \
+&& { \
+    echo '[global]'; \
+    echo 'daemonize = no'; \
+    echo; \
+    echo '[www]'; \
+    echo 'listen = [::]:9000'; \
+} | tee php-fpm.d/zz-docker.conf
 
 EXPOSE 9000
 
+# Time to milk the cows ;)
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["php-fpm"]
+CMD ["php-fpm7"]

--- a/data/Dockerfiles/php-fpm/docker-entrypoint.sh
+++ b/data/Dockerfiles/php-fpm/docker-entrypoint.sh
@@ -10,7 +10,7 @@ while ! mysqladmin ping --host mysql --silent; do
   sleep 2
 done
 
-until [ $(redis-cli -h redis-mailcow PING) == "PONG" ]; do
+until [ "$(redis-cli -h redis-mailcow PING)" == "PONG" ]; do
   sleep 2
 done
 
@@ -18,14 +18,14 @@ done
 
 declare -a DOMAIN_ARR
 redis-cli -h redis-mailcow DEL DOMAIN_MAP
-while read line
+while read -r line
 do
   DOMAIN_ARR+=("$line")
-done < <(mysql -h mysql-mailcow -u ${DBUSER} -p${DBPASS} ${DBNAME} -e "SELECT domain FROM domain" -Bs)
+done < <(mysql -h mysql-mailcow -u "${DBUSER}" -p"${DBPASS}" "${DBNAME}" -e "SELECT domain FROM domain" -Bs)
 
 if [[ ! -z ${DOMAIN_ARR} ]]; then
 for domain in "${DOMAIN_ARR[@]}"; do
-  redis-cli -h redis-mailcow HSET DOMAIN_MAP ${domain} 1
+  redis-cli -h redis-mailcow HSET DOMAIN_MAP "${domain}" 1
 done
 fi
 
@@ -33,50 +33,51 @@ fi
 
 declare -a SUBJ_TAG_ARR
 redis-cli -h redis-mailcow DEL SUBJ_TAG_ARR
-while read line
+while read -r line
 do
   SUBJ_TAG_ARR+=("$line")
-done < <(mysql -h mysql-mailcow -u ${DBUSER} -p${DBPASS} ${DBNAME} -e "SELECT username FROM mailbox WHERE wants_tagged_subject='1'" -Bs)
+done < <(mysql -h mysql-mailcow -u "${DBUSER}" -p"${DBPASS}" "${DBNAME}" -e "SELECT username FROM mailbox WHERE wants_tagged_subject='1'" -Bs)
 
 if [[ ! -z ${SUBJ_TAG_ARR} ]]; then
 for user in "${SUBJ_TAG_ARR[@]}"; do
-  redis-cli -h redis-mailcow HSET RCPT_WANTS_SUBJECT_TAG ${user} 1
-  mysql -h mysql-mailcow -u ${DBUSER} -p${DBPASS} ${DBNAME} -e "UPDATE mailbox SET wants_tagged_subject='2' WHERE username = '${user}'"
+  redis-cli -h redis-mailcow HSET RCPT_WANTS_SUBJECT_TAG "${user}" 1
+  mysql -h mysql-mailcow -u "${DBUSER}" -p"${DBPASS}" "${DBNAME}" -e "UPDATE mailbox SET wants_tagged_subject='2' WHERE username = '${user}'"
 done
 fi
 
 # Migrate DKIM keys
 
-for file in $(ls /data/dkim/keys/); do
+for file in /data/dkim/keys/*; do
+  [[ -e $file ]] || break  # handle the case of no files
   domain=${file%.dkim}
   if [[ -f /data/dkim/txt/${file} ]]; then
     redis-cli -h redis-mailcow HSET DKIM_PUB_KEYS "${domain}" "$(cat /data/dkim/txt/${file})"
     redis-cli -h redis-mailcow HSET DKIM_PRIV_KEYS "dkim.${domain}" "$(cat /data/dkim/keys/${file})"
     redis-cli -h redis-mailcow HSET DKIM_SELECTORS "${domain}" "dkim"
   fi
-  rm /data/dkim/{keys,txt}/${file}
+  rm /data/dkim/{keys,txt}/"${file}"
 done
 
 # Fix DKIM keys
 
 # Fetch domains
 declare -a DOMAIN_ARRAY
-while read line
+while read -r line
 do
  DOMAIN_ARRAY+=("$line")
-done < <(mysql -h mysql-mailcow -u ${DBUSER} -p${DBPASS} ${DBNAME} -e "SELECT domain FROM domain" -Bs)
-while read line
+done < <(mysql -h mysql-mailcow -u "${DBUSER}" -p"${DBPASS}" "${DBNAME}" -e "SELECT domain FROM domain" -Bs)
+while read -r line
 do
  DOMAIN_ARRAY+=("$line")
-done < <(mysql -h mysql-mailcow -u ${DBUSER} -p${DBPASS} ${DBNAME} -e "SELECT alias_domain FROM alias_domain" -Bs)
+done < <(mysql -h mysql-mailcow -u "${DBUSER}" -p"${DBPASS}" "${DBNAME}" -e "SELECT alias_domain FROM alias_domain" -Bs)
 
 # Loop through array and fix keys
 if [[ ! -z ${DOMAIN_ARRAY} ]]; then
  for domain in "${DOMAIN_ARRAY[@]}"; do
-   WRONG_KEY=$(redis-cli -h redis-mailcow HGET DKIM_PRIV_KEYS ${domain} | tr -d \")
+   WRONG_KEY=$(redis-cli -h redis-mailcow HGET DKIM_PRIV_KEYS "${domain}" | tr -d \")
    if [[ ! -z ${WRONG_KEY} ]]; then
      echo "Migrating defect key for domain ${domain}"
-     redis-cli -h redis-mailcow HSET DKIM_PRIV_KEYS "dkim.${domain}" ${WRONG_KEY}
+     redis-cli -h redis-mailcow HSET DKIM_PRIV_KEYS "dkim.${domain}" "${WRONG_KEY}"
      redis-cli -h redis-mailcow HDEL DKIM_PRIV_KEYS "${domain}"
    fi
  done


### PR DESCRIPTION
Locked to specific Alpine release.
Fewer layers.
Size reduction of 403.3 MB.
![image](https://cloud.githubusercontent.com/assets/858296/26532327/fadb086a-43fd-11e7-8552-5d9f0307e67e.png)

I also checked the docker-entrypoint.sh script againtst http://www.shellcheck.net/ and corected most of the warnings. There are still a few left.

The last part of the dockerfile, from "# Configuring php-fpm" and below is a modified version of the last section of the official php image dockerfile - https://github.com/docker-library/php/blob/76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68/7.1/fpm/alpine/Dockerfile
