### PR TITLE
Update rspamd

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
             - clamd
 
     rspamd-mailcow:
-      image: mailcow/rspamd:1.11
+      image: mailcow/rspamd:1.12
       build: ./data/Dockerfiles/rspamd
       stop_grace_period: 30s
       depends_on:


### PR DESCRIPTION
Includes the fix for DKIM validation when more than two Received headers were present (https://github.com/vstakhov/rspamd/pull/1876).