### PR TITLE
Extract container's last IP address by default

### DIFF
--- a/data/Dockerfiles/watchdog/watchdog.sh
+++ b/data/Dockerfiles/watchdog/watchdog.sh
@@ -70,7 +70,7 @@ get_container_ip() {
     sleep 1
     CONTAINER_ID=$(curl --silent http://dockerapi:8080/containers/json | jq -r ".[] | {name: .Config.Labels[\"com.docker.compose.service\"], id: .Id}" | jq -rc "select( .name | tostring | contains(\"${1}\")) | .id")
     if [[ ! -z ${CONTAINER_ID} ]]; then
-      CONTAINER_IP=$(curl --silent http://dockerapi:8080/containers/${CONTAINER_ID}/json | jq -r '.NetworkSettings.Networks[].IPAddress')
+      CONTAINER_IP=$(curl --silent http://dockerapi:8080/containers/${CONTAINER_ID}/json | jq -r '[.NetworkSettings.Networks[].IPAddress] | last')
     fi
     LOOP_C=$((LOOP_C + 1))
   done


### PR DESCRIPTION
This takes care of the case where multiple IP addresses exist for a container and ensures that get_container_ip only returns one (the last one).

The issue with the existing script occurs when multiple IP addresses exist for a service.  For example, if nginx-mailcow is also on a network with a reverse proxy server.  In this case, the get_container_ip function would return a string with a space separated list of IP addresses.  Check functions calling get_container_ip would be unable to reach their respective services with this non-ip address string and would show these services as failed.