### PR TITLE
Update rspamd

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
             - clamd
 
     rspamd-mailcow:
-      image: mailcow/rspamd:1.12
+      image: mailcow/rspamd:1.13
       build: ./data/Dockerfiles/rspamd
       stop_grace_period: 30s
       depends_on:


### PR DESCRIPTION
rspamd updated its APT packages last night, so we can now fis https://github.com/vstakhov/rspamd/pull/1898 in Mailcow.