### PR TITLE
[Web] Improve Input Validation (and error messages)

### DIFF
--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -1818,11 +1818,11 @@ function mailbox($_action, $_type, $_data = null, $attr = null) {
                 $backupmx             = (isset($_data['backupmx'])) ? intval($_data['backupmx']) : $is_now['backupmx_int'];
                 $relay_all_recipients = (isset($_data['relay_all_recipients'])) ? intval($_data['relay_all_recipients']) : $is_now['relay_all_recipients_int'];
                 $relayhost            = (isset($_data['relayhost'])) ? intval($_data['relayhost']) : $is_now['relayhost'];
-                $aliases              = (!empty($_data['aliases'])) ? $_data['aliases'] : $is_now['max_num_aliases_for_domain'];
-                $mailboxes            = (!empty($_data['mailboxes'])) ? $_data['mailboxes'] : $is_now['max_num_mboxes_for_domain'];
-                $maxquota             = (!empty($_data['maxquota'])) ? $_data['maxquota'] : ($is_now['max_quota_for_mbox'] / 1048576);
-                $quota                = (!empty($_data['quota'])) ? $_data['quota'] : ($is_now['max_quota_for_domain'] / 1048576);
-                $description          = (!empty($_data['description'])) ? $_data['description'] : $is_now['description'];
+                $aliases              = ($_data['aliases'] != '') ? $_data['aliases'] : $is_now['max_num_aliases_for_domain'];
+                $mailboxes            = ($_data['mailboxes'] != '') ? $_data['mailboxes'] : $is_now['max_num_mboxes_for_domain'];
+                $maxquota             = ($_data['maxquota'] != '') ? $_data['maxquota'] : ($is_now['max_quota_for_mbox'] / 1048576);
+                $quota                = ($_data['quota'] != '') ? $_data['quota'] : ($is_now['max_quota_for_domain'] / 1048576);
+                $description          = ($_data['description'] != '') ? $_data['description'] : $is_now['description'];
                 ($relay_all_recipients == '1') ? $backupmx = '1' : null;
               }
               else {


### PR DESCRIPTION
The previous condition made it impossible to set a value of "**0**" to the numeric inputs. As you can see on the 2nd item on the list below:

> The following values are matched in the `empty` function
> "" (an empty string)
> **0** (0 as an integer)
> **0.0** (0 as a float)
> "**0**" (0 as a string)
> **NULL**
> **FALSE**
> **array()** (an empty array)

___________________________________________
When you enter "0" in the number field and submit, It shows `Changes to domain phoenixpeca.xyz have been saved` but the value hasn't changed, which I believe is a bug. This is a bug because setting the value as zero should result in an error that explains why mailcow retains the old value.
![image](https://user-images.githubusercontent.com/9730242/43397465-8c5bdece-9437-11e8-8d33-458a1c2be12f.png)
![image](https://user-images.githubusercontent.com/9730242/43397416-58dfe0fe-9437-11e8-92be-c61745474791.png)
