### PR TITLE
[JSON API] fix silent json_encode() error

### DIFF
--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -150,7 +150,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
       break;
       case "get":
         function process_get_return($data) {
-          echo (!isset($data) || empty($data)) ? '{}' : json_encode($data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+          echo (!isset($data) || empty($data)) ? '{}' : json_encode($data, JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK | JSON_PRETTY_PRINT);
         }
         switch ($category) {
           case "rspamd":


### PR DESCRIPTION
... when old `INFINITE` value is used at `percent_in_use` attribute

`https://mail.example.net/mailbox.php` was not loading because of an empty response;
`json_encode()` silently returned false because of `[percent_in_use] => INF` --> json_last_error_msg() returns `Inf and NaN cannot be JSON encoded`

```
Array
        (
            [max_new_quota] => 4294967296
            [username] => foobar@example.net
            [is_relayed] => 0
            [name] => Foo Bar
            [active] => &#10004;
            [active_int] => 1
            [domain] => example.net
            [quota] => 0
            [attributes] => Array
                (
                    [force_pw_update] => 0
                    [tls_enforce_in] => 0
                    [tls_enforce_out] => 0
                )

            [quota_used] => 220580689
            [percent_in_use] => INF
            [messages] => 4986
            [spam_aliases] => 0
            [percent_class] => danger
        )
```
