### PR TITLE
ACME: support CNAME in domain checks

### DIFF
--- a/data/Dockerfiles/acme/docker-entrypoint.sh
+++ b/data/Dockerfiles/acme/docker-entrypoint.sh
@@ -53,7 +53,7 @@ while true; do
 	done < <(mysql -h mysql-mailcow -u ${DBUSER} -p${DBPASS} ${DBNAME} -e "SELECT domain FROM domain" -Bs)
 
 	for SQL_DOMAIN in "${SQL_DOMAIN_ARR[@]}"; do
-		A_CONFIG=$(dig A autoconfig.${SQL_DOMAIN} +short)
+		A_CONFIG=$(dig A autoconfig.${SQL_DOMAIN} +short | tail -n 1)
 		if [[ ! -z ${A_CONFIG} ]]; then
 			echo "Found A record for autoconfig.${SQL_DOMAIN}: ${A_CONFIG}"
 			if [[ ${IPV4} == ${A_CONFIG} ]]; then
@@ -66,7 +66,7 @@ while true; do
 			echo "No A record for autoconfig.${SQL_DOMAIN} found"
 		fi
 
-        A_DISCOVER=$(dig A autodiscover.${SQL_DOMAIN} +short)
+        A_DISCOVER=$(dig A autodiscover.${SQL_DOMAIN} +short | tail -n 1)
 		if [[ ! -z ${A_DISCOVER} ]]; then
 			echo "Found A record for autodiscover.${SQL_DOMAIN}: ${A_CONFIG}"
 			if [[ ${IPV4} == ${A_DISCOVER} ]]; then
@@ -81,7 +81,7 @@ while true; do
 	done
 
 	for SAN in "${ADDITIONAL_SAN_ARR[@]}"; do
-		A_SAN=$(dig A ${SAN} +short)
+		A_SAN=$(dig A ${SAN} +short | tail -n 1)
 		if [[ ! -z ${A_SAN} ]]; then
 			echo "Found A record for ${SAN}: ${A_SAN}"
 			if [[ ${IPV4} == ${A_SAN} ]]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -284,7 +284,7 @@ services:
     acme-mailcow:
       depends_on:
         - nginx-mailcow
-      image: mailcow/acme:1.1
+      image: mailcow/acme:1.2
       build: ./data/Dockerfiles/acme
       dns:
         - 172.22.1.254


### PR DESCRIPTION
If autodiscover.domain.com/autoconfig.domain.com are CNAME records and not A records, `dig`ing them returns two lines, the data from the CNAME record and the data from the A record it points to. As `dig` does not appear to have an option to omit the first line, this pull request uses `tail` to only retrieve the IP address. Previously, the ACME client would simply skip over these domains, saying "No A record for autodiscover.domain.com"; now it treats them correctly.

I've incremented the image tag and @andryyy will need to push the new one to Docker Hub.

I'm proposing this PR to be merged straight into master as it's a bugfix and not a new feature. You'll still need to merge master into dev. If you'd rather like to merge it to dev and then merge dev to master, I can change the base branch.