### PR TITLE
Add Tooltip to mailcow Apps

### DIFF
--- a/data/web/inc/header.inc.php
+++ b/data/web/inc/header.inc.php
@@ -99,7 +99,7 @@
           <?php
           foreach ($MAILCOW_APPS as $app):
           ?>
-            <li><a href="<?= $app['link']; ?>"><?= $app['name']; ?></a></li>
+            <li title="<?= htmlspecialchars($app['description']); ?>"><a href="<?= htmlspecialchars($app['link']); ?>"><?= htmlspecialchars($app['name']); ?></a></li>
           <?php
           endforeach;
           ?>

--- a/data/web/inc/vars.inc.php
+++ b/data/web/inc/vars.inc.php
@@ -42,11 +42,13 @@ $PASSWD_REGEP = '.{4,}';
 $MAILCOW_APPS = array(
   array(
     'name' => 'SOGo',
-    'link' => '/SOGo/'
+    'link' => '/SOGo/',
+    'description' => 'SOGo is a collaborative software (groupware) server.'
   ),
   // array(
     // 'name' => 'Roundcube',
-    // 'link' => '/rc/'
+    // 'link' => '/rc/',
+    // 'description' => 'Roundcube is a web-based IMAP email client.',
   // ),
 );
 

--- a/data/web/inc/vars.inc.php
+++ b/data/web/inc/vars.inc.php
@@ -43,12 +43,12 @@ $MAILCOW_APPS = array(
   array(
     'name' => 'SOGo',
     'link' => '/SOGo/',
-    'description' => 'SOGo is a collaborative software (groupware) server.'
+    'description' => 'SOGo is a web-based client for email, address book and calendar.'
   ),
   // array(
     // 'name' => 'Roundcube',
     // 'link' => '/rc/',
-    // 'description' => 'Roundcube is a web-based IMAP email client.',
+    // 'description' => 'Roundcube is a web-based email client.',
   // ),
 );
 

--- a/data/web/index.php
+++ b/data/web/index.php
@@ -69,7 +69,7 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
           <?php
           foreach ($MAILCOW_APPS as $app):
           ?>
-            <a href="<?= $app['link']; ?>" role="button" class="btn btn-lg btn-default"><?= $app['name']; ?></a>&nbsp;
+            <a href="<?= htmlspecialchars($app['link']); ?>" role="button" title="<?= htmlspecialchars($app['description']); ?>" class="btn btn-lg btn-default"><?= htmlspecialchars($app['name']); ?></a>&nbsp;
           <?php
           endforeach;
           ?>


### PR DESCRIPTION
Basically, this allows the admin to set an optional custom description of a specific mailcow app that can be read on mouse hover. Additionally, I have also added `htmlspecialchars` to escape double quotes in some html attributes. The descriptions are in english by default, but users can always customize them in `vars.local.inc.php` so I don't think we'll need a dedicated translation entries in the `lang` folder.
![sdgdfg](https://user-images.githubusercontent.com/9730242/27007206-26baf060-4e7d-11e7-901b-a9fdcba36222.jpg)
