### PR TITLE
Pass hostname to SOGo Integrator build script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,7 @@ services:
         - DBUSER=${DBUSER}
         - DBPASS=${DBPASS}
         - TZ=${TZ}
+        - MAILCOW_HOSTNAME=${MAILCOW_HOSTNAME}
       volumes:
         - ./data/conf/sogo/:/etc/sogo/
         - ./data/web/thunderbird-plugins:/thunderbird


### PR DESCRIPTION
This was a bug in #365