### PR TITLE
Rspamd user settings: fix matching From header

### DIFF
--- a/data/conf/rspamd/dynmaps/settings.php
+++ b/data/conf/rspamd/dynmaps/settings.php
@@ -191,8 +191,8 @@ while ($row = array_shift($rows)) {
 	$grouped_lists = $stmt->fetchAll(PDO::FETCH_COLUMN);
 	$value_sane = preg_replace("/\.\./", ".", (preg_replace("/\*/", ".*", $grouped_lists[0])));
 ?>
-		request_header = {
-			"From" = "(<?=$value_sane;?>)";
+		header = {
+			"From" = "/(<?=$value_sane;?>)/i";
 		}
 <?php
 	if (!filter_var(trim($row['object']), FILTER_VALIDATE_EMAIL)) {
@@ -283,8 +283,8 @@ while ($row = array_shift($rows)) {
 	$grouped_lists = $stmt->fetchAll(PDO::FETCH_COLUMN);
 	$value_sane = preg_replace("/\.\./", ".", (preg_replace("/\*/", ".*", $grouped_lists[0])));
 ?>
-		request_header = {
-			"From" = "(<?=$value_sane;?>)";
+		header = {
+			"From" = "/(<?=$value_sane;?>)/i";
 		}
 <?php
 	if (!filter_var(trim($row['object']), FILTER_VALIDATE_EMAIL)) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
             - clamd
 
     rspamd-mailcow:
-      image: mailcow/rspamd:1.6
+      image: mailcow/rspamd:1.7
       build: ./data/Dockerfiles/rspamd
       command: "/usr/bin/rspamd -f -u _rspamd -g _rspamd"
       depends_on:


### PR DESCRIPTION
#536 introduced From header matching (in addition to the existing Envelope-From matching) into the rspamd user settings. This turned out to work slightly unreliably because _header_ and _request_header_ are not the same thing in rspamd. I recently submitted a patch to rspamd (https://github.com/vstakhov/rspamd/pull/1821) that added a _header_ rule type.

The apt packages were finally rebuilt with the latest 1.7.0 beta today (see https://rspamd.com/apt/pool/main/r/rspamd/), so we can now upgrade to an rspamd version that supports the _header_ rule type.

@andryyy, can you merge dev to master after merging this PR? It's technically a bugfix, but I couldn't submit it against master due to merge conflicts in docker-compose.yml. That ACME sleep fix on dev should probably also go to master as soon as possible.