### PR TITLE
Included folder mapping for iOS Mail Trash folder

### DIFF
--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -55,6 +55,9 @@ namespace inbox {
   mailbox "Deleted Items" {
     special_use = \Trash
   }
+  mailbox "Rubbish" {
+    special_use = \Trash
+  }
   mailbox "Gelöschte Objekte" {
     special_use = \Trash
   }


### PR DESCRIPTION
Within iOS on EAS accounts, the Trash folder in the mail app appears as "Bin" and expects a mapping for a folder named "Rubbish".

If the Rubbish folder doesn't exist, items cannot be deleted directly via the Mail app without either:

1. Creating the folder via IMAP
2. Having Dovecot manage the mapping like it does for Outlook client(s) similarly with "Deleted Items"