### PR TITLE
Preliminary support for Outlook 2016’s autodiscover.json

### DIFF
--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -86,6 +86,14 @@ server {
     try_files /autodiscover.php =404;
   }
 
+  location ~* ^/Autodiscover/Autodiscover.json {
+    fastcgi_split_path_info ^(.+\.php)(/.+)$;
+    fastcgi_pass phpfpm:9000;
+    include /etc/nginx/fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    try_files /autodiscover-json.php =404;
+  }
+
   location ~ /(?:m|M)ail/(?:c|C)onfig-v1.1.xml {
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
     fastcgi_pass phpfpm:9000;
@@ -231,6 +239,14 @@ server {
     include /etc/nginx/fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     try_files /autodiscover.php =404;
+  }
+
+  location ~* ^/Autodiscover/Autodiscover.json {
+    fastcgi_split_path_info ^(.+\.php)(/.+)$;
+    fastcgi_pass phpfpm:9000;
+    include /etc/nginx/fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    try_files /autodiscover-json.php =404;
   }
 
   location ~ /(?:m|M)ail/(?:c|C)onfig-v1.1.xml {

--- a/data/web/autodiscover-json.php
+++ b/data/web/autodiscover-json.php
@@ -1,0 +1,23 @@
+<?php
+require_once 'inc/vars.inc.php';
+require_once 'inc/functions.inc.php';
+$default_autodiscover_config = $autodiscover_config;
+if(file_exists('inc/vars.local.inc.php')) {
+  include_once 'inc/vars.local.inc.php';
+}
+$autodiscover_config = array_merge($default_autodiscover_config, $autodiscover_config);
+
+header('Content-type: application/json');
+
+$domain_dot = strpos($_SERVER['HTTP_HOST'], '.');
+$domain = substr($_SERVER['HTTP_HOST'], $domain_dot+1);
+
+if ($_GET['Protocol'] == 'ActiveSync') {
+  echo '{"Protocol":"ActiveSync","Url":"' . $autodiscover_config['activesync']['url'] . '"}';
+} elseif ($_GET['Protocol'] == 'AutodiscoverV1') {
+  echo '{"Protocol":"AutodiscoverV1","Url":"https://autodiscover.' . $domain . '/autodiscover/autodiscover.xml"}';
+} else {
+  http_response_code(400);
+  echo '{"ErrorCode":"InvalidProtocol","ErrorMessage":"The given protocol value \u0027' . $_GET['Protocol'] . '\u0027 is invalid. Supported values are \u0027ActiveSync,AutodiscoverV1\u0027"}';
+}
+?>

--- a/data/web/autodiscover-json.php
+++ b/data/web/autodiscover-json.php
@@ -8,15 +8,13 @@ if(file_exists('inc/vars.local.inc.php')) {
 $autodiscover_config = array_merge($default_autodiscover_config, $autodiscover_config);
 
 header('Content-type: application/json');
-
-$domain_dot = strpos($_SERVER['HTTP_HOST'], '.');
-$domain = substr($_SERVER['HTTP_HOST'], $domain_dot+1);
-
 if ($_GET['Protocol'] == 'ActiveSync') {
   echo '{"Protocol":"ActiveSync","Url":"' . $autodiscover_config['activesync']['url'] . '"}';
-} elseif ($_GET['Protocol'] == 'AutodiscoverV1') {
-  echo '{"Protocol":"AutodiscoverV1","Url":"https://autodiscover.' . $domain . '/autodiscover/autodiscover.xml"}';
-} else {
+}
+elseif ($_GET['Protocol'] == 'AutodiscoverV1') {
+  echo '{"Protocol":"AutodiscoverV1","Url":"https://' . $_SERVER['HTTP_HOST'] . '/autodiscover/autodiscover.xml"}';
+}
+else {
   http_response_code(400);
   echo '{"ErrorCode":"InvalidProtocol","ErrorMessage":"The given protocol value \u0027' . $_GET['Protocol'] . '\u0027 is invalid. Supported values are \u0027ActiveSync,AutodiscoverV1\u0027"}';
 }


### PR DESCRIPTION
This adds preliminary support to Outlook 2016's JSON-based autodiscovery mechanism.

My PHP script behaves exactly like Microsoft Exchange does as far as I can tell, though unfortunately Outlook doesn't pick up the configuration correctly. Until Microsoft publishes documentation on the file format or someone reverse engineers all the remaining protocol details, we will not be able to provide full autodiscovery support for Outlook 2016.

Partial fix for #615