### PR TITLE
Fix for large Mailboxes to avoid timeouts 2

### DIFF
--- a/data/Dockerfiles/dovecot/imapsync_cron.pl
+++ b/data/Dockerfiles/dovecot/imapsync_cron.pl
@@ -77,7 +77,7 @@ while ($row = $sth->fetchrow_arrayref()) {
 	"--nofoldersizes",
 	"--skipsize",
 	"--buffersize 8192000",
-	"--skipheader 'X-*",
+	"--skipheader 'X-*'",
 	"--split1 3000",
 	"--split2 3000",
 	"--fastio1",


### PR DESCRIPTION
Missing ' (sorry my editor keeps correcting the '" to " )