### PR TITLE
Enable maildir compression

### DIFF
--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -280,7 +280,11 @@ plugin {
   #mail_crypt_global_private_key = </mail_crypt/ecprivkey.pem
   #mail_crypt_global_public_key = </mail_crypt/ecpubkey.pem
   #mail_crypt_save_version = 2
+  # Enable compression while saving, lz4 Dovecot v2.2.11+
+  zlib_save_level = 9
+  zlib_save = lz4
 }
+
 dict {
   sqlquota = mysql:/usr/local/etc/dovecot/sql/dovecot-dict-sql-quota.conf
   sieve_after = mysql:/usr/local/etc/dovecot/sql/dovecot-dict-sql-sieve_after.conf


### PR DESCRIPTION
Currently the plugin is loaded, but actual compression is not enabled.

https://wiki.dovecot.org/Plugins/Zlib