### PR TITLE
Rspamd user blacklist/whitelist improvements

### DIFF
--- a/data/conf/rspamd/dynmaps/settings.php
+++ b/data/conf/rspamd/dynmaps/settings.php
@@ -182,6 +182,47 @@ while ($row = array_shift($rows)) {
 			"MAILCOW_WHITE"
 		]
 	}
+	whitelist_header_<?=$username_sane;?> {
+<?php
+	$stmt = $pdo->prepare("SELECT GROUP_CONCAT(REPLACE(`value`, '*', '.*') SEPARATOR '|') AS `value` FROM `filterconf`
+		WHERE `object`= :object
+			AND `option` = 'whitelist_from'");
+	$stmt->execute(array(':object' => $row['object']));
+	$grouped_lists = $stmt->fetchAll(PDO::FETCH_COLUMN);
+	$value_sane = preg_replace("/\.\./", ".", (preg_replace("/\*/", ".*", $grouped_lists[0])));
+?>
+		request_header = {
+			"From" = "/(<?=$value_sane;?>)/i";
+		}
+<?php
+	if (!filter_var(trim($row['object']), FILTER_VALIDATE_EMAIL)) {
+?>
+		priority = 5;
+<?php
+		foreach (ucl_rcpts($row['object'], 'mailbox') as $rcpt) {
+?>
+		rcpt = "<?=$rcpt;?>";
+<?php
+		}
+	}
+	else {
+?>
+		priority = 6;
+<?php
+		foreach (ucl_rcpts($row['object'], 'mailbox') as $rcpt) {
+?>
+		rcpt = "<?=$rcpt;?>";
+<?php
+		}
+	}
+?>
+		apply "default" {
+			MAILCOW_WHITE = -999.0;
+		}
+		symbols [
+			"MAILCOW_WHITE"
+		]
+	}
 <?php
 }
 
@@ -204,6 +245,47 @@ while ($row = array_shift($rows)) {
 	$value_sane = preg_replace("/\.\./", ".", (preg_replace("/\*/", ".*", $grouped_lists[0])));
 ?>
 		from = "/(<?=$value_sane;?>)/i";
+<?php
+	if (!filter_var(trim($row['object']), FILTER_VALIDATE_EMAIL)) {
+?>
+		priority = 5;
+<?php
+		foreach (ucl_rcpts($row['object'], 'mailbox') as $rcpt) {
+?>
+		rcpt = "<?=$rcpt;?>";
+<?php
+		}
+	}
+	else {
+?>
+		priority = 6;
+<?php
+		foreach (ucl_rcpts($row['object'], 'mailbox') as $rcpt) {
+?>
+		rcpt = "<?=$rcpt;?>";
+<?php
+		}
+	}
+?>
+		apply "default" {
+			MAILCOW_BLACK = 999.0;
+		}
+		symbols [
+			"MAILCOW_BLACK"
+		]
+	}
+	blacklist_header_<?=$username_sane;?> {
+<?php
+	$stmt = $pdo->prepare("SELECT GROUP_CONCAT(REPLACE(`value`, '*', '.*') SEPARATOR '|') AS `value` FROM `filterconf`
+		WHERE `object`= :object
+			AND `option` = 'blacklist_from'");
+	$stmt->execute(array(':object' => $row['object']));
+	$grouped_lists = $stmt->fetchAll(PDO::FETCH_COLUMN);
+	$value_sane = preg_replace("/\.\./", ".", (preg_replace("/\*/", ".*", $grouped_lists[0])));
+?>
+		request_header = {
+			"From" = "/(<?=$value_sane;?>)/i";
+		}
 <?php
 	if (!filter_var(trim($row['object']), FILTER_VALIDATE_EMAIL)) {
 ?>

--- a/data/conf/rspamd/dynmaps/settings.php
+++ b/data/conf/rspamd/dynmaps/settings.php
@@ -83,7 +83,7 @@ function ucl_rcpts($object, $type) {
 		$rcpt[] = '/.*@' . $object . '/i';
 		$stmt = $pdo->prepare("SELECT `alias_domain` FROM `alias_domain`
 			WHERE `target_domain` = :object");
-		$stmt->execute(array(':object' => $row['object']));
+		$stmt->execute(array(':object' => $object));
 		$alias_domains = $stmt->fetchAll(PDO::FETCH_ASSOC);
 		array_filter($alias_domains);
 		while ($row = array_shift($alias_domains)) {
@@ -112,7 +112,7 @@ while ($row = array_shift($rows)) {
 	score_<?=$username_sane;?> {
 		priority = 4;
 <?php
-  foreach (ucl_rcpts($row['object'], 'mailbox') as $rcpt) {
+  foreach (ucl_rcpts($row['object'], strpos($row['object'], '@') === FALSE ? 'domain' : 'mailbox') as $rcpt) {
 ?>
 		rcpt = "<?=$rcpt;?>";
 <?php
@@ -158,7 +158,7 @@ while ($row = array_shift($rows)) {
 ?>
 		priority = 5;
 <?php
-		foreach (ucl_rcpts($row['object'], 'mailbox') as $rcpt) {
+		foreach (ucl_rcpts($row['object'], strpos($row['object'], '@') === FALSE ? 'domain' : 'mailbox') as $rcpt) {
 ?>
 		rcpt = "<?=$rcpt;?>";
 <?php
@@ -168,7 +168,7 @@ while ($row = array_shift($rows)) {
 ?>
 		priority = 6;
 <?php
-		foreach (ucl_rcpts($row['object'], 'mailbox') as $rcpt) {
+		foreach (ucl_rcpts($row['object'], strpos($row['object'], '@') === FALSE ? 'domain' : 'mailbox') as $rcpt) {
 ?>
 		rcpt = "<?=$rcpt;?>";
 <?php
@@ -199,7 +199,7 @@ while ($row = array_shift($rows)) {
 ?>
 		priority = 5;
 <?php
-		foreach (ucl_rcpts($row['object'], 'mailbox') as $rcpt) {
+		foreach (ucl_rcpts($row['object'], strpos($row['object'], '@') === FALSE ? 'domain' : 'mailbox') as $rcpt) {
 ?>
 		rcpt = "<?=$rcpt;?>";
 <?php
@@ -209,7 +209,7 @@ while ($row = array_shift($rows)) {
 ?>
 		priority = 6;
 <?php
-		foreach (ucl_rcpts($row['object'], 'mailbox') as $rcpt) {
+		foreach (ucl_rcpts($row['object'], strpos($row['object'], '@') === FALSE ? 'domain' : 'mailbox') as $rcpt) {
 ?>
 		rcpt = "<?=$rcpt;?>";
 <?php
@@ -250,7 +250,7 @@ while ($row = array_shift($rows)) {
 ?>
 		priority = 5;
 <?php
-		foreach (ucl_rcpts($row['object'], 'mailbox') as $rcpt) {
+		foreach (ucl_rcpts($row['object'], strpos($row['object'], '@') === FALSE ? 'domain' : 'mailbox') as $rcpt) {
 ?>
 		rcpt = "<?=$rcpt;?>";
 <?php
@@ -260,7 +260,7 @@ while ($row = array_shift($rows)) {
 ?>
 		priority = 6;
 <?php
-		foreach (ucl_rcpts($row['object'], 'mailbox') as $rcpt) {
+		foreach (ucl_rcpts($row['object'], strpos($row['object'], '@') === FALSE ? 'domain' : 'mailbox') as $rcpt) {
 ?>
 		rcpt = "<?=$rcpt;?>";
 <?php
@@ -291,7 +291,7 @@ while ($row = array_shift($rows)) {
 ?>
 		priority = 5;
 <?php
-		foreach (ucl_rcpts($row['object'], 'mailbox') as $rcpt) {
+		foreach (ucl_rcpts($row['object'], strpos($row['object'], '@') === FALSE ? 'domain' : 'mailbox') as $rcpt) {
 ?>
 		rcpt = "<?=$rcpt;?>";
 <?php
@@ -301,7 +301,7 @@ while ($row = array_shift($rows)) {
 ?>
 		priority = 6;
 <?php
-		foreach (ucl_rcpts($row['object'], 'mailbox') as $rcpt) {
+		foreach (ucl_rcpts($row['object'], strpos($row['object'], '@') === FALSE ? 'domain' : 'mailbox') as $rcpt) {
 ?>
 		rcpt = "<?=$rcpt;?>";
 <?php

--- a/data/conf/rspamd/dynmaps/settings.php
+++ b/data/conf/rspamd/dynmaps/settings.php
@@ -47,7 +47,7 @@ function ucl_rcpts($object, $type) {
       $local = parse_email($row['address'])['local'];
       $domain = parse_email($row['address'])['domain'];
       if (!empty($local) && !empty($domain)) {
-        $rcpt[] = '/' . $local . '\+.*' . $domain . '/';
+        $rcpt[] = '/' . $local . '\+.*' . $domain . '/i';
       }
       $rcpt[] = $row['address'];
     }
@@ -65,7 +65,7 @@ function ucl_rcpts($object, $type) {
         $local = parse_email($row['alias'])['local'];
         $domain = parse_email($row['alias'])['domain'];
         if (!empty($local) && !empty($domain)) {
-          $rcpt[] = '/' . $local . '\+.*' . $domain . '/';
+          $rcpt[] = '/' . $local . '\+.*' . $domain . '/i';
         }
       $rcpt[] = $row['alias'];
       }
@@ -74,20 +74,20 @@ function ucl_rcpts($object, $type) {
     $local = parse_email($row['object'])['local'];
     $domain = parse_email($row['object'])['domain'];
     if (!empty($local) && !empty($domain)) {
-      $rcpt[] = '/' . $local . '\+.*' . $domain . '/';
+      $rcpt[] = '/' . $local . '\+.*' . $domain . '/i';
     }
     $rcpt[] = $object;
   }
   elseif ($type == 'domain') {
     // Domain self
-		$rcpt[] = '/.*@' . $object . '/';
+		$rcpt[] = '/.*@' . $object . '/i';
 		$stmt = $pdo->prepare("SELECT `alias_domain` FROM `alias_domain`
 			WHERE `target_domain` = :object");
 		$stmt->execute(array(':object' => $row['object']));
 		$alias_domains = $stmt->fetchAll(PDO::FETCH_ASSOC);
 		array_filter($alias_domains);
 		while ($row = array_shift($alias_domains)) {
-      $rcpt[] = '/.*@' . $row['alias_domain'] . '/';
+      $rcpt[] = '/.*@' . $row['alias_domain'] . '/i';
 		}
   }
   if (!empty($rcpt)) {
@@ -152,7 +152,7 @@ while ($row = array_shift($rows)) {
 	$grouped_lists = $stmt->fetchAll(PDO::FETCH_COLUMN);
 	$value_sane = preg_replace("/\.\./", ".", (preg_replace("/\*/", ".*", $grouped_lists[0])));
 ?>
-		from = "/(<?=$value_sane;?>)/";
+		from = "/(<?=$value_sane;?>)/i";
 <?php
 	if (!filter_var(trim($row['object']), FILTER_VALIDATE_EMAIL)) {
 ?>
@@ -203,7 +203,7 @@ while ($row = array_shift($rows)) {
 	$grouped_lists = $stmt->fetchAll(PDO::FETCH_COLUMN);
 	$value_sane = preg_replace("/\.\./", ".", (preg_replace("/\*/", ".*", $grouped_lists[0])));
 ?>
-		from = "/(<?=$value_sane;?>)/";
+		from = "/(<?=$value_sane;?>)/i";
 <?php
 	if (!filter_var(trim($row['object']), FILTER_VALIDATE_EMAIL)) {
 ?>

--- a/data/conf/rspamd/dynmaps/settings.php
+++ b/data/conf/rspamd/dynmaps/settings.php
@@ -192,7 +192,7 @@ while ($row = array_shift($rows)) {
 	$value_sane = preg_replace("/\.\./", ".", (preg_replace("/\*/", ".*", $grouped_lists[0])));
 ?>
 		request_header = {
-			"From" = "/(<?=$value_sane;?>)/i";
+			"From" = "(<?=$value_sane;?>)";
 		}
 <?php
 	if (!filter_var(trim($row['object']), FILTER_VALIDATE_EMAIL)) {
@@ -284,7 +284,7 @@ while ($row = array_shift($rows)) {
 	$value_sane = preg_replace("/\.\./", ".", (preg_replace("/\*/", ".*", $grouped_lists[0])));
 ?>
 		request_header = {
-			"From" = "/(<?=$value_sane;?>)/i";
+			"From" = "(<?=$value_sane;?>)";
 		}
 <?php
 	if (!filter_var(trim($row['object']), FILTER_VALIDATE_EMAIL)) {


### PR DESCRIPTION
- Make regex matching case-insensitive.
  - The web UI normalizes all white-/blacklist entries to lower case, but email addresses in an SMTP conversation may have any (mixed) case.
- In addition to the Envelope-From, match the From header.
  - The average end user doesn't know about Envelope-From (or how to extract it from the email headers in their email client), so they expect to be able to add a From address to their blacklist/whitelist.
  - Some mailing lists and newsletters send messages with different Envelope-From and From, so this change is actually necessary to be able to correctly handle certain messages.
  - This is not a security/spam issue as Envelope-From is just as easily forged as From headers.
- For domain-global whitelist/blacklist entries, settings.php should not print all email addresses in that domain (potentially making the settings map really large), but a domain regex.
  - The `ucl_rcpts` function was already capable of this, but needed a trivial bug fix and be called with `$type = 'domain'`.