### PR TITLE
Redact user IP from outgoing mail header

### DIFF
--- a/data/conf/postfix/header_cleanup_outgoing
+++ b/data/conf/postfix/header_cleanup_outgoing
@@ -1,0 +1,6 @@
+/^\s*(Received: from)[^\n]*(.*)/ REPLACE $1 127.0.0.1 (localhost [127.0.0.1])$2
+/^\s*User-Agent/ IGNORE
+/^\s*X-Enigmail/ IGNORE
+/^\s*X-Mailer/ IGNORE
+/^\s*X-Originating-IP/ IGNORE
+/^\s*Mime-Version/ IGNORE

--- a/data/conf/postfix/main.cf
+++ b/data/conf/postfix/main.cf
@@ -127,3 +127,4 @@ smtp_sasl_auth_enable = yes
 smtp_sasl_password_maps = proxy:mysql:/opt/postfix/conf/sql/mysql_sasl_passwd_maps.cf
 smtp_sasl_security_options = 
 smtp_sasl_mechanism_filter = plain, login
+smtp_header_checks = pcre:/opt/postfix/conf/header_cleanup_outgoing


### PR DESCRIPTION
For privacy reasons the IP of the sender should be stripped from outgoing SMTP headers and replaced by localhost. The other ignored headers are to protect the user from leaking additional information from his mail client.