### PR TITLE
Rspamd: increase task timeout

### DIFF
--- a/data/conf/rspamd/override.d/worker-normal.inc
+++ b/data/conf/rspamd/override.d/worker-normal.inc
@@ -1,1 +1,2 @@
 bind_socket = "*:11333";
+task_timeout = 12s;


### PR DESCRIPTION
Since #589, we wait up to 8 seconds for mx_check. Incidentally, the default task timeout is only 8 seconds, so we sometimes run into the latter timeout. This PR increases it. The 4 extra seconds should be plenty as all other modules are much faster than the mx_check.