### PR TITLE
Table overflow in mobile fix

### DIFF
--- a/data/web/css/admin.css
+++ b/data/web/css/admin.css
@@ -9,7 +9,12 @@ table.footable>tbody>tr.footable-empty>td {
   overflow: visible !important;
 }
 .table-responsive {
-  overflow-x: scroll !important;
+  overflow: visible !important;
+}
+@media screen and (max-width: 767px) {
+  .table-responsive {
+    overflow-x: scroll !important;
+  }
 }
 body {
   overflow-y:scroll;

--- a/data/web/css/admin.css
+++ b/data/web/css/admin.css
@@ -9,7 +9,7 @@ table.footable>tbody>tr.footable-empty>td {
   overflow: visible !important;
 }
 .table-responsive {
-  overflow: visible !important;
+  overflow-x: scroll !important;
 }
 body {
   overflow-y:scroll;

--- a/data/web/css/edit.css
+++ b/data/web/css/edit.css
@@ -9,7 +9,7 @@ table.footable>tbody>tr.footable-empty>td {
   overflow: visible !important;
 }
 .table-responsive {
-  overflow: visible !important;
+  overflow-x: scroll !important;
 }
 .footer-add-item {
   display:block;

--- a/data/web/css/edit.css
+++ b/data/web/css/edit.css
@@ -9,7 +9,12 @@ table.footable>tbody>tr.footable-empty>td {
   overflow: visible !important;
 }
 .table-responsive {
-  overflow-x: scroll !important;
+  overflow: visible !important;
+}
+@media screen and (max-width: 767px) {
+  .table-responsive {
+    overflow-x: scroll !important;
+  }
 }
 .footer-add-item {
   display:block;

--- a/data/web/css/mailbox.css
+++ b/data/web/css/mailbox.css
@@ -9,7 +9,12 @@ table.footable>tbody>tr.footable-empty>td {
   overflow: visible !important;
 }
 .table-responsive {
-  overflow-x: scroll !important;
+  overflow: visible !important;
+}
+@media screen and (max-width: 767px) {
+  .table-responsive {
+    overflow-x: scroll !important;
+  }
 }
 .footer-add-item {
   display:block;
@@ -30,4 +35,3 @@ table.footable>tbody>tr.footable-empty>td {
 .inputMissingAttr {
   border-color: #FF4136;
 }
-

--- a/data/web/css/mailbox.css
+++ b/data/web/css/mailbox.css
@@ -9,7 +9,7 @@ table.footable>tbody>tr.footable-empty>td {
   overflow: visible !important;
 }
 .table-responsive {
-  overflow: visible !important;
+  overflow-x: scroll !important;
 }
 .footer-add-item {
   display:block;

--- a/data/web/css/user.css
+++ b/data/web/css/user.css
@@ -9,7 +9,7 @@ table.footable>tbody>tr.footable-empty>td {
   overflow: visible !important;
 }
 .table-responsive {
-  overflow: visible !important;
+  overflow-x: scroll !important;
 }
 .footer-add-item {
   display:block;

--- a/data/web/css/user.css
+++ b/data/web/css/user.css
@@ -9,7 +9,12 @@ table.footable>tbody>tr.footable-empty>td {
   overflow: visible !important;
 }
 .table-responsive {
-  overflow-x: scroll !important;
+  overflow: visible !important;
+}
+@media screen and (max-width: 767px) {
+  .table-responsive {
+    overflow-x: scroll !important;
+  }
 }
 .footer-add-item {
   display:block;


### PR DESCRIPTION
Making these tables mobile-responsive is difficult because element widths have been hard-coded within its javascript dependencies. So, I think the easiest solution is to add some scrollbars to whenever the viewport is within the range of mobile screens.