### PR TITLE
Updates generate_config.sh making it working on macOS

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -24,7 +24,8 @@ if [[ -f mailcow.conf ]]; then
 fi
 
 while [ -z "${MAILCOW_HOSTNAME}" ]; do
-  read -p "Hostname (FQDN): " -ei "mx.example.org" MAILCOW_HOSTNAME
+  read -p "Hostname (FQDN): " -e MAILCOW_HOSTNAME
+  [ -z "${MAILCOW_HOSTNAME}" ] && MAILCOW_HOSTNAME='mx.example.org'
   DOTS=${MAILCOW_HOSTNAME//[^.]};
   if [ ${#DOTS} -lt 2 ]; then
     echo "${MAILCOW_HOSTNAME} is not a FQDN"
@@ -39,9 +40,11 @@ elif  [[ -a /etc/localtime ]]; then
 fi
 
 if [ -z "$TZ" ]; then
-  read -p "Timezone: " -ei "Europe/Berlin" TZ
+  read -p "Timezone: " -e MAILCOW_TZ
+  [ -z "${MAILCOW_TZ}" ] && MAILCOW_TZ='Europe/Berlin'
 else
-  read -p "Timezone: " -ei ${TZ} TZ
+  read -p "Timezone: " -e MAILCOW_TZ
+  [ -z "${MAILCOW_TZ}" ] && MAILCOW_TZ=${TZ}
 fi
 
 [[ ! -f ./data/conf/rspamd/override.d/worker-controller-password.inc ]] && echo '# Placeholder' > ./data/conf/rspamd/override.d/worker-controller-password.inc
@@ -62,8 +65,8 @@ DBNAME=mailcow
 DBUSER=mailcow
 
 # Please use long, random alphanumeric strings (A-Za-z0-9)
-DBPASS=$(</dev/urandom tr -dc A-Za-z0-9 | head -c 28)
-DBROOT=$(</dev/urandom tr -dc A-Za-z0-9 | head -c 28)
+DBPASS=$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 | head -c 28)
+DBROOT=$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 | head -c 28)
 
 # ------------------------------
 # HTTP/S Bindings
@@ -95,7 +98,7 @@ DOVEADM_PORT=127.0.0.1:19991
 SQL_PORT=127.0.0.1:13306
 
 # Your timezone
-TZ=${TZ}
+TZ=${MAILCOW_TZ}
 
 # Fixed project name
 COMPOSE_PROJECT_NAME=mailcowdockerized


### PR DESCRIPTION
This PR is solving issue #1556 by updating the `generate_config.sh` file which wasn't working on macOS.

 * Changes the usage of the `read` command in order to not use the `-i` flag and check the answered value by the user after the `read` command.
 * Adds `LC_ALL=C` in front of the `tr` command to generate `DBPASS` and `DBROOT` variable values
 * Also update variable naming for `TZ` to `MAILCOW_TZ` avoiding collisions

Tested with the script on macOS 10.14 with empty and non empty answer for FQDN and timezone, both working fine.

Closes #1556 