### PR TITLE
Properly wait for MySQL to come up before starting SOGo

### DIFF
--- a/data/Dockerfiles/sogo/bootstrap-sogo.sh
+++ b/data/Dockerfiles/sogo/bootstrap-sogo.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 # Wait for MySQL to warm-up
-while mysqladmin ping --host mysql -u${DBUSER} -p${DBPASS}${DBPASS} --silent; do
+while ! mysqladmin ping --host mysql -u${DBUSER} -p${DBPASS} --silent; do
+  echo "Waiting for database to come up..."
+  sleep 2
+done
 
 # Wait until port becomes free and send sig
 until ! nc -z sogo-mailcow 20000;
@@ -101,5 +104,3 @@ chown sogo:sogo -R /var/lib/sogo/
 chmod 600 /var/lib/sogo/GNUstep/Defaults/sogod.plist
 
 exec gosu sogo /usr/sbin/sogod
-
-done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: mailcow/sogo:1.12
+      image: mailcow/sogo:1.13
       build: ./data/Dockerfiles/sogo
       environment:
         - DBNAME=${DBNAME}


### PR DESCRIPTION
If MySQL was already up (or came up within about 30 seconds) when the SOGo container was started, everything would be fine (supervisord does 10 retries in 3-second intervals). But if MySQL took too long to start up, supervisord would give up on SOGo.

This was broken for a while now. The `mysqladmin ping` check was pretty useless previously -- if MySQL was not up, the script would just exit. Even though a `while` loop was used, it would be executed no more than once. I have now replaced the check with the same one used by the ACME container, which loops until the database comes up.