### PR TITLE
Automated builds using Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+- echo 'Europe/Berlin' | MAILCOW_HOSTNAME=build.mailcow ./generate_config.sh
+- docker-compose pull --ignore-pull-failures --parallel
+- docker-compose build
+- docker login --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD
+- docker-compose push
+
+branches:
+  only:
+  - master


### PR DESCRIPTION
@andryyy, here's a first suggestion for building on Travis (as discussed in https://github.com/mailcow/mailcow-dockerized/issues/401#issuecomment-310859925). You can use an API token instead of your real Docker Hub password, and you store it in an encrypted variable on the Travis web site. For testing, you can remove the last three lines that limit builds to master and push this to a new branch. Once it's working, put the file into master. I have only done very limited testing so far, but it should be quite easy to get this set up.