### PR TITLE
[Web] remove encoding for resource data attribute to fix deletion

### DIFF
--- a/data/web/js/mailbox.js
+++ b/data/web/js/mailbox.js
@@ -310,7 +310,7 @@ jQuery(function($){
           $.each(data, function (i, item) {
             item.action = '<div class="btn-group">' +
               '<a href="/edit.php?resource=' + encodeURIComponent(item.name) + '" class="btn btn-xs btn-default"><span class="glyphicon glyphicon-pencil"></span> ' + lang.edit + '</a>' +
-              '<a href="#" id="delete_selected" data-id="single-resource" data-api-url="delete/resource" data-item="' + encodeURIComponent(item.name) + '" class="btn btn-xs btn-danger"><span class="glyphicon glyphicon-trash"></span> ' + lang.remove + '</a>' +
+              '<a href="#" id="delete_selected" data-id="single-resource" data-api-url="delete/resource" data-item="' + item.name + '" class="btn btn-xs btn-danger"><span class="glyphicon glyphicon-trash"></span> ' + lang.remove + '</a>' +
               '</div>';
             item.chkbox = '<input type="checkbox" data-id="resource" name="multi_select" value="' + encodeURIComponent(item.name) + '" />';
             item.name = escapeHtml(item.name);


### PR DESCRIPTION
When creating a resource in the web administrating interface users can't delete it afterward.
This is related to the data-item attribute which encodes the item name.

`test@domain.com` is encoded in `test%40domain.com` and send in the ajax request to the server which can not handle it.

I tested the solution at my own server and it worked successfully!

I'm not shure if this would be the best solution but it is the easiest one.

Greetings,
droidsheep