### PR TITLE
Fix initial compose project name

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -93,7 +93,7 @@ SQL_PORT=127.0.0.1:13306
 TZ=${TZ}
 
 # Fixed project name
-COMPOSE_PROJECT_NAME=mailcow-dockerized
+COMPOSE_PROJECT_NAME=mailcowdockerized
 
 # Additional SAN for the certificate
 ADDITIONAL_SAN=

--- a/update.sh
+++ b/update.sh
@@ -70,7 +70,7 @@ for option in ${CONFIG_ARRAY[@]}; do
   elif [[ ${option} == "COMPOSE_PROJECT_NAME" ]]; then
     if ! grep -q ${option} mailcow.conf; then
       echo "Adding new option \"${option}\" to mailcow.conf"
-      echo "COMPOSE_PROJECT_NAME=mailcow-dockerized" >> mailcow.conf
+      echo "COMPOSE_PROJECT_NAME=mailcowdockerized" >> mailcow.conf
     fi
   elif [[ ${option} == "DOVEADM_PORT" ]]; then
     if ! grep -q ${option} mailcow.conf; then


### PR DESCRIPTION
According to commit https://github.com/mailcow/mailcow-dockerized/commit/152ccba1d4a5d107019ca73ec11cc6155d8238cf, the initial compose project name should also be fixed