### PR TITLE
enable smtpd_tls_received_header

### DIFF
--- a/data/conf/postfix/main.cf
+++ b/data/conf/postfix/main.cf
@@ -3,6 +3,7 @@ append_dot_mydomain = no
 smtpd_tls_cert_file = /etc/ssl/mail/cert.pem
 smtpd_tls_key_file = /etc/ssl/mail/key.pem
 smtpd_use_tls=yes
+smtpd_tls_received_header = yes
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination


### PR DESCRIPTION
see: http://www.postfix.org/postconf.5.html#smtpd_tls_received_header

> Request that the Postfix SMTP server produces Received: message headers that include information about the protocol and cipher used, as well as the remote SMTP client CommonName and client certificate issuer CommonName. 

bevor:

```
Received: from example.com (example.com [192.168.1.1])
```

after:

```
Received: from example.com (example.com [192.168.1.1])
	(using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
```

Find this a useful option. Gmail has this also enabled. I don't see any disadvantages. Could also be useful for debugging purposes.