### PR TITLE
Fix EAS autodiscover for certain Outlook variants

### DIFF
--- a/data/web/autodiscover.php
+++ b/data/web/autodiscover.php
@@ -33,9 +33,8 @@ $data = trim(file_get_contents("php://input"));
 if (strpos($data, 'autodiscover/outlook/responseschema')) { // desktop client
 	$config['autodiscoverType'] = 'imap';
 	if ($config['useEASforOutlook'] == 'yes' &&
-	    strpos($_SERVER['HTTP_USER_AGENT'], 'Outlook') !== FALSE && // Outlook
 	    strpos($_SERVER['HTTP_USER_AGENT'], 'Windows NT') !== FALSE && // Windows
-	    preg_match('/Outlook (1[5-9]\.|[2-9]|1[0-9][0-9])/', $_SERVER['HTTP_USER_AGENT']) && // Outlook 2013 (version 15) or higher
+	    preg_match('/(Outlook|Office) (1[5-9]\.|[2-9]|1[0-9][0-9])/', $_SERVER['HTTP_USER_AGENT']) && // Outlook 2013 (version 15) or higher
 	    strpos($_SERVER['HTTP_USER_AGENT'], 'MS Connectivity Analyzer') === FALSE // https://testconnectivity.microsoft.com doesn't support EAS for Outlook
 	) {
 			$config['autodiscoverType'] = 'activesync';


### PR DESCRIPTION
Fixes the issue discovered by @andryyy (https://github.com/mailcow/mailcow-dockerized/pull/370#issuecomment-310895640). Evidently, the MSI-installed and the click-to-run-installed versions of Office have different user agents.