### PR TITLE
Reorder navigation items

### DIFF
--- a/data/Dockerfiles/dovecot/imapsync_cron.pl
+++ b/data/Dockerfiles/dovecot/imapsync_cron.pl
@@ -85,7 +85,7 @@ while ($row = $sth->fetchrow_arrayref()) {
 	($exclude eq ""	? () : ("--exclude", $exclude)),
 	($subfolder2 eq "" ? () : ('--subfolder2', $subfolder2)),
 	($maxage eq "0" ? () : ('--maxage', $maxage)),
-  ($maxbytespersecond eq "0" ? () : ('--maxbytespersecond', $maxage)),
+  ($maxbytespersecond eq "0" ? () : ('--maxbytespersecond', $maxbytespersecond)),
 	($delete2duplicates	ne "1" ? () : ('--delete2duplicates')),
 	($delete1	ne "1" ? () : ('--delete')),
   ($delete2 ne "1" ? () : ('--delete2')),

--- a/data/web/autodiscover.php
+++ b/data/web/autodiscover.php
@@ -21,7 +21,7 @@ if (strpos($data, 'autodiscover/outlook/responseschema') !== false) {
     // Office for macOS does not support EAS
     strpos($_SERVER['HTTP_USER_AGENT'], 'Mac') === false &&
     // Outlook 2013 (version 15) or higher
-    preg_match('/(Outlook|Office).+15\./', $_SERVER['HTTP_USER_AGENT'])
+    preg_match('/(Outlook|Office).+1[5-9]\./', $_SERVER['HTTP_USER_AGENT'])
   ) {
     $autodiscover_config['autodiscoverType'] = 'activesync';
   }

--- a/data/web/debug.php
+++ b/data/web/debug.php
@@ -9,14 +9,7 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
 <div class="container">
 
   <ul class="nav nav-tabs" role="tablist">
-    <li class="dropdown active"><a class="dropdown-toggle" data-toggle="dropdown" href="#">Rspamd
-      <span class="caret"></span></a>
-      <ul class="dropdown-menu">
-        <li role="presentation" class="active"><a href="#tab-rspamd-ui" aria-controls="tab-rspamd-ui" role="tab" data-toggle="tab">Rspamd UI</a></li>
-        <li role="presentation"><a href="#tab-rspamd-settings" aria-controls="tab-rspamd-settings" role="tab" data-toggle="tab">Rspamd settings map</a></li>
-      </ul>
-    </li>
-    <li role="presentation"><a href="#tab-containers" aria-controls="tab-containers" role="tab" data-toggle="tab">Containers</a></li>
+    <li role="presentation" class="active"><a href="#tab-containers" aria-controls="tab-containers" role="tab" data-toggle="tab">Containers</a></li>
     <li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="#">Logs
       <span class="caret"></span></a>
       <ul class="dropdown-menu">
@@ -31,67 +24,20 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
         <li role="presentation"><a href="#tab-api-logs" aria-controls="tab-api-logs" role="tab" data-toggle="tab">API</a></li>
       </ul>
     </li>
+    <li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="#">Rspamd
+      <span class="caret"></span></a>
+      <ul class="dropdown-menu">
+        <li role="presentation"><a href="#tab-rspamd-ui" aria-controls="tab-rspamd-ui" role="tab" data-toggle="tab">Rspamd UI</a></li>
+        <li role="presentation"><a href="#tab-rspamd-settings" aria-controls="tab-rspamd-settings" role="tab" data-toggle="tab">Rspamd settings map</a></li>
+      </ul>
+    </li>
   </ul>
 
 	<div class="row">
 		<div class="col-md-12">
       <div class="tab-content" style="padding-top:20px">
 
-        <div role="tabpanel" class="tab-pane active" id="tab-rspamd-ui">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <h3 class="panel-title">Rspamd UI</h3>
-            </div>
-            <div class="panel-body">
-              <div class="row">
-                <div class="col-sm-9">
-                <form class="form-horizontal" autocapitalize="none" data-id="admin" autocorrect="off" role="form" method="post">
-                  <div class="form-group">
-                    <div class="col-sm-offset-3 col-sm-9">
-                      <label>
-                        <a href="/rspamd/" target="_blank"><span class="glyphicon glyphicon-new-window" aria-hidden="true"></span> Rspamd UI</a>
-                      </label>
-                    </div>
-                  </div>
-                  <div class="form-group">
-                    <label class="control-label col-sm-3" for="rspamd_ui_pass"><?=$lang['admin']['password'];?>:</label>
-                    <div class="col-sm-9">
-                    <input type="password" class="form-control" name="rspamd_ui_pass" id="rspamd_ui_pass">
-                    </div>
-                  </div>
-                  <div class="form-group">
-                    <label class="control-label col-sm-3" for="rspamd_ui_pass2"><?=$lang['admin']['password_repeat'];?>:</label>
-                    <div class="col-sm-9">
-                    <input type="password" class="form-control" name="rspamd_ui_pass2" id="rspamd_ui_pass2">
-                    </div>
-                  </div>
-                  <div class="form-group">
-                    <div class="col-sm-offset-3 col-sm-9">
-                      <button type="submit" class="btn btn-default" id="rspamd_ui" name="rspamd_ui" href="#"><span class="glyphicon glyphicon-check"></span> <?=$lang['admin']['save'];?></button>
-                    </div>
-                  </div>
-                </form>
-                </div>
-                <div class="col-sm-3">
-                  <img class="img-responsive" src="/img/rspamd_logo.png" alt="Rspamd UI" />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div role="tabpanel" class="tab-pane" id="tab-rspamd-settings">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <h3 class="panel-title">Rspamd settings map</h3>
-            </div>
-            <div class="panel-body">
-            <textarea autocorrect="off" spellcheck="false" autocapitalize="none" class="form-control" rows="20" id="settings_map" name="settings_map" readonly><?=file_get_contents('http://nginx:8081/settings.php');?></textarea>
-            </div>
-          </div>
-        </div>
-
-        <div role="tabpanel" class="tab-pane" id="tab-containers">
+        <div role="tabpanel" class="tab-pane active" id="tab-containers">
           <div class="panel panel-default">
             <div class="panel-heading">
               <h3 class="panel-title">Container information</h3>
@@ -296,6 +242,60 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
               <div class="table-responsive">
                 <table class="table table-striped table-condensed" id="api_log"></table>
               </div>
+            </div>
+          </div>
+        </div>
+
+        <div role="tabpanel" class="tab-pane" id="tab-rspamd-ui">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h3 class="panel-title">Rspamd UI</h3>
+            </div>
+            <div class="panel-body">
+              <div class="row">
+                <div class="col-sm-9">
+                <form class="form-horizontal" autocapitalize="none" data-id="admin" autocorrect="off" role="form" method="post">
+                  <div class="form-group">
+                    <div class="col-sm-offset-3 col-sm-9">
+                      <label>
+                        <a href="/rspamd/" target="_blank"><span class="glyphicon glyphicon-new-window" aria-hidden="true"></span> Rspamd UI</a>
+                      </label>
+                    </div>
+                  </div>
+                  <div class="form-group">
+                    <label class="control-label col-sm-3" for="rspamd_ui_pass"><?=$lang['admin']['password'];?>:</label>
+                    <div class="col-sm-9">
+                    <input type="password" class="form-control" name="rspamd_ui_pass" id="rspamd_ui_pass">
+                    </div>
+                  </div>
+                  <div class="form-group">
+                    <label class="control-label col-sm-3" for="rspamd_ui_pass2"><?=$lang['admin']['password_repeat'];?>:</label>
+                    <div class="col-sm-9">
+                    <input type="password" class="form-control" name="rspamd_ui_pass2" id="rspamd_ui_pass2">
+                    </div>
+                  </div>
+                  <div class="form-group">
+                    <div class="col-sm-offset-3 col-sm-9">
+                      <button type="submit" class="btn btn-default" id="rspamd_ui" name="rspamd_ui" href="#"><span class="glyphicon glyphicon-check"></span> <?=$lang['admin']['save'];?></button>
+                    </div>
+                  </div>
+                </form>
+                </div>
+                <div class="col-sm-3">
+                  <img class="img-responsive" src="/img/rspamd_logo.png" alt="Rspamd UI" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div role="tabpanel" class="tab-pane" id="tab-rspamd-settings">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h3 class="panel-title">Rspamd settings map</h3>
+            </div>
+            <div class="panel-body">
+            <textarea autocorrect="off" spellcheck="false" autocapitalize="none" class="form-control" rows="20" id="settings_map" name="settings_map" readonly><?=file_get_contents('http://nginx:8081/settings.php');?></textarea>
             </div>
           </div>
         </div>

--- a/data/web/inc/header.inc.php
+++ b/data/web/inc/header.inc.php
@@ -74,8 +74,8 @@
             if (isset($_SESSION['mailcow_cc_role'])) {
               if ($_SESSION['mailcow_cc_role'] == 'admin') {
               ?>
-                <li<?= (preg_match("/debug/i", $_SERVER['REQUEST_URI'])) ? ' class="active"' : ''; ?>><a href="/debug.php"><?= $lang['header']['debug']; ?></a></li>
                 <li<?= (preg_match("/admin/i", $_SERVER['REQUEST_URI'])) ? ' class="active"' : ''; ?>><a href="/admin.php"><?= $lang['header']['administration']; ?></a></li>
+                <li<?= (preg_match("/debug/i", $_SERVER['REQUEST_URI'])) ? ' class="active"' : ''; ?>><a href="/debug.php"><?= $lang['header']['debug']; ?></a></li>
               <?php
               }
               if ($_SESSION['mailcow_cc_role'] == 'admin' || $_SESSION['mailcow_cc_role'] == 'domainadmin') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -329,6 +329,8 @@ services:
         - USE_WATCHDOG=${USE_WATCHDOG:-n}
         - WATCHDOG_NOTIFY_EMAIL=${WATCHDOG_NOTIFY_EMAIL}
         - MAILCOW_HOSTNAME=${MAILCOW_HOSTNAME}
+      dns:
+        - ${IPV4_NETWORK:-172.22.1}.254
       networks:
         mailcow-network:
           aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,7 +149,7 @@ services:
             - sogo
 
     dovecot-mailcow:
-      image: mailcow/dovecot:1.20
+      image: mailcow/dovecot:1.21
       build: ./data/Dockerfiles/dovecot
       cap_add:
         - NET_BIND_SERVICE


### PR DESCRIPTION
This PR reorders the navigation items for the configuration dropdown and the debugging tabs for the following reasons:
* The default page for admins is "Administration", therefore it should be the first item in the configuration dropdown
* It makes more sense to show the container overview in the debug page by default