### PR TITLE
Reload webpage after container restart

### DIFF
--- a/data/web/inc/footer.inc.php
+++ b/data/web/inc/footer.inc.php
@@ -186,6 +186,7 @@ $(document).ready(function() {
       $(this).prop("disabled",true);
       $(this).html('<span class="glyphicon glyphicon-refresh glyphicon-spin"></span> ');
       $('#statusTriggerRestartContainer').text('Restarting container, this may take a while... ');
+      $('#statusTriggerRestartContainer2').text('Reloading webpage... ');
       $.ajax({
         method: 'get',
         url: '/inc/ajax/container_ctrl.php',
@@ -200,6 +201,9 @@ $(document).ready(function() {
         success: function(data) {
           $('#statusTriggerRestartContainer').append(data);
           $('#triggerRestartContainer').html('<span class="glyphicon glyphicon-ok"></span> ');
+          $('#statusTriggerRestartContainer2').append(data);
+          $('#triggerRestartContainer').html('<span class="glyphicon glyphicon-ok"></span> ');
+          location.reload();
         }
       });
     });

--- a/data/web/modals/footer.php
+++ b/data/web/modals/footer.php
@@ -196,6 +196,7 @@ if (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == 'admi
       <button class="btn btn-md btn-primary" id="triggerRestartContainer"><?= $lang['footer']['restart_now']; ?></button>
       <br><br>
       <div id="statusTriggerRestartContainer"></div>
+      <div id="statusTriggerRestartContainer2"></div>
     </div>
     </div>
   </div>


### PR DESCRIPTION
Apparently you can't restart 2 containers in a row without first reloading the webpage.
**This fixes that problem by automatically reloading the webpage after every container restart.** 