### PR TITLE
rspamd: Fix NO_LOG_STAT for everycloud monitoring

### DIFF
--- a/data/conf/rspamd/lua/rspamd.local.lua
+++ b/data/conf/rspamd/lua/rspamd.local.lua
@@ -118,7 +118,7 @@ rspamd_config:register_symbol({
   type = 'postfilter',
   callback = function(task)
     local from = task:get_header('From')
-    if from and (from == 'monitoring-system@everycloudtech.us' or from == 'watchdog@localhost') then
+    if from and (string.find(from, 'monitoring-system@everycloudtech.us', 1, true) or from == 'watchdog@localhost') then
       task:set_flag('no_log')
       task:set_flag('no_stat')
     end


### PR DESCRIPTION
They recently added a name to their `From` header: `Everycloud Mail Flow Monitor <monitoring-system@everycloudtech.us>`.