### PR TITLE
Fixes idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -696,7 +696,7 @@ function is_valid_domain_name($domain_name) {
 	if (empty($domain_name)) {
 		return false;
 	}
-	$domain_name = idn_to_ascii($domain_name);
+	$domain_name = idn_to_ascii($domain_name,0,INTL_IDNA_VARIANT_UTS46);
 	return (preg_match("/^([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*$/i", $domain_name)
 		   && preg_match("/^.{1,253}$/", $domain_name)
 		   && preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*$/", $domain_name));


### PR DESCRIPTION
Fixes: idn_to_ascii(): INTL_IDNA_VARIANT_2003 which is deprecated since 7.2 
See https://secure.php.net/manual/en/function.idn-to-ascii.php