### PR TITLE
Use different exit code on updates check

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -51,10 +51,11 @@ case "${1}" in
 		git fetch origin ${BRANCH}
 		if ! git diff origin/${BRANCH} --quiet; then
 			echo "Updated code is available."
+			exit 0
 		else
 			echo "No updates available."
+			exit 3
 		fi
-		exit 0
 	;;
 esac
 


### PR DESCRIPTION
Enables some scripting, e.g. putting this in a cron job:

    ./update.sh --check && <notify-me-about-available-updates>

By the way, what is the recommended way to follow updates? I'm preparing to switch from Mail-in-a-box, and there users receive an email when a new release is available. I found this `./update.sh --check` which with this PR merged will be able to help me follow updates, but is there maybe an alternative that everyone is currently using?