### PR TITLE
dovecot: increase process_limit for imap-login 

### DIFF
--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -214,6 +214,7 @@ service managesieve-login {
 service imap-login {
   service_count = 1
   vsz_limit = 64M
+  process_limit = 500
   user = dovenull
 }
 service pop3-login {


### PR DESCRIPTION
The default `process_limit` of imap-login is 100. Seems to me that's a little bit less. Some mail clients log in very often. Especially mobile devices that are often reconnecting.

Too few process limits leads to login problems:

```syslog
Jun 15 18:43:47 localhost.localdomain 4e62d58591fd[1972]: Jun 15 18:43:47 mail dovecot: master: Warning: service(imap-login): process_limit (100) reached, client connections are being dropped
```

In my own installation I increased the limit. This works without any problems so far. I don't see any disadvantages at first glance.

The question now is: do we want to increase the limit in general?