### PR TITLE
Change default client_max_body_size to match php setting

### DIFF
--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -46,6 +46,7 @@ server {
   error_log  /var/log/nginx/error.log;
   access_log /var/log/nginx/access.log;
   absolute_redirect off;
+  client_max_body_size 64m;
   root /web;
 
   location ~ ^/api/v1/(.*)$ {


### PR DESCRIPTION
This change specifically is to cater for file uploads if anybody follows the instructions to install [Roundcube](https://mailcow.github.io/mailcow-dockerized-docs/third_party-roundcube/).
This change will ensure that users are able to upload files beyond the current 1MB limit.

Currently with default values when attempting to upload a file that is larger than 1MB an error is thrown in Roundcube stating `File upload failed.`

Specific locations like SOGo have client_max_body_size set to 0, essentially disabling the checking of client request body size.
Given that not every instance may have Roundcube installed, this change increases the default limit from 1MB to 64MB in all locations that do not explicitly have a client_max_body_size defined.

The reason I went specifically with 64MB is because that appears to be what the php setting is limited to.