### PR TITLE
[rspamd] fix redis multimaps in version 1.7.5

### DIFF
--- a/data/conf/rspamd/local.d/multimap.conf
+++ b/data/conf/rspamd/local.d/multimap.conf
@@ -2,29 +2,34 @@ RCPT_MAILCOW_DOMAIN {
   type = "rcpt";
   filter = "email:domain";
   map = "redis://DOMAIN_MAP";
+  symbols_set = ["RCPT_MAILCOW_DOMAIN"];
 }
 
 RCPT_WANTS_SUBJECT_TAG {
   type = "rcpt";
   filter = "email:addr";
   map = "redis://RCPT_WANTS_SUBJECT_TAG";
+  symbols_set = ["RCPT_WANTS_SUBJECT_TAG"];
 }
 
 RCPT_WANTS_SUBFOLDER_TAG {
   type = "rcpt";
   filter = "email:addr";
   map = "redis://RCPT_WANTS_SUBFOLDER_TAG";
+  symbols_set = ["RCPT_WANTS_SUBFOLDER_TAG"];
 }
 
 WHITELISTED_FWD_HOST {
   type = "ip";
   map = "redis://WHITELISTED_FWD_HOST";
+  symbols_set = ["WHITELISTED_FWD_HOST"];
 }
 
 KEEP_SPAM {
   type = "ip";
   map = "redis://KEEP_SPAM";
   action = "accept";
+  symbols_set = ["KEEP_SPAM"];
 }
 
 LOCAL_BL_ASN {
@@ -33,6 +38,7 @@ LOCAL_BL_ASN {
   map = "$LOCAL_CONFDIR/custom/bad_asn.map";
   score = 5;
   description = "Sender's ASN is on the local blacklist";
+  symbols_set = ["LOCAL_BL_ASN"];
 }
 
 #SPOOFED_SENDER {
@@ -40,4 +46,5 @@ LOCAL_BL_ASN {
 #  filter = "email:domain:tld";
 #  map = "redis://DOMAIN_MAP";
 #  require_symbols = "AUTH_NA | !RCVD_VIA_SMTP_AUTH";
+#  symbols_set = ["SPOOFED_SENDER"];
 #}


### PR DESCRIPTION
Rspamd 1.7.4 and higher (https://github.com/vstakhov/rspamd/commit/92cfb7f3b92813736ff949028366f989b5e5f8b1) changed the behavior of redis multimaps. Whereas previously it would only check whether a key is present and insert the defined symbol if it was, it now inserts the *value of the key* as a symbol.

This change broke the forwarding hosts functionality (instead of inserting a `WHITELISTED_FWD_HOST`, a useless symbol like `gmx` or `gmail` might be inserted) and may have also affected the tagged recipient functionality.

This pull request restores the old behavior by forcing the multimap module to only insert the symbol corresponding to the rule name.