### PR TITLE
rspamd: exclude Mail Flow monitoring from logs and stats

### DIFF
--- a/data/conf/rspamd/lua/rspamd.local.lua
+++ b/data/conf/rspamd/lua/rspamd.local.lua
@@ -108,3 +108,15 @@ rspamd_config:register_symbol({
   end,
   priority = 20
 })
+
+rspamd_config:register_symbol({
+  name = 'NO_LOG_STAT_MAILFLOW',
+  type = 'postfilter',
+  callback = function(task)
+    local sender = task:get_header('From')
+    if sender == 'monitoring-system@everycloudtech.us' then
+      task:set_flag('no_log')
+      task:set_flag('no_stat')
+    end
+  end
+})


### PR DESCRIPTION
[Everycloudtech's free Mail flow monitoring](https://www.everycloudtech.com/free-mail-flow-monitor) has been recommended on the issue tracker multiple times (e.g. https://github.com/mailcow/mailcow-dockerized/issues/228#issuecomment-298694532) as a means of ensuring that incoming and outgoing mails work continuously. Using such a service, however, pollutes the rspamd log and distorts its statistics. This PR applies the _no_log_ and _no_stat_ flags to messages coming from monitoring-system@everycloudtech.us to exclude them from logging and statistics.

I don't think it's necessary to make this an option available in the admin interface as it's basically only useful with such a monitoring service. Everycloudtech is pretty popular and is the only one I know that is free. If somebody uses another one, they can simply submit a PR that adds the respective address.

Note that it makes no sense to use the existing "Forwarding Hosts" feature to exclude the monitoring system's email from spam filtering entirely -- this could leave situations undetected where the SMTP server works fine, but the spam filter is somehow broken so it rejects all emails. So mail flow monitoring should always flow through the spam filter too.