### PR TITLE
[Nginx] Reduce config duplication

### DIFF
--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -21,182 +21,6 @@ server {
   charset utf-8;
   override_charset on;
 
-  add_header Strict-Transport-Security "max-age=15768000; includeSubDomains";
-  add_header X-Content-Type-Options nosniff;
-  add_header X-XSS-Protection "1; mode=block";
-  add_header X-Robots-Tag none;
-  add_header X-Download-Options noopen;
-  add_header X-Frame-Options "SAMEORIGIN";
-  add_header X-Permitted-Cross-Domain-Policies none;
-
-  index index.php index.html;
-
-  include /etc/nginx/conf.d/listen_plain.active;
-  include /etc/nginx/conf.d/server_name.active;
-
-  error_log  /var/log/nginx/error.log;
-  access_log /var/log/nginx/access.log;
-  absolute_redirect off;
-  root /web;
-
-  location ~ ^/api/v1/(.*)$ {
-    try_files $uri $uri/ /json_api.php?query=$1;
-  }
-
-  location ^~ /.well-known/acme-challenge/ {
-    allow all;
-    default_type "text/plain";
-  }
-
-  # If behind reverse proxy, forwards the correct IP
-  set_real_ip_from 10.0.0.0/8;
-  set_real_ip_from 172.16.0.0/12;
-  set_real_ip_from 192.168.0.0/16;
-  set_real_ip_from fc00::/7;
-  real_ip_header X-Forwarded-For;
-  real_ip_recursive on;
-
-  rewrite ^/.well-known/caldav$ /SOGo/dav/ permanent;
-  rewrite ^/.well-known/carddav$ /SOGo/dav/ permanent;
-
-  location ^~ /principals {
-        return 301 /SOGo/dav;
-  }
-
-  location ~ \.php$ {
-    try_files $uri =404;
-    fastcgi_split_path_info ^(.+\.php)(/.+)$;
-    fastcgi_pass phpfpm:9000;
-    fastcgi_index index.php;
-    include /etc/nginx/fastcgi_params;
-    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    fastcgi_param PATH_INFO $fastcgi_path_info;
-    fastcgi_param PHP_VALUE "max_execution_time = 1200
-                             max_input_time = 1200
-                             memory_limit = 64M";
-    fastcgi_read_timeout 1200;
-  }
-
-  location /rspamd/ {
-    proxy_pass       http://rspamd:11334/;
-    proxy_set_header Host      $http_host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_redirect off;
-    expires $expires;
-  }
-
-  location ~* ^/Autodiscover/Autodiscover.xml {
-    fastcgi_split_path_info ^(.+\.php)(/.+)$;
-    fastcgi_pass phpfpm:9000;
-    include /etc/nginx/fastcgi_params;
-    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    try_files /autodiscover.php =404;
-  }
-
-  location ~* ^/Autodiscover/Autodiscover.json {
-    fastcgi_split_path_info ^(.+\.php)(/.+)$;
-    fastcgi_pass phpfpm:9000;
-    include /etc/nginx/fastcgi_params;
-    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    try_files /autodiscover-json.php =404;
-  }
-
-  location ~ /(?:m|M)ail/(?:c|C)onfig-v1.1.xml {
-    fastcgi_split_path_info ^(.+\.php)(/.+)$;
-    fastcgi_pass phpfpm:9000;
-    include /etc/nginx/fastcgi_params;
-    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    try_files /autoconfig.php =404;
-  }
-
-  location ^~ /Microsoft-Server-ActiveSync {
-    include /etc/nginx/conf.d/sogo_eas.active;
-    proxy_connect_timeout 1000;
-    proxy_next_upstream timeout error;
-    proxy_send_timeout 1000;
-    proxy_read_timeout 1000;
-    proxy_buffer_size 8k;
-    proxy_buffers 4 32k;
-    proxy_temp_file_write_size 64k;
-    proxy_busy_buffers_size 64k;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
-    proxy_set_header x-webobjects-server-protocol HTTP/1.0;
-    proxy_set_header x-webobjects-remote-host $remote_addr;
-    proxy_set_header x-webobjects-server-name $server_name;
-    proxy_set_header x-webobjects-server-url $client_req_scheme://$http_host;
-    proxy_set_header x-webobjects-server-port $server_port;
-    client_body_buffer_size 128k;
-    client_max_body_size 0;
-  }
-
-  location ^~ /SOGo {
-    include /etc/nginx/conf.d/sogo.active;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
-    proxy_set_header x-webobjects-server-protocol HTTP/1.0;
-    proxy_set_header x-webobjects-remote-host $remote_addr;
-    proxy_set_header x-webobjects-server-name $server_name;
-    proxy_set_header x-webobjects-server-url $client_req_scheme://$http_host;
-    proxy_set_header x-webobjects-server-port $server_port;
-    client_body_buffer_size 128k;
-    client_max_body_size 0;
-    break;
-  }
-
-  location /SOGo.woa/WebServerResources/ {
-    proxy_pass http://sogo:9192/WebServerResources/;
-    proxy_set_header Host $http_host;
-    proxy_cache sogo;
-    proxy_cache_valid 200 1d;
-    proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
-    #alias /usr/lib/GNUstep/SOGo/WebServerResources/;
-    expires $expires;
-    allow all;
-  }
-
-  location /.woa/WebServerResources/ {
-    proxy_pass http://sogo:9192/WebServerResources/;
-    proxy_set_header Host $http_host;
-    proxy_cache sogo;
-    proxy_cache_valid 200 1d;
-    proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
-    #alias /usr/lib/GNUstep/SOGo/WebServerResources/;
-    expires $expires;
-    allow all;
-  }
-
-  location /SOGo/WebServerResources/ {
-    proxy_pass http://sogo:9192/WebServerResources/;
-    proxy_set_header Host $http_host;
-    proxy_cache sogo;
-    proxy_cache_valid 200 1d;
-    proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
-    #alias /usr/lib/GNUstep/SOGo/WebServerResources/;
-    allow all;
-  }
-
-  location (^/SOGo/so/ControlPanel/Products/[^/]*UI/Resources/.*\.(jpg|png|gif|css|js)$) {
-    proxy_pass http://sogo:9192/$1.SOGo/Resources/$2;
-    proxy_set_header Host $http_host;
-    proxy_cache sogo;
-    proxy_cache_valid 200 1d;
-    proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
-    #alias /usr/lib/GNUstep/SOGo/$1.SOGo/Resources/$2;
-  }
-
-  include /etc/nginx/conf.d/site.*.custom;
-}
-
-server {
-  include /etc/nginx/mime.types;
-  charset utf-8;
-  override_charset on;
-
-  ssl on;
   ssl_certificate /etc/ssl/mail/cert.pem;
   ssl_certificate_key /etc/ssl/mail/key.pem;
   ssl_protocols TLSv1.2;
@@ -216,6 +40,7 @@ server {
 
   index index.php index.html;
 
+  include /etc/nginx/conf.d/listen_plain.active;
   include /etc/nginx/conf.d/listen_ssl.active;
   include /etc/nginx/conf.d/server_name.active;
 
@@ -245,7 +70,7 @@ server {
   rewrite ^/.well-known/carddav$ /SOGo/dav/ permanent;
 
   location ^~ /principals {
-	return 301 /SOGo/dav;
+    return 301 /SOGo/dav;
   }
 
   location ~ \.php$ {

--- a/data/conf/nginx/templates/listen_ssl.template
+++ b/data/conf/nginx/templates/listen_ssl.template
@@ -1,2 +1,2 @@
-listen ${HTTPS_PORT} http2;
-listen [::]:${HTTPS_PORT} http2;
+listen ${HTTPS_PORT} ssl http2;
+listen [::]:${HTTPS_PORT} ssl http2;


### PR DESCRIPTION
It does not make sense having a seperate server block for both http
and https.
According to the nginx doc [1], using the same server block for both
should work.

[1] http://nginx.org/en/docs/http/configuring_https_servers.html#single_http_https_server

---

I'm using this configuration right now, and it seems to work fine.