### PR TITLE
Fixes dockerapi-mailcow_1 | raise TypeError('port must be an integer')

### DIFF
--- a/data/Dockerfiles/dockerapi/server.py
+++ b/data/Dockerfiles/dockerapi/server.py
@@ -110,7 +110,7 @@ class GracefulKiller:
     self.kill_now = True
 
 def startFlaskAPI():
-  app.run(debug=False, host='0.0.0.0', port='8080', threaded=True)
+  app.run(debug=False, host='0.0.0.0', port=8080, threaded=True)
 
 api.add_resource(containers_get, '/containers/json')
 api.add_resource(container_get, '/containers/<string:container_id>/json')


### PR DESCRIPTION
Fixes dockerapi-mailcow_1 | raise TypeError('port must be an integer')

Containers are now restarting.