### PR TITLE
Add perl dependency for Postfix‘s qshape

### DIFF
--- a/data/Dockerfiles/postfix/Dockerfile
+++ b/data/Dockerfiles/postfix/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	dirmngr \
 	gnupg \
 	libsasl2-modules \
+	perl \
 	postfix \
 	postfix-mysql \
 	postfix-pcre \


### PR DESCRIPTION
Added dependency to Perl package as the package is only recommended but needed by postfix qshape and possibly also other tools.

Fixes #1123