### PR TITLE
Fix issue where AUTO_INCREMENT != PK in mailbox table

### DIFF
--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -198,10 +198,11 @@ function init_db_schema() {
         ),
         "keys" => array(
           "primary" => array(
-            "" => array("username")
+            "" => array("id")
           ),
           "key" => array(
-            "domain" => array("domain")
+            "domain" => array("domain"),
+            "username" => array("username")
           )
         ),
         "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"


### PR DESCRIPTION
Currently new builds fail because we're trying to use username as a primary key and have id auto incrementing.
I've presumed there should be an index on username considering it's the mailbox table.

Fixes #1363