### PR TITLE
Add missing backslash in php-fpm Dockerfile

### DIFF
--- a/data/Dockerfiles/php-fpm/Dockerfile
+++ b/data/Dockerfiles/php-fpm/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add -U --no-cache libxml2-dev \
 	autoconf \
 	g++ \
 	make \
-	openssl
+	openssl \
 	&& pecl install redis \
 	&& pecl clear-cache \
 	&& docker-php-ext-configure intl \


### PR DESCRIPTION
Missed this in #352 