### PR TITLE
Forwarding hosts: treat soft reject like greylist

### DIFF
--- a/data/conf/rspamd/local.d/force_actions.conf
+++ b/data/conf/rspamd/local.d/force_actions.conf
@@ -12,11 +12,11 @@ rules {
   WHITELIST_FORWARDING_HOST_NO_REJECT {
     action = "add header";
     expression = "WHITELISTED_FWD_HOST";
-    require_action = ["soft reject", "reject"];
+    require_action = ["reject"];
   }
   WHITELIST_FORWARDING_HOST_NO_GREYLIST {
     action = "no action";
     expression = "WHITELISTED_FWD_HOST";
-    require_action = ["greylist"];
+    require_action = ["greylist", "soft reject"];
   }
 }


### PR DESCRIPTION
The _greylist_ action actually turns into _soft reject_ by the time it reaches the _force_actions_ module. So we should treat _soft reject_ the same as _greylist_ when we deal with forwarding hosts, meaning the message should not be flagged as spam.

The old behavior is inconsistent: mails from forwarding hosts are flagged as spam on scores higher than 4.0, while mails from other hosts are flagged above 5.0. This PR makes that consistent by using 5.0 for both.