### PR TITLE
kitterman.com redirects to TLS by default

### DIFF
--- a/data/web/inc/ajax/dns_diagnostics.php
+++ b/data/web/inc/ajax/dns_diagnostics.php
@@ -74,7 +74,7 @@ if (!isset($autodiscover_config['sieve'])) {
 
 // Init records array
 $spf_link = '<a href="http://www.openspf.org/SPF_Record_Syntax" target="_blank">SPF Record Syntax</a><br />';
-$dmarc_link = '<a href="http://www.kitterman.com/dmarc/assistant.html" target="_blank">DMARC Assistant</a>';
+$dmarc_link = '<a href="https://www.kitterman.com/dmarc/assistant.html" target="_blank">DMARC Assistant</a>';
 
 $records = array();
 if ($_SESSION['mailcow_cc_role'] == "admin") {


### PR DESCRIPTION
kitterman.com redirects to TLS by default so we should follow this

```
curl -I http://www.kitterman.com/dmarc/assistant.html
HTTP/1.1 302 Found
Date: Sun, 05 Aug 2018 02:53:18 GMT
Server: Apache/2.4.34
Location: https://www.kitterman.com/dmarc/assistant.html
Content-Type: text/html; charset=iso-8859-1
```