### PR TITLE
Support custom server blocks

### DIFF
--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -212,3 +212,5 @@ server {
 
   include /etc/nginx/conf.d/site.*.custom;
 }
+
+include /etc/nginx/conf.d/server*.*.custom;


### PR DESCRIPTION
Allows adding files in the `/data/conf/nginx/` folder, with names
`server.FOO.custom`. Each of thse should contain a full `server` block.

Fixes #1227.