### PR TITLE
Index performance fsync never for lmtp  optimized

### DIFF
--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -7,7 +7,7 @@ log_path = syslog
 disable_plaintext_auth = yes
 # Uncomment on NFS share
 #mmap_disable = yes
-#mail_fsync = always
+mail_fsync = never
 #mail_nfs_index = yes
 #mail_nfs_storage = yes
 login_log_format_elements = "user=<%u> method=%m rip=%r lip=%l mpid=%e %c %k"
@@ -244,6 +244,7 @@ protocol imap {
 protocol lmtp {
   mail_plugins = quota sieve acl zlib listescape #mail_crypt
   auth_socket_path = /usr/local/var/run/dovecot/auth-master
+  mail_fsync = optimized
 }
 protocol sieve {
   managesieve_logout_format = bytes=%i/%o


### PR DESCRIPTION
Per https://wiki2.dovecot.org/MailLocation/LocalDisk#preview
lmtp  optimized is enough to save from power loss
works with no issues, tested over gluster mounts cluster
Ideally we should do separate dir for mail index as a setting as standard setup is to put those to SSD mounts to be separated from mail files. Index is also auto recoverable.