### PR TITLE
Client configuration guide link

### DIFF
--- a/data/web/lang/lang.de.php
+++ b/data/web/lang/lang.de.php
@@ -108,6 +108,7 @@ $lang['user']['user_settings'] = 'Benutzereinstellungen';
 $lang['user']['mailbox_settings'] = 'Mailbox-Einstellungen';
 $lang['user']['mailbox_details'] = 'Mailbox-Details';
 $lang['user']['change_password'] = 'Passwort ändern';
+$lang['user']['client_configuration'] = 'Konfigurationsanleitungen für E-Mail-Programme und Smartphones anzeigen';
 $lang['user']['new_password'] = 'Neues Passwort';
 $lang['user']['save_changes'] = 'Änderungen speichern';
 $lang['user']['password_now'] = 'Aktuelles Passwort (Änderungen bestätigen)';

--- a/data/web/lang/lang.en.php
+++ b/data/web/lang/lang.en.php
@@ -110,6 +110,7 @@ $lang['user']['user_settings'] = 'User settings';
 $lang['user']['mailbox_settings'] = 'Mailbox settings';
 $lang['user']['mailbox_details'] = 'Mailbox details';
 $lang['user']['change_password'] = 'Change password';
+$lang['user']['client_configuration'] = 'Show configuration guides for email clients and smartphones';
 $lang['user']['new_password'] = 'New password';
 $lang['user']['save_changes'] = 'Save changes';
 $lang['user']['password_now'] = 'Current password (confirm changes)';

--- a/data/web/user.php
+++ b/data/web/user.php
@@ -64,6 +64,25 @@ elseif (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == '
 	$_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
 	$username = $_SESSION['mailcow_cc_username'];
   $mailboxdata = mailbox('get', 'mailbox_details', $username);
+  
+  $clientconfigstr = "host=" . urlencode($mailcow_hostname) . "&email=" . urlencode($username) . "&name=" . urlencode($mailboxdata['name']) . "&port=" . urlencode($autodiscover_config['caldav']['port']);
+  if ($autodiscover_config['useEASforOutlook'] == 'yes')
+    $clientconfigstr .= "&outlookEAS=1";
+  if (file_exists('thunderbird-plugins/version.csv'))
+  {
+    $fh = fopen('thunderbird-plugins/version.csv', 'r');
+    if ($fh)
+    {
+      while (($row = fgetcsv($fh, 1000, ';')) !== FALSE)
+      {
+        if ($row[0] == 'sogo-integrator@inverse.ca') {
+          $clientconfigstr .= "&integrator=" . urlencode($row[1]);
+        }
+      }
+      fclose($fh);
+    }
+  }
+  
 ?>
 <div class="container">
 <h3><?=$lang['user']['user_settings'];?></h3>
@@ -74,6 +93,7 @@ elseif (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == '
   <div class="row">
     <div class="col-sm-offset-3 col-sm-9">
       <p><a href="#pwChangeModal" data-toggle="modal">[<?=$lang['user']['change_password'];?>]</a></p>
+      <p><a target="_blank" href="https://mailcow.github.io/mailcow-dockerized-docs/client/#<?=$clientconfigstr;?>">[<?=$lang['user']['client_configuration'];?>]</a></p>
     </div>
   </div>
   <hr>


### PR DESCRIPTION
This supersedes #450.

I was able to move everything to the docs repository (https://github.com/mailcow/mailcow-dockerized-docs/pull/37). When the page in the documentation is accessed via the link on the user page, the necessary variables (host name, whether Outlook EAS is enabled, etc.) are passed via the URL anchor and the documentation is dynamically modified via JavaScript. The variables are never sent to the server as the anchor is only dealt with by the browser.

~~#449 needs to be merged before this PR works.~~