### PR TITLE
Disable ClamAV phishing filter

### DIFF
--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -15,6 +15,8 @@ RUN apk add --update \
 	&& chmod 750 /run/clamav \
 	&& sed -i '/Foreground yes/s/^#//g' /etc/clamav/clamd.conf \
 	&& sed -i '/TCPSocket 3310/s/^#//g' /etc/clamav/clamd.conf \
+	&& sed -i 's/#PhishingSignatures yes/PhishingSignatures no/g' /etc/clamav/clamd.conf \
+	&& sed -i 's/#PhishingScanURLs yes/PhishingScanURLs no/g' /etc/clamav/clamd.conf \
 	&& sed -i '/Foreground yes/s/^#//g' /etc/clamav/freshclam.conf
 
 # Port provision

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
             - redis
 
     clamd-mailcow:
-      image: mailcow/clamd:1.1
+      image: mailcow/clamd:1.2
       build: ./data/Dockerfiles/clamd
       restart: always
       environment:


### PR DESCRIPTION
ClamAV has a phishing filter built in, but it generates too many false positives as it only has some very simple heuristics for detecting phishing. Any email it suspects to be phishing is rejected with a status message claiming it contains a virus. Obviously this is not true.
We can disable ClamAV's phishing filter without risk because rspamd also checks for phishing itself. Since rspamd does not only do simple text analysis, but also considers headers and the training of its Bayesian filter, it is much more suited than ClamAV to deliver accurate judgements over whether an email is really phishing.