### PR TITLE
rspamd: fully disable greylisting for forwarding hosts

### DIFF
--- a/data/conf/rspamd/dynmaps/forwardinghosts.php
+++ b/data/conf/rspamd/dynmaps/forwardinghosts.php
@@ -28,17 +28,28 @@ function in_net($addr, $net) {
   return substr($addr_bin, 0, $mask) == substr($net_bin, 0, $mask);
 }
 
-try {
-  foreach ($redis->hGetAll('WHITELISTED_FWD_HOST') as $host => $source) {
-    if (in_net($_GET['host'], $host)) {
-      echo '200 PERMIT';
-      exit;
+if (isset($_GET['host'])) {
+  try {
+    foreach ($redis->hGetAll('WHITELISTED_FWD_HOST') as $host => $source) {
+      if (in_net($_GET['host'], $host)) {
+        echo '200 PERMIT';
+        exit;
+      }
+    }
+    echo '200 DUNNO';
+  }
+  catch (RedisException $e) {
+    echo '200 DUNNO';
+    exit;
+  }
+} else {
+  try {
+    foreach ($redis->hGetAll('WHITELISTED_FWD_HOST') as $host => $source) {
+      echo $host . "\n";
     }
   }
-  echo '200 DUNNO';
-}
-catch (RedisException $e) {
-  echo '200 DUNNO';
-  exit;
+  catch (RedisException $e) {
+    exit;
+  }
 }
 ?>

--- a/data/conf/rspamd/local.d/greylist.conf
+++ b/data/conf/rspamd/local.d/greylist.conf
@@ -1,0 +1,1 @@
+whitelisted_ip = "http://172.22.1.251:8081/forwardinghosts.php";


### PR DESCRIPTION
If the force_action module downgrades a "reject" to an "add header" action because the mail came from a trusted forwarding host, rspamd may still apply greylisting because the greylist module does [its own score check](https://github.com/vstakhov/rspamd/blob/54c77a450d4a6dbf53c98406fa18dbc0a775caad/src/plugins/lua/greylist.lua#L247). Of course, we don't want that as emails should never be rejected or delayed when coming from a forwarding host.

The main difficulty in fixing this is that the greylist module runs after the force_actions module, so we cannot override an action set by the greylist module. There are two possible solutions: either the [user settings](https://rspamd.com/doc/configuration/settings.html) dynmap can be used to disable the greylist module for certain IP addresses (but this doesn't support netmasks, only explicit IP addresses), or the [greylist module](https://rspamd.com/doc/modules/greylisting.html)'s whitelist feature can be used.

This pull request does the latter (because we need netmask support) and tells rspamd's greylist module to check the forwarding hosts whitelist and not apply greylisting to any host contained in it.