### PR TITLE
Added the "Authentication-Results" header

### DIFF
--- a/data/conf/rspamd/local.d/rmilter_headers.conf
+++ b/data/conf/rspamd/local.d/rmilter_headers.conf
@@ -1,0 +1,1 @@
+use = ["authentication-results"];


### PR DESCRIPTION
This header allows MUAs to understand if received emails have passed SPF, DKIM and DMARC checks.

This also works with Rspamd 1.6.0 (https://rspamd.com/announce/2017/06/12/rspamd-1.6.0.html and https://rspamd.com/doc/modules/milter_headers.html).