### PR TITLE
[Dockerapi] Auto detect version of docker server

### DIFF
--- a/data/Dockerfiles/dockerapi/server.py
+++ b/data/Dockerfiles/dockerapi/server.py
@@ -7,7 +7,7 @@ import docker
 import signal
 import time
 
-docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock')
+docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock', version='auto')
 app = Flask(__name__)
 api = Api(app)
 


### PR DESCRIPTION
Some older versions of docker need specific version of client api to be able to
communicate. This change allows automatically detect and set version of API to
match server version of API.

Fixes #765