### PR TITLE
Rewrite the if for getting timezone

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -16,7 +16,12 @@ if [ -z "$MAILCOW_HOSTNAME" ]; then
   read -p "Hostname (FQDN): " -ei "mx.example.org" MAILCOW_HOSTNAME
 fi
 
-[[ -a /etc/timezone ]] && TZ=$(cat /etc/timezone) || [[ -a /etc/localtime ]] && TZ=$(readlink /etc/localtime|sed -n 's|^.*zoneinfo/||p')
+if [[ -a /etc/timezone ]]; then 
+ TZ=$(cat /etc/timezone) 
+elif  [[ -a /etc/localtime ]]; then
+ TZ=$(readlink /etc/localtime|sed -n 's|^.*zoneinfo/||p')
+fi
+
 if [ -z "$TZ" ]; then
   read -p "Timezone: " -ei "Europe/Berlin" TZ
 else


### PR DESCRIPTION
My last edit of this file caused issue even if the file /etc/timezone existed it wouldn't use the timezone value of it, the only file it would try to get the timezone out of is /etc/localtime.

This edit fixes the logic issue of my last edit so it now try to get the current timezone from /etc/timezone if it exist then try /etc/localtime unlike my last edit that would only work if /etc/localtime exist.