### PR TITLE
Autodiscovery for eM Client and Outlook 2007/2010

### DIFF
--- a/data/web/autodiscover.php
+++ b/data/web/autodiscover.php
@@ -35,7 +35,8 @@ if (strpos($data, 'autodiscover/outlook/responseschema')) { // desktop client
 	if ($config['useEASforOutlook'] == 'yes' &&
 	    strpos($_SERVER['HTTP_USER_AGENT'], 'Outlook') !== FALSE && // Outlook
 	    strpos($_SERVER['HTTP_USER_AGENT'], 'Windows NT') !== FALSE && // Windows
-	    preg_match('/Outlook (1[5-9]\.|[2-9]|1[0-9][0-9])/', $_SERVER['HTTP_USER_AGENT']) // Outlook 2013 (version 15) or higher
+	    preg_match('/Outlook (1[5-9]\.|[2-9]|1[0-9][0-9])/', $_SERVER['HTTP_USER_AGENT']) && // Outlook 2013 (version 15) or higher
+	    strpos($_SERVER['HTTP_USER_AGENT'], 'MS Connectivity Analyzer') === FALSE // https://testconnectivity.microsoft.com doesn't support EAS for Outlook
 	) {
 			$config['autodiscoverType'] = 'activesync';
 	}

--- a/data/web/autodiscover.php
+++ b/data/web/autodiscover.php
@@ -33,6 +33,10 @@ if ($config['useEASforOutlook'] == 'no') {
 	}
 }
 
+if (!isset($_SERVER['HTTP_USER_AGENT']) || empty($_SERVER['HTTP_USER_AGENT'])) { // eM Client sends no user agent
+	$config['autodiscoverType'] = 'imap';
+}
+
 $dsn = "$database_type:host=$database_host;dbname=$database_name";
 $opt = [
 		PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
@@ -93,6 +97,18 @@ if (!isset($_SERVER['PHP_AUTH_USER']) OR $as !== "user") {
               <AuthRequired>on</AuthRequired>
               <UsePOPAuth>on</UsePOPAuth>
               <SMTPLast>off</SMTPLast>
+          </Protocol>
+          <Protocol>
+              <Type>CalDAV</Type>
+              <Server>https://<?php echo $mailcow_hostname; ?>/SOGo/dav/<?php echo $email; ?>/Calendar</Server>
+              <DomainRequired>off</DomainRequired>
+              <LoginName><?php echo $email; ?></LoginName>
+          </Protocol>
+          <Protocol>
+              <Type>CardDAV</Type>
+              <Server>https://<?php echo $mailcow_hostname; ?>/SOGo/dav/<?php echo $email; ?>/Contacts</Server>
+              <DomainRequired>off</DomainRequired>
+              <LoginName><?php echo $email; ?></LoginName>
           </Protocol>
       </Account>
   </Response>

--- a/data/web/autodiscover.php
+++ b/data/web/autodiscover.php
@@ -29,7 +29,7 @@ error_reporting(0);
 
 $data = trim(file_get_contents("php://input"));
 
-// Desktop clients need IMAP, unless it's Outlook 2013 or higher on Windows
+// Desktop client needs IMAP, unless it's Outlook 2013 or higher on Windows
 if (strpos($data, 'autodiscover/outlook/responseschema')) { // desktop client
 	$config['autodiscoverType'] = 'imap';
 	if ($config['useEASforOutlook'] == 'yes' &&
@@ -77,6 +77,9 @@ if (!isset($_SERVER['PHP_AUTH_USER']) OR $as !== "user") {
       if ($config['autodiscoverType'] == 'imap') {
       ?>
   <Response xmlns="http://schemas.microsoft.com/exchange/autodiscover/outlook/responseschema/2006a">
+      <User>
+          <DisplayName><?php echo $displayname; ?></DisplayName>
+      </User>
       <Account>
           <AccountType>email</AccountType>
           <Action>settings</Action>


### PR DESCRIPTION
[eM Client](http://www.emclient.com) is an alternative to Thunderbird and Outlook. It natively supports CalDAV and CardDAV. It can autodiscover mail servers through the same mechanism as Outlook. As it doesn't support EAS, we need to send it the IMAP configuration.

~~eM Client can only be identified by its lack of User Agent when performing autodiscovery. All other common clients correctly send a User Agent header, so we can use that as an identification criterion.~~
Autodiscovery clients include in their request whether they are mobile devices (iPhone, Windows Phone, etc.) or desktop clients (Outlook, eM Client) using a response scheme attribute. We now differentiate based on that to determine whether a client gets IMAP or EAS. For desktop clients, with this PR, we now only use EAS for Outlook 2013 or higher on Windows. All other versions only support IMAP.

This PR also adds extra `<Protocol>` sections for CalDAV and CardDAV, which are ignored by Microsoft Outlook but used by eM Client to automatically set up calendars and address books.