### PR TITLE
Add support for LDAP auth.

### DIFF
--- a/data/Dockerfiles/phpfpm/Dockerfile
+++ b/data/Dockerfiles/phpfpm/Dockerfile
@@ -33,6 +33,7 @@ RUN apk add -U --no-cache libxml2-dev \
   imagemagick \
   libtool \
   librsvg \
+  openldap-dev \
   && pear install channel://pear.php.net/Net_IDNA2-0.2.0 \
     channel://pear.php.net/Auth_SASL-1.1.0 \
     Net_IMAP \
@@ -42,7 +43,7 @@ RUN apk add -U --no-cache libxml2-dev \
 	&& docker-php-ext-enable redis apcu memcached imagick \
 	&& pecl clear-cache \
 	&& docker-php-ext-configure intl \
-  && docker-php-ext-install -j 4 intl pdo pdo_mysql xmlrpc gd zip pcntl opcache \
+  && docker-php-ext-install -j 4 intl pdo pdo_mysql xmlrpc gd zip pcntl opcache ldap \
   && docker-php-ext-configure imap --with-imap --with-imap-ssl \
 	&& docker-php-ext-install -j 4 imap \
 	&& apk del --purge autoconf g++ make libxml2-dev icu-dev imap-dev openssl-dev cyrus-sasl-dev pcre-dev libpng-dev libpng-dev libjpeg-turbo-dev libwebp-dev zlib-dev imagemagick-dev \
@@ -55,7 +56,6 @@ RUN apk add -U --no-cache libxml2-dev \
   echo 'opcache.save_comments=1'; \
   echo 'opcache.revalidate_freq=1'; \
 } > /usr/local/etc/php/conf.d/opcache-recommended.ini
-
 
 COPY ./docker-entrypoint.sh /
 

--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -144,9 +144,17 @@ function verify_ssha256($hash, $password) {
 		return false;
 	}
 }
-function check_login($user, $pass) {
+function check_login($user, $pass, $skip_ldap = false) {
 	global $pdo;
 	global $redis;
+	global $ldap_config;
+
+	if(!$skip_ldap && $ldap_config) {
+		$retval = ldap_check_login($user, $pass);
+		if($retval !== false)
+			return $retval;
+	}
+
 	if (!filter_var($user, FILTER_VALIDATE_EMAIL) && !ctype_alnum(str_replace(array('_', '.', '-'), '', $user))) {
 		return false;
 	}

--- a/data/web/inc/functions.ldap.inc.php
+++ b/data/web/inc/functions.ldap.inc.php
@@ -1,0 +1,103 @@
+<?php
+
+function ldap_do_bind() {
+	global $ldap_config;
+	$version         = isset($ldap_config['version']) ? $ldap_config['version'] : 3;
+	$ldap_uri        = $ldap_config['uri'];
+	$base_dn         = $ldap_config['base_dn'];
+	$bind_admin_dn   = isset($ldap_config['bind_admin_dn']) ? $ldap_config['bind_admin_dn'] : null;
+	$bind_admin_pass = isset($ldap_config['bind_admin_pass']) ? $ldap_config['bind_admin_pass'] : null;
+
+	// When OpenLDAP 2.x.x is used, ldap_connect() will always return a resource as it does not actually connect but just
+	// initializes the connecting parameters. The actual connect happens with the next calls to ldap_* funcs, usually with ldap_bind().
+	// See http://php.net/manual/en/function.ldap-connect.php
+	$ldap = ldap_connect($ldap_uri);
+	if( ! $ldap) {
+		error_log("mailcow UI: Cannot connect to LDAP server \"$ldap_uri\"");
+
+		return false;
+	}
+
+	// The following is recommended here http://php.net/manual/en/ref.ldap.php
+	ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, $version);
+	ldap_set_option($ldap, LDAP_OPT_REFERRALS, 0);
+
+	// Admin bind
+	if($bind_admin_dn && $bind_admin_pass) {
+		$bind_rdn = join(',', array($bind_admin_dn, $base_dn));
+		if( ! ldap_bind($ldap, $bind_rdn, $bind_admin_pass)) {
+			error_log("mailcow UI: Cannot bind to LDAP server \"$ldap_uri\" using \"$bind_rdn\"");
+
+			return false;
+		}
+	}
+
+	// Anonymous bind
+	if( ! ldap_bind($ldap)) {
+		error_log("mailcow UI: Cannot bind to LDAP server \"$ldap_uri\"");
+
+		return false;
+	}
+
+	return $ldap;
+}
+
+function ldap_get_user_info($ldap, $user, $attr = array('dn', 'uid', 'mail')) {
+	global $ldap_config;
+	$base_dn = $ldap_config['base_dn'];
+	$filter  = str_replace('%', $user, isset($ldap_config['user_filter']) ? $ldap_config['user_filter'] : '(|(uid=%*)(mail=%*))');
+	$result  = ldap_search($ldap, $base_dn, $filter, $attr);
+	$entries = ldap_get_entries($ldap, $result);
+
+	return isset($entries['count']) && $entries['count'] > 0 ? $entries[0] : null;
+}
+
+function ldap_do_login($ldap, $info, $pass) {
+	return isset($info['dn']) && ldap_bind($ldap, $info['dn'], $pass);
+}
+
+function ldap_sync_db($info, $user, $pass) {
+	global $pdo;
+
+	$mail = array();
+	if(isset($info['mail']['count'])) {
+		for($i = 0; $i < $info['mail']['count']; $i ++) {
+			array_push($mail, $info['mail'][ $i ]);
+		}
+	}
+
+	// Update table "mailbox" using the "mail" attribute
+	$stmt = $pdo->prepare("
+		UPDATE `mailbox` SET password = ? 
+		WHERE `username` IN (".join(',', array_fill(0, count($mail), '?')).")");
+	$stmt->execute(array_merge(array(hash_password($pass)), $mail));
+
+	// Update table "admin"
+	$stmt = $pdo->prepare("UPDATE `admin` SET password = :pass WHERE `username` LIKE :user");
+	$stmt->execute(array(
+		'user' => $user,
+		'pass' => hash_password($pass)
+	));
+}
+
+function ldap_check_login($user, $pass) {
+
+	$ldap = ldap_do_bind();
+	if( ! $ldap) {
+		return false;
+	}
+
+	$info = ldap_get_user_info($ldap, $user);
+	if( ! $info) {
+		return false;
+	}
+
+	if( ! ldap_do_login($ldap, $info, $pass)) {
+		return false;
+	}
+
+	// We are successfully logged in. Update db and pass back to normal login
+	ldap_sync_db($info, $user, $pass);
+
+	return check_login($user, $pass, true);
+}

--- a/data/web/inc/prerequisites.inc.php
+++ b/data/web/inc/prerequisites.inc.php
@@ -62,6 +62,7 @@ if (isset($_GET['lang']) && in_array($_GET['lang'], $AVAILABLE_LANGUAGES)) {
 require_once $_SERVER['DOCUMENT_ROOT'] . '/lang/lang.en.php';
 include $_SERVER['DOCUMENT_ROOT'] . '/lang/lang.'.$_SESSION['mailcow_locale'].'.php';
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.inc.php';
+require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.ldap.inc.php';
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.mailbox.inc.php';
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.customize.inc.php';
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.domain_admin.inc.php';


### PR DESCRIPTION
This will add a minimal LDAP auth support for admin users and mailboxes:

1. Create a LDAP user (inetOrgPerson) having `uid` and to also update mailbox password having one or more `mail` attributes.
1. Create a mailcow (domain) admin (matching `uid`) and/or mailboxes (matching one of `mail`)
2. Configure LDAP in `inc/vars.local.inc.php` as follows:  
```php
<?php
$ldap_config = array(
	'uri' => 'ldap://your-ldap-host',
	'base_dn' => 'dc=mx,dc=example,dc=org',

	// Optional params (see defaults below):
	//'bind_admin_dn' => null,
	//'bind_admin_pass' => 'null,
	//'user_filter' => '(|(uid=%*)(mail=%*))',
);
```
3. Login using mailcow admin username and/or mailbox
4. User is search in LDAP using the specified filters (by default using `uid` and `mail` attributes)
5. LDAP user login is tried using the given password
6. On success, the corresponding passwords are updated in the mailcow db
7. The native login is repeated (now using the updated passwords).