### PR TITLE
SOGO & Rspamd interface: adding "expire" header to static files, allowing browser to be able to cache them

### DIFF
--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -7,6 +7,13 @@ map $http_x_forwarded_proto $client_req_scheme {
      https https;
 }
 
+map $sent_http_content_type $expires {
+        default off;
+        text/css 1d;
+        application/javascript 1d;
+        ~image/ 1d;
+}
+
 server {
   listen 80 default_server;
   listen [::]:80 default_server;
@@ -81,6 +88,7 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_redirect off;
+    expires $expires;
   }
 
   location ~* ^/Autodiscover/Autodiscover.xml {
@@ -263,6 +271,7 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_redirect off;
+    expires $expires;
   }
 
   location ~* ^/Autodiscover/Autodiscover.xml {

--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -161,6 +161,7 @@ server {
     proxy_cache_valid 200 1d;
     proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
     #alias /usr/lib/GNUstep/SOGo/WebServerResources/;
+    expires $expires;
     allow all;
   }
 
@@ -171,6 +172,7 @@ server {
     proxy_cache_valid 200 1d;
     proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
     #alias /usr/lib/GNUstep/SOGo/WebServerResources/;
+    expires $expires;
     allow all;
   }
 
@@ -344,6 +346,7 @@ server {
     proxy_cache_valid 200 1d;
     proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
     #alias /usr/lib/GNUstep/SOGo/WebServerResources/;
+    expires $expires;
     allow all;
   }
 
@@ -354,6 +357,7 @@ server {
     proxy_cache_valid 200 1d;
     proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
     #alias /usr/lib/GNUstep/SOGo/WebServerResources/;
+    expires $expires;
     allow all;
   }
 

--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -9,9 +9,11 @@ map $http_x_forwarded_proto $client_req_scheme {
 
 map $sent_http_content_type $expires {
         default off;
+        text/html off;
         text/css 1d;
         application/javascript 1d;
-        ~image/ 1d;
+        application/json off;
+        image/png       1d;
 }
 
 server {


### PR DESCRIPTION
Hi,
I noticed there are no "Expire" headers for static content in Rspamd interface and SOGO.
In Rspamd, This causes RequireJS errors due to static files being loaded late (in case of a slow server or low bandwidth).
Also speeds up SOGO loading on slower links.
I have added a map to nginx allowing static content to be cached by browser.
