### PR TITLE
Make autodiscover location case insensitive

### DIFF
--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -64,7 +64,7 @@ server {
     proxy_redirect off;
   }
 
-  location ~ /(?:a|A)utodiscover/(?:a|A)utodiscover.xml {
+  location ~* ^/Autodiscover/Autodiscover.xml {
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
     fastcgi_pass phpfpm:9000;
     include /etc/nginx/fastcgi_params;
@@ -209,7 +209,7 @@ server {
     proxy_redirect off;
   }
 
-  location ~ /(?:a|A)utodiscover/(?:a|A)utodiscover.xml {
+  location ~* ^/Autodiscover/Autodiscover.xml {
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
     fastcgi_pass phpfpm:9000;
     include /etc/nginx/fastcgi_params;


### PR DESCRIPTION
The current Nginx location for autodiscover only work for autodiscover with lower or uppercase first letter. 

which work;s fine for most client but not a Microsoft Client the build-in email client in Windows 10 uses POST /AutoDiscover/AutoDiscover.xml which dose not match.

The change i did made it case insensitive so it should work with any client no matter the mix of lower or upper case. 


Ryan