### PR TITLE
Added dns option for watchdog

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -329,6 +329,8 @@ services:
         - USE_WATCHDOG=${USE_WATCHDOG:-n}
         - WATCHDOG_NOTIFY_EMAIL=${WATCHDOG_NOTIFY_EMAIL}
         - MAILCOW_HOSTNAME=${MAILCOW_HOSTNAME}
+      dns:
+        - ${IPV4_NETWORK:-172.22.1}.254
       networks:
         mailcow-network:
           aliases:


### PR DESCRIPTION
I added the dns option for watchdog because it would query the Google Public DNS if using IPv6 otherwise. I described the problem in #1044 
Because its a fix and I tested it I thought its okay to merge it into master.