### PR TITLE
Adds 'do nothing' as default for sub-addressing

### DIFF
--- a/data/conf/rspamd/local.d/multimap.conf
+++ b/data/conf/rspamd/local.d/multimap.conf
@@ -6,8 +6,14 @@ RCPT_MAILCOW_DOMAIN {
 
 RCPT_WANTS_SUBJECT_TAG {
   type = "rcpt";
-  filter = "email:addr"
+  filter = "email:addr";
   map = "redis://RCPT_WANTS_SUBJECT_TAG";
+}
+
+RCPT_WANTS_SUBFOLDER_TAG {
+  type = "rcpt";
+  filter = "email:addr";
+  map = "redis://RCPT_WANTS_SUBFOLDER_TAG";
 }
 
 WHITELISTED_FWD_HOST {

--- a/data/conf/rspamd/lua/rspamd.local.lua
+++ b/data/conf/rspamd/lua/rspamd.local.lua
@@ -30,8 +30,9 @@ rspamd_config:register_symbol({
       end
 
       local wants_subject_tag = task:get_symbol("RCPT_WANTS_SUBJECT_TAG")
+      local wants_subfolder_tag = task:get_symbol("RCPT_WANTS_SUBFOLDER_TAG")
 
-      if wants_subject_tag == 1 then
+      if wants_subject_tag then
         rspamd_logger.infox("user wants subject modified for tagged mail")
         local sbj = task:get_header('Subject')
         new_sbj = '=?UTF-8?B?' .. tostring(util.encode_base64('[' .. tag .. '] ' .. sbj)) .. '?='
@@ -39,7 +40,7 @@ rspamd_config:register_symbol({
           remove_headers = {['Subject'] = 1},
           add_headers = {['Subject'] = new_sbj}
         })
-      elseif wants_subject_tag == 2 then
+      elseif wants_subfolder_tag then
         rspamd_logger.infox("Add X-Moo-Tag header")
         task:set_milter_reply({
           add_headers = {['X-Moo-Tag'] = 'YES'}

--- a/data/conf/rspamd/lua/rspamd.local.lua
+++ b/data/conf/rspamd/lua/rspamd.local.lua
@@ -31,7 +31,7 @@ rspamd_config:register_symbol({
 
       local wants_subject_tag = task:get_symbol("RCPT_WANTS_SUBJECT_TAG")
 
-      if wants_subject_tag then
+      if wants_subject_tag == 1 then
         rspamd_logger.infox("user wants subject modified for tagged mail")
         local sbj = task:get_header('Subject')
         new_sbj = '=?UTF-8?B?' .. tostring(util.encode_base64('[' .. tag .. '] ' .. sbj)) .. '?='
@@ -39,7 +39,7 @@ rspamd_config:register_symbol({
           remove_headers = {['Subject'] = 1},
           add_headers = {['Subject'] = new_sbj}
         })
-      else
+      elseif wants_subject_tag == 2 then
         rspamd_logger.infox("Add X-Moo-Tag header")
         task:set_milter_reply({
           add_headers = {['X-Moo-Tag'] = 'YES'}

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -1287,6 +1287,18 @@ function mailbox($_action, $_type, $_data = null, $attr = null) {
                 return false;
               }
             }
+            else if (isset($_data['tagged_mail_handler']) && $_data['tagged_mail_handler'] == "subfolder") {
+              try {
+                $redis->hSet('RCPT_WANTS_SUBJECT_TAG', $username, 2);
+              }
+              catch (RedisException $e) {
+                $_SESSION['return'] = array(
+                  'type' => 'danger',
+                  'msg' => 'Redis: '.$e
+                );
+                return false;
+              }
+            }
             else {
               try {
                 $redis->hDel('RCPT_WANTS_SUBJECT_TAG', $username);
@@ -2599,11 +2611,15 @@ function mailbox($_action, $_type, $_data = null, $attr = null) {
             $_data = $_SESSION['mailcow_cc_username'];
           }
           try {
-            if ($redis->hGet('RCPT_WANTS_SUBJECT_TAG', $_data)) {
+            $wants_subject_tag = $redis->hGet('RCPT_WANTS_SUBJECT_TAG', $_data);
+            if ($wants_subject_tag == 1) {
               return "subject";
             }
-            else {
+            elseif ($wants_subject_tag == 2) {
               return "subfolder";
+            }
+            else {
+              return "none";
             }
           }
           catch (RedisException $e) {

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -1298,6 +1298,7 @@ function mailbox($_action, $_type, $_data = null, $attr = null) {
             if (isset($_data['tagged_mail_handler']) && $_data['tagged_mail_handler'] == "subject") {
               try {
                 $redis->hSet('RCPT_WANTS_SUBJECT_TAG', $username, 1);
+                $redis->hDel('RCPT_WANTS_SUBFOLDER_TAG', $username);
               }
               catch (RedisException $e) {
                 $_SESSION['return'] = array(
@@ -1309,7 +1310,8 @@ function mailbox($_action, $_type, $_data = null, $attr = null) {
             }
             else if (isset($_data['tagged_mail_handler']) && $_data['tagged_mail_handler'] == "subfolder") {
               try {
-                $redis->hSet('RCPT_WANTS_SUBJECT_TAG', $username, 2);
+                $redis->hSet('RCPT_WANTS_SUBFOLDER_TAG', $username, 1);
+                $redis->hDel('RCPT_WANTS_SUBJECT_TAG', $username);
               }
               catch (RedisException $e) {
                 $_SESSION['return'] = array(
@@ -1322,6 +1324,7 @@ function mailbox($_action, $_type, $_data = null, $attr = null) {
             else {
               try {
                 $redis->hDel('RCPT_WANTS_SUBJECT_TAG', $username);
+                $redis->hDel('RCPT_WANTS_SUBFOLDER_TAG', $username);
               }
               catch (RedisException $e) {
                 $_SESSION['return'] = array(
@@ -2631,11 +2634,10 @@ function mailbox($_action, $_type, $_data = null, $attr = null) {
             $_data = $_SESSION['mailcow_cc_username'];
           }
           try {
-            $wants_subject_tag = $redis->hGet('RCPT_WANTS_SUBJECT_TAG', $_data);
-            if ($wants_subject_tag == 1) {
+            if ($redis->hGet('RCPT_WANTS_SUBJECT_TAG', $_data)) {
               return "subject";
             }
-            elseif ($wants_subject_tag == 2) {
+            elseif ($redis->hGet('RCPT_WANTS_SUBFOLDER_TAG', $_data)) {
               return "subfolder";
             }
             else {

--- a/data/web/lang/lang.de.php
+++ b/data/web/lang/lang.de.php
@@ -577,7 +577,6 @@ $lang['admin']['merged_vars_hint'] = 'Ausgegraute Zeilen wurden aus der Datei <c
 $lang['mailbox']['waiting'] = "Wartend";
 $lang['mailbox']['status'] = "Status";
 $lang['mailbox']['running'] = "In Ausführung";
-<<<<<<< HEAD
 
 $lang['admin']['ui_texts'] = "UI Label und Texte";
 $lang['admin']['help_text'] = "Hilfstext unter Login-Maske (HTML zulässig)";
@@ -654,5 +653,3 @@ $lang['mailbox']['bcc_to_rcpt'] = "Map empfängerabhängig verwenden";
 $lang['mailbox']['add_bcc_entry'] = "BCC-Eintrag hinzufügen";
 $lang['mailbox']['bcc_info'] = "Eine empfängerabhängige Map wird verwendet, wenn die BCC-Map Eintragung auf den Eingang einer E-Mail auf das lokale Ziel reagieren soll. Senderabhängige Maps verfahren nach dem gleichen Prinzip.<br/>
   Das lokale Ziel wird bei Fehlzustellungen an ein BCC-Ziel nicht informiert.";
-=======
->>>>>>> subject_none

--- a/data/web/lang/lang.de.php
+++ b/data/web/lang/lang.de.php
@@ -174,6 +174,7 @@ $lang['user']['misc_delete_profile'] = 'Sonstige Kontoeinstellungen';
 $lang['user']['tag_handling'] = 'Umgang mit getaggten E-Mails steuern';
 $lang['user']['tag_in_subfolder'] = 'In Unterordner';
 $lang['user']['tag_in_subject'] = 'In Betreff';
+$lang['user']['tag_in_none'] = 'Nichts tun';
 $lang['user']['tag_help_explain'] = 'Als Unterordner: Es wird ein Ordner mit dem Namen des Tags unterhalb der Inbox erstellt ("INBOX/Facebook").<br>
 In Betreff: Der Name des Tags wird dem Betreff angefügt, etwa "[Facebook] Meine Neuigkeiten".';
 $lang['user']['tag_help_example'] = 'Beispiel für eine getaggte E-Mail-Adresse: ich<b>+Facebook</b>@example.org';

--- a/data/web/lang/lang.en.php
+++ b/data/web/lang/lang.en.php
@@ -173,6 +173,7 @@ $lang['user']['misc_delete_profile'] = 'Other profile settings';
 $lang['user']['tag_handling'] = 'Set handling for tagged mail';
 $lang['user']['tag_in_subfolder'] = 'In subfolder';
 $lang['user']['tag_in_subject'] = 'In subject';
+$lang['user']['tag_in_none'] = 'Do nothing';
 $lang['user']['tag_help_explain'] = 'In subfolder: a new subfolder named after the tag will be created below INBOX ("INBOX/Facebook").<br>
 In subject: the tags name will be prepended to the mails subject, example: "[Facebook] My News".';
 $lang['user']['tag_help_example'] = 'Example for a tagged email address: me<b>+Facebook</b>@example.org';

--- a/data/web/lang/lang.es.php
+++ b/data/web/lang/lang.es.php
@@ -144,6 +144,7 @@ $lang['user']['misc_delete_profile'] = 'Otras configuraciones de usuario';
 $lang['user']['tag_handling'] = 'Establecer manejo para el correo etiquetado';
 $lang['user']['tag_in_subfolder'] = 'En subcarpeta';
 $lang['user']['tag_in_subject'] = 'En asunto';
+$lang['user']['tag_in_none'] = 'Hacer nada';
 $lang['user']['tag_help_explain'] = 'En subcarpeta: una nueva subcarpeta llamada como la etiqueta será creada debajo de INBOX ("INBOX/Facebook").<br>
 En asunto: los nombres de las etiquetas serán añadidos al asunto de los correos, ejemplo: "[Facebook] Mis Noticias".';
 $lang['user']['tag_help_example'] = 'Ejemplo de una dirección email etiquetada: mi<b>+Facebook</b>@ejemplo.org';

--- a/data/web/lang/lang.fr.php
+++ b/data/web/lang/lang.fr.php
@@ -167,6 +167,7 @@ $lang['user']['misc_delete_profile'] = "Autre paramètres de profil";
 $lang['user']['tag_handling'] = "Définir la gestion des courriel étiquetés";
 $lang['user']['tag_in_subfolder'] = "Dans un sous-dossier";
 $lang['user']['tag_in_subject'] = "Dans l'objet";
+$lang['user']['tag_in_none'] = "Ne fais rien";
 $lang['user']['tag_help_explain'] = "Dans un sous-dossier : a nouveau sous-dossier portant le nom de l'étiquette sera crée sous INBOX (\"INBOX/Facebook\").<br>Dans l'objet : le nom de l'étiquette sera accolé à l'objet du courriel. Par exemple : \"[Facebook] Mes Nouvelles\".";
 $lang['user']['tag_help_example'] = "Exemple pour une adresse de courriel étiquetée : moi<b>+Facebook</b>@exemple.org";
 $lang['user']['eas_reset'] = "Réinitialiser le cache de l'appareil ActiveSync";

--- a/data/web/lang/lang.it.php
+++ b/data/web/lang/lang.it.php
@@ -167,6 +167,7 @@ $lang['user']['misc_delete_profile'] = 'Impostazioni di altri profili';
 $lang['user']['tag_handling'] = 'Imposta le gestione della mail evidenziate';
 $lang['user']['tag_in_subfolder'] = 'Nella sotto cartella';
 $lang['user']['tag_in_subject'] = 'Nell\'oggetto';
+$lang['user']['tag_in_none'] = "Fare niente";
 $lang['user']['tag_help_explain'] = 'In sotto cartelle: Una nuova cartella dal nome del tag verrà creata sotto INBOX ("INBOX/Facebook").<br />
 Nell\'oggetto: Il nome del tag verrà aggiunto all\'inizio dell\'oggetto mail, esempio: "[Facebook] Meine Neuigkeiten".';
 $lang['user']['tag_help_example'] = 'Esempio di mail con tag: ich<b>+Facebook</b>@example.org';

--- a/data/web/lang/lang.nl.php
+++ b/data/web/lang/lang.nl.php
@@ -140,6 +140,7 @@ $lang['user']['misc_delete_profile'] = 'Andere profielinstellingen';
 $lang['user']['tag_handling'] = 'Omgaan met e-mail tags';
 $lang['user']['tag_in_subfolder'] = 'In onderliggende map';
 $lang['user']['tag_in_subject'] = 'In onderwerp';
+$lang['user']['tag_in_none'] = 'Niets doen';
 $lang['user']['tag_help_explain'] = 'In onderliggende map: maakt onder INBOX een nieuwe map aan met de naam van de tag (bijv.: "INBOX/Facebook").<br>
 In onderwerp: de tag wordt vóór het oorspronkelijke e-mail onderwerp geplaatst (bijv.: "[Facebook] Mijn nieuws").';
 $lang['user']['tag_help_example'] = 'Voorbeeld van een e-mailadres met tag: ik<b>+Facebook</b>@voorbeeld.org';

--- a/data/web/lang/lang.pl.php
+++ b/data/web/lang/lang.pl.php
@@ -169,6 +169,7 @@ $lang['user']['misc_delete_profile'] = 'Ustawienia innego profilu';
 $lang['user']['tag_handling'] = 'Ustaw obsługę znaczników pocztowych';
 $lang['user']['tag_in_subfolder'] = 'W podfolderze';
 $lang['user']['tag_in_subject'] = 'W temacie';
+$lang['user']['tag_in_none'] = 'Nic nie robić';
 $lang['user']['tag_help_explain'] = 'W podfolderze: tworzy nowy podfolder z nazwą taką jak etykieta, który zostanie umieszczony pod Skrzynką odbiorczą ("Skrzynka odbiorcza/Facebook").<br>
 W temacie: nazwy etykiet zostaną dodane na początku tematów wiadomości, np.: "[Facebook] Moje wiadomości".';
 $lang['user']['tag_help_example'] = 'Przykład adresu email z etykietą: ja<b>+Facebook</b>@example.org';

--- a/data/web/lang/lang.ru.php
+++ b/data/web/lang/lang.ru.php
@@ -167,6 +167,7 @@ $lang['user']['misc_delete_profile'] = 'Другие настройки проф
 $lang['user']['tag_handling'] = 'Set handling for tagged mail';
 $lang['user']['tag_in_subfolder'] = 'В подпапку';
 $lang['user']['tag_in_subject'] = 'В теме';
+$lang['user']['tag_in_none'] = 'Ничего не делать';
 $lang['user']['tag_help_explain'] = 'In subfolder: a new subfolder named after the tag will be created below INBOX ("INBOX/Facebook").<br>
 In subject: the tags name will be prepended to the mails subject, example: "[Facebook] Meine Neuigkeiten".';
 $lang['user']['tag_help_example'] = 'Example for a tagged email address: ich<b>+Facebook</b>@example.org';

--- a/data/web/user.php
+++ b/data/web/user.php
@@ -171,6 +171,13 @@ elseif (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == '
         data-api-url='edit/delimiter_action'
         data-api-attr='{"tagged_mail_handler":"subject"}'><?=$lang['user']['tag_in_subject'];?></button>
 
+      <button type="button" class="btn btn-sm btn-default <?=($get_tagging_options == "none") ? 'active' : null; ?>"
+        id="edit_selected"
+        data-item="<?= $username; ?>"
+        data-id="delimiter_action"
+        data-api-url='edit/delimiter_action'
+        data-api-attr='{"tagged_mail_handler":"none"}'><?=$lang['user']['tag_in_none'];?></button>
+
     </div>
     <p class="help-block"><?=$lang['user']['tag_help_explain'];?></p>
     <p class="help-block"><?=$lang['user']['tag_help_example'];?></p>


### PR DESCRIPTION
You can still change your sub-addressing configuration on the user.php in the mailcow backend.
There are three options now: subject, subfolder and none.

Subject adds the tag in [] to the subject, as before.
Subfolder moves the mail in a Subfolder with the Tag as name, as before.
None does nothing of the above and just puts that mail in your inbox. You can see the tag in the To field of the mail.