### PR TITLE
Better Dovecot auth failure logging

### DIFF
--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -3,6 +3,7 @@
 # --------------------------------------------------------------------------
 auth_mechanisms = plain login
 #mail_debug = yes
+auth_verbose=yes
 log_path = syslog
 disable_plaintext_auth = yes
 # Uncomment on NFS share


### PR DESCRIPTION
Log all failed authentication attempts, with the "service auth"
ie allows one to view failed login usernames when postfix authorizes against dovecot.

sample output in the log will be like this
````
auth: Info:(test@domain.com,199.99.99.1,<5Ff/7Htd6QCpAM+Y>): invalid credentials
````

https://wiki2.dovecot.org/Logging
````
auth_verbose=yes enables logging all failed authentication attempts.
`````