### PR TITLE
BugFix: Outlook 2016 not using EAS

### DIFF
--- a/data/web/autodiscover.php
+++ b/data/web/autodiscover.php
@@ -21,7 +21,7 @@ if (strpos($data, 'autodiscover/outlook/responseschema') !== false) {
     // Office for macOS does not support EAS
     strpos($_SERVER['HTTP_USER_AGENT'], 'Mac') === false &&
     // Outlook 2013 (version 15) or higher
-    preg_match('/(Outlook|Office).+15\./', $_SERVER['HTTP_USER_AGENT'])
+    preg_match('/(Outlook|Office).+1[5-9]\./', $_SERVER['HTTP_USER_AGENT'])
   ) {
     $autodiscover_config['autodiscoverType'] = 'activesync';
   }


### PR DESCRIPTION
Outlook 2016 autoconfig will not be EAS enabled, even though "$autodiscover_config['useEASforOutlook'] = 'yes';

Outlook 2016 gives the HTTP_USER_AGENT string of
```
Microsoft Office/16.0 (Windows NT 10.0; MAPI 16.0.9001; Pro)
```

Limiting the regex to only 15, causes the entire if statement to fail.

For future proofing, this has been set to any version string containing 15,16,17,18,19

This has been tested using the "Test Email AutoConfiguration for Outlook 2016"