### PR TITLE
ACME needs to wait for MySQL to be ready

### DIFF
--- a/data/Dockerfiles/acme/docker-entrypoint.sh
+++ b/data/Dockerfiles/acme/docker-entrypoint.sh
@@ -80,6 +80,11 @@ else
 	fi
 fi
 
+while ! mysqladmin ping --host mysql -u${DBUSER} -p${DBPASS} --silent; do
+	echo "Waiting for database to come up..."
+	sleep 2
+done
+
 while true; do
 	if [[ "${SKIP_LETS_ENCRYPT}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
 		echo "SKIP_LETS_ENCRYPT=y, skipping Let's Encrypt..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -249,7 +249,8 @@ services:
     acme-mailcow:
       depends_on:
         - nginx-mailcow
-      image: mailcow/acme:1.19
+        - mysql-mailcow
+      image: mailcow/acme:1.20
       build: ./data/Dockerfiles/acme
       init: true
       dns:


### PR DESCRIPTION
Today, I installed a Docker update on my server and it restarted all containers. Unfortunately, the acme container came up before the mysql container and thus all my autoconfig.* and autodiscover.* SANs were removed from the certificate.
```
acme-mailcow_1       | Found Let's Encrypt or mailcow snake-oil CA issued certificate with SANs: autoconfig.example.com autodiscover.example.com cloud.example.com mailcow.example.com
acme-mailcow_1       | ERROR 2003 (HY000): Can't connect to MySQL server on 'mysql-mailcow' (111 "Connection refused")
acme-mailcow_1       | ERROR 2003 (HY000): Can't connect to MySQL server on 'mysql-mailcow' (111 "Connection refused")
acme-mailcow_1       | Found A record for mailcow.example.com: 192.0.2.42
acme-mailcow_1       | Confirmed A record mailcow.example.com
acme-mailcow_1       | Found A record for cloud.example.com: 192.0.2.42
acme-mailcow_1       | Confirmed A record cloud.example.com
acme-mailcow_1       | Found orphaned SAN autoconfig.example.com autodiscover.example.com in certificate, moving old files to /var/lib/acme/acme/private/2017-09-27_04_40_20.bak/, keeping key file...
```

This PR fixes this race condition by making ACME wait for MySQL to come up.