### PR TITLE
Optimize updating of docker-compose

### DIFF
--- a/data/conf/rspamd/lua/rspamd.local.lua
+++ b/data/conf/rspamd/lua/rspamd.local.lua
@@ -118,7 +118,7 @@ rspamd_config:register_symbol({
   type = 'postfilter',
   callback = function(task)
     local from = task:get_header('From')
-    if from and (from == 'monitoring-system@everycloudtech.us' or from == 'watchdog@localhost') then
+    if from and (string.find(from, 'monitoring-system@everycloudtech.us', 1, true) or from == 'watchdog@localhost') then
       task:set_flag('no_log')
       task:set_flag('no_stat')
     end

--- a/data/web/inc/ajax/relay_check.php
+++ b/data/web/inc/ajax/relay_check.php
@@ -23,7 +23,7 @@ if (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == "admi
     $password = $relayhost_details['password'];
 
     $mail = new PHPMailer;
-
+    $mail->Timeout = 10;
     $mail->SMTPDebug = 3;
     $mail->Debugoutput = function($str, $level) {
       foreach(preg_split("/((\r?\n)|(\r\n?)|\n)/", $str) as $line){
@@ -57,8 +57,8 @@ if (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == "admi
       $mail->SMTPAuth = true;
       $mail->Username = $username;
       $mail->Password = $password;
-      $mail->Port = $port;
     }
+    $mail->Port = $port;
     $mail->setFrom($mail_from, 'Mailer');
     $mail->Subject = 'A subject for a SMTP test';
     $mail->addAddress($RELAY_TO, 'Joe Null');

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -1461,7 +1461,7 @@ function mailbox($_action, $_type, $_data = null, $attr = null) {
               $subfolder2 = (isset($_data['subfolder2'])) ? $_data['subfolder2'] : $is_now['subfolder2'];
               $enc1 = (!empty($_data['enc1'])) ? $_data['enc1'] : $is_now['enc1'];
               $mins_interval = (!empty($_data['mins_interval'])) ? $_data['mins_interval'] : $is_now['mins_interval'];
-              $exclude = (!empty($_data['exclude'])) ? $_data['exclude'] : $is_now['exclude'];
+              $exclude = (isset($_data['exclude'])) ? $_data['exclude'] : $is_now['exclude'];
               $maxage = (isset($_data['maxage']) && $_data['maxage'] != "") ? intval($_data['maxage']) : $is_now['maxage'];
               $maxbytespersecond = (isset($_data['maxbytespersecond']) && $_data['maxbytespersecond'] != "") ? intval($_data['maxbytespersecond']) : $is_now['maxbytespersecond'];
             }

--- a/data/web/js/mailbox.js
+++ b/data/web/js/mailbox.js
@@ -310,7 +310,7 @@ jQuery(function($){
           $.each(data, function (i, item) {
             item.action = '<div class="btn-group">' +
               '<a href="/edit.php?resource=' + encodeURIComponent(item.name) + '" class="btn btn-xs btn-default"><span class="glyphicon glyphicon-pencil"></span> ' + lang.edit + '</a>' +
-              '<a href="#" id="delete_selected" data-id="single-resource" data-api-url="delete/resource" data-item="' + encodeURIComponent(item.name) + '" class="btn btn-xs btn-danger"><span class="glyphicon glyphicon-trash"></span> ' + lang.remove + '</a>' +
+              '<a href="#" id="delete_selected" data-id="single-resource" data-api-url="delete/resource" data-item="' + item.name + '" class="btn btn-xs btn-danger"><span class="glyphicon glyphicon-trash"></span> ' + lang.remove + '</a>' +
               '</div>';
             item.chkbox = '<input type="checkbox" data-id="resource" name="multi_select" value="' + encodeURIComponent(item.name) + '" />';
             item.name = escapeHtml(item.name);

--- a/helper-scripts/mailcow-reset-admin.sh
+++ b/helper-scripts/mailcow-reset-admin.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 [[ -f mailcow.conf ]] && source mailcow.conf
 [[ -f ../mailcow.conf ]] && source ../mailcow.conf
 

--- a/update.sh
+++ b/update.sh
@@ -195,8 +195,12 @@ elif [[ $(curl -sL -w "%{http_code}" https://www.servercow.de/docker-compose/lat
   LATEST_COMPOSE=$(curl -#L https://www.servercow.de/docker-compose/latest.php)
   COMPOSE_VERSION=$(docker-compose version --short)
   if [[ "$LATEST_COMPOSE" != "$COMPOSE_VERSION" ]]; then
-    curl -#L https://github.com/docker/compose/releases/download/${LATEST_COMPOSE}/docker-compose-$(uname -s)-$(uname -m) > $(which docker-compose)
-    chmod +x $(which docker-compose)
+    if [[ -w $(which docker-compose) ]]; then
+      curl -#L https://github.com/docker/compose/releases/download/${LATEST_COMPOSE}/docker-compose-$(uname -s)-$(uname -m) > $(which docker-compose)
+      chmod +x $(which docker-compose)
+    else
+      echo -e "\e[33mWARNING: $(which docker-compose) is not writable, but new version $LATEST_COMPOSE is available (installed: $COMPOSE_VERSION)\e[0m"
+    fi
   fi
 
 else

--- a/update.sh
+++ b/update.sh
@@ -193,8 +193,12 @@ if [[ ! -z $(which pip) && $(pip list --local | grep -c docker-compose) == 1 ]];
   #prevent breaking a working docker-compose installed with pip
 elif [[ $(curl -sL -w "%{http_code}" https://www.servercow.de/docker-compose/latest.php -o /dev/null) == "200" ]]; then
   LATEST_COMPOSE=$(curl -#L https://www.servercow.de/docker-compose/latest.php)
-  curl -#L https://github.com/docker/compose/releases/download/${LATEST_COMPOSE}/docker-compose-$(uname -s)-$(uname -m) > $(which docker-compose)
-  chmod +x $(which docker-compose)
+  COMPOSE_VERSION=$(docker-compose version --short)
+  if [[ "$LATEST_COMPOSE" != "$COMPOSE_VERSION" ]]; then
+    curl -#L https://github.com/docker/compose/releases/download/${LATEST_COMPOSE}/docker-compose-$(uname -s)-$(uname -m) > $(which docker-compose)
+    chmod +x $(which docker-compose)
+  fi
+
 else
   echo -e "\e[33mCannot determine latest docker-compose version, skipping...\e[0m"
 fi


### PR DESCRIPTION
This pull request aims to prevent a download of docker-compose if the latest version is the same we have already installed.

While most servers connection should be fast enough to download docker-compose without any issues, I'm having some problems with the approach of first stopping the containers, then downloading docker-compose before restarting the containers. The approach itself is reasonable, considering the compose file might introduce changes requiring a recent docker-compose version, however waiting some minutes (assuming a bad connection) before restarting the containers bugs me. While it should be possible to download docker-compose before stopping the containers (assuming no change in docker-compose breaks `docker-compose down`, obviously) this propose leads to less wasted bandwith and was quite easy to implement.

Feel free to share your thoughts if you think this is a bad idea :)
