### PR TITLE
Disable broken MariaDB health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,6 @@ services:
       image: mailcow/unbound:1.0
       build: ./data/Dockerfiles/unbound
       command: /usr/sbin/unbound
-      depends_on:
-        mysql-mailcow:
-          condition: service_healthy
       volumes:
         - ./data/conf/unbound/unbound.conf:/etc/unbound/unbound.conf:ro
       restart: always
@@ -20,11 +17,6 @@ services:
     mysql-mailcow:
       image: mariadb:10.2
       command: mysqld --max_allowed_packet=192M --max-connections=1500 --innodb-strict-mode=0 --skip-host-cache --skip-name-resolve --log-warnings=0
-      healthcheck:
-        test: ["CMD", "mysqladmin", "-u$DBUSER", "-p$DBPASS",  "ping", "-h", "localhost"]
-        interval: 5s
-        timeout: 5s
-        retries: 10
       volumes:
         - mysql-vol-1:/var/lib/mysql/
         - ./data/conf/mysql/:/etc/mysql/conf.d/:ro


### PR DESCRIPTION
After a few days of running, my /run partition had filled up with hundreds of megabytes of old pid files from the MariaDB container. To see whether you are affected, run
```
du -h -d 1 /run/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby
```
and check whether one of the folders contains more than 50KB. The long hexadecimal ID corresponds to the one displayed by `docker ps`.

This pull request might fix #784. The underlying issue is not Mailcow's fault: it affected all my MariaDB containers, so it must have been caused by a Docker, MariaDB or kernel update from the past few weeks. Apparently, there is currently something broken in Healthchecks that causes this leakage of pid files.

unbound doesn't need to depend on mysql -- I'm not sure why it even did that, most likely it was a copy-and-paste error. All containers that use mysql depend on it gracefully -- if it's not available, they wait for a few seconds and try again.