### PR TITLE
[JSON API] fix json_encode() error when old INFINITE value is used

### DIFF
--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -1032,7 +1032,16 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
                     echo '{}';
                   }
                   else {
-                    echo json_encode($data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+                    $json = json_encode($data, JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK | JSON_PRETTY_PRINT);
+
+                    if ($json) {
+                      echo $json;
+                    } else {
+                      echo json_encode(array(
+                        'type' => 'error',
+                        'msg' => json_last_error_msg(
+                      ));
+                    }
                   }
                 }
                 else {


### PR DESCRIPTION
... see also: https://github.com/mailcow/mailcow-dockerized/pull/1356