### PR TITLE
Set curve for ecdhe ciphers

### DIFF
--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -25,6 +25,7 @@ server {
   ssl_certificate_key /etc/ssl/mail/key.pem;
   ssl_protocols TLSv1.2;
   ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+  ssl_ecdh_curve secp384r1;
   ssl_prefer_server_ciphers on;
   ssl_session_cache shared:SSL:50m;
   ssl_session_timeout 1d;


### PR DESCRIPTION
Only strong ECDHE ciphers are currently used, so this PR also sets a strong ECDHE curve for key exchange. With this change the https nginx configuration gets highest rating at [CryptCheck](https://tls.imirhil.fr/).