### PR TITLE
Always backup mailcow.conf

### DIFF
--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -53,6 +53,7 @@ function backup() {
   DATE=$(date +"%Y-%m-%d-%H-%M-%S")
   mkdir -p "${BACKUP_LOCATION}/mailcow-${DATE}"
   chmod 755 "${BACKUP_LOCATION}/mailcow-${DATE}"
+  cp "${SCRIPT_DIR}/../mailcow.conf" "${BACKUP_LOCATION}/mailcow-${DATE}"
   while (( "$#" )); do
     case "$1" in
     vmail|all)


### PR DESCRIPTION
Because when restoring from backup, it is essential to use the previous mailcow.conf: https://github.com/mailcow/mailcow-dockerized/issues/1610#issuecomment-408661312