### PR TITLE
Replace symlink to PHP script

### DIFF
--- a/data/conf/rspamd/dynmaps/vars.inc.php
+++ b/data/conf/rspamd/dynmaps/vars.inc.php
@@ -1,1 +1,3 @@
-../../../web/inc/vars.inc.php
+<?php
+require_once('../../../web/inc/vars.inc.php');
+?>


### PR DESCRIPTION
There is one symlink in Mailcow (besides the .env => mailcow.conf one) that might cause trouble on Docker for Windows, see #326.

This PR replaces it with `require_once` inside the PHP script.