### PR TITLE
Fix infinite loop when parsing update.sh arguments

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -28,6 +28,7 @@ while (($#)); do
       MERGE_STRATEGY=ours
     ;;
   esac
+  shift
 done
 
 [[ ! -f mailcow.conf ]] && { echo "mailcow.conf is missing"; exit 1;}


### PR DESCRIPTION
update.sh would enter an infinite loop when arguments (e.g. --ours, --check). This is due to a missing `shift` statement that has now been added. This fixes #1193.