### PR TITLE
Fixing error with somaxconn

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
             - mysql
 
     redis-mailcow:
+      sysctls:                                                                     
+        - net.core.somaxconn=511
       image: redis:alpine
       volumes:
         - redis-vol-1:/data/


### PR DESCRIPTION
Fixing error -> The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128

Fixes #685 