### PR TITLE
Added custom website title feature

### DIFF
--- a/data/web/admin.php
+++ b/data/web/admin.php
@@ -511,6 +511,10 @@ $tfa_data = get_tfa();
         ?>
         <form class="form" data-id="uitexts" role="form" method="post">
           <div class="form-group">
+            <label for="title_name"><?=$lang['admin']['title_name'];?>:</label>
+            <input type="text" class="form-control" id="title_name" name="title_name" placeholder="mailcow UI" value="<?=$ui_texts['title_name'];?>">
+          </div>
+          <div class="form-group">
             <label for="main_name"><?=$lang['admin']['main_name'];?>:</label>
             <input type="text" class="form-control" id="main_name" name="main_name" placeholder="mailcow UI" value="<?=$ui_texts['main_name'];?>">
           </div>

--- a/data/web/inc/functions.customize.inc.php
+++ b/data/web/inc/functions.customize.inc.php
@@ -98,10 +98,12 @@ function customize($_action, $_item, $_data = null) {
           );
         break;
         case 'ui_texts':
+          $title_name = $_data['title_name'];
           $main_name = $_data['main_name'];
           $apps_name = $_data['apps_name'];
           $help_text = $_data['help_text'];
           try {
+            $redis->set('TITLE_NAME', htmlspecialchars($title_name));
             $redis->set('MAIN_NAME', htmlspecialchars($main_name));
             $redis->set('APPS_NAME', htmlspecialchars($apps_name));
             $redis->set('HELP_TEXT', $help_text);
@@ -178,6 +180,7 @@ function customize($_action, $_item, $_data = null) {
         break;
         case 'ui_texts':
           try {
+            $data['title_name'] = ($title_name = $redis->get('TITLE_NAME')) ? $title_name : 'mailcow UI';
             $data['main_name'] = ($main_name = $redis->get('MAIN_NAME')) ? $main_name : 'mailcow UI';
             $data['apps_name'] = ($apps_name = $redis->get('APPS_NAME')) ? $apps_name : 'mailcow Apps';
             $data['help_text'] = ($help_text = $redis->get('HELP_TEXT')) ? $help_text : false;

--- a/data/web/inc/header.inc.php
+++ b/data/web/inc/header.inc.php
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>mailcow UI</title>
+<title><?=$UI_TEXTS['title_name'];?></title>
 <!--[if lt IE 9]>
   <script src="/js/html5shiv.min.js"></script>
   <script src="/js/respond.min.js"></script>

--- a/data/web/lang/lang.de.php
+++ b/data/web/lang/lang.de.php
@@ -580,6 +580,7 @@ $lang['mailbox']['running'] = "In Ausführung";
 
 $lang['admin']['ui_texts'] = "UI Label und Texte";
 $lang['admin']['help_text'] = "Hilfstext unter Login-Maske (HTML zulässig)";
+$lang['admin']['title_name'] = '"mailcow UI" Webseiten Titel';
 $lang['admin']['main_name'] = '"mailcow UI" Name';
 $lang['admin']['apps_name'] = '"mailcow Apps" Name';
 

--- a/data/web/lang/lang.en.php
+++ b/data/web/lang/lang.en.php
@@ -572,6 +572,7 @@ $lang['admin']['quarantine_exclude_domains'] = "Exclude domains and alias-domain
 
 $lang['admin']['ui_texts'] = "UI labels and texts";
 $lang['admin']['help_text'] = "Override help text below login mask (HTML allowed)";
+$lang['admin']['title_name'] = '"mailcow UI" website title';
 $lang['admin']['main_name'] = '"mailcow UI" name';
 $lang['admin']['apps_name'] = '"mailcow Apps" name';
 


### PR DESCRIPTION
I have added a custom website title box to configure the website title from the Mailcow admin interface.

**Preview:**
![preview](https://user-images.githubusercontent.com/6564899/35113423-a324b5e8-fc81-11e7-8df5-663b8ca29e72.png)

Same as https://github.com/mailcow/mailcow-dockerized/pull/923 but I think it's easier for users to set the webpage title in the admin interface.