### PR TITLE
Add ability to define if Mailcow is running behind Reverse Proxy 

### DIFF
--- a/data/web/inc/prerequisites.inc.php
+++ b/data/web/inc/prerequisites.inc.php
@@ -74,6 +74,7 @@ set_exception_handler('pdo_exception_handler');
 // TODO: Move function
 function get_remote_ip($anonymize = null) {
   global $ANONYMIZE_IPS;
+  global $PROXY_SERVER;
   if ($anonymize === null) { 
     $anonymize = $ANONYMIZE_IPS;
   }
@@ -81,22 +82,22 @@ function get_remote_ip($anonymize = null) {
     $anonymize = true;
   }
   $remote = '';
-  if ($_SERVER['HTTP_CLIENT_IP']) {
-    $remote = $_SERVER['HTTP_CLIENT_IP'];
-  }
-  elseif ($_SERVER['HTTP_X_FORWARDED_FOR']) {
-    $remote = $_SERVER['HTTP_X_FORWARDED_FOR'];
-  }
-  elseif ($_SERVER['HTTP_X_FORWARDED']) {
-    $remote = $_SERVER['HTTP_X_FORWARDED'];
-  }
-  elseif ($_SERVER['HTTP_FORWARDED_FOR']) {
-    $remote = $_SERVER['HTTP_FORWARDED_FOR'];
-  }
-  elseif ($_SERVER['HTTP_FORWARDED']) {
-    $remote = $_SERVER['HTTP_FORWARDED'];
-  }
-  elseif ($_SERVER['REMOTE_ADDR']) {
+  if ($PROXY_SERVER == true) {
+    if ($_SERVER['HTTP_CLIENT_IP']) {
+      $remote = $_SERVER['HTTP_CLIENT_IP'];
+    }
+    elseif ($_SERVER['HTTP_X_FORWARDED_FOR']) {
+      $remote = $_SERVER['HTTP_X_FORWARDED_FOR'];
+    }
+    elseif ($_SERVER['HTTP_X_FORWARDED']) {
+      $remote = $_SERVER['HTTP_X_FORWARDED'];
+    }
+    elseif ($_SERVER['HTTP_FORWARDED_FOR']) {
+      $remote = $_SERVER['HTTP_FORWARDED_FOR'];
+    }
+    elseif ($_SERVER['HTTP_FORWARDED']) {
+      $remote = $_SERVER['HTTP_FORWARDED'];
+  } else {
     $remote = $_SERVER['REMOTE_ADDR'];
   }
   if (filter_var($remote, FILTER_VALIDATE_IP) === false) {

--- a/data/web/inc/vars.inc.php
+++ b/data/web/inc/vars.inc.php
@@ -122,3 +122,6 @@ $DOCKER_TIMEOUT = 60;
 
 // Anonymize IPs logged via UI
 $ANONYMIZE_IPS = true;
+
+// Reverse Proxy Setting
+$PROXY_SERVER = false;


### PR DESCRIPTION
This Setting defines if Mailcow is running behind a proxy Server. If we don't do this Plugins like IPFuck spoof all those Headers and Mailcow is logging random IP's generated by a Plugin :o 

https://chrome.google.com/webstore/detail/ipfuck/bjgmbpodpcgmnpfjmigcckcjfldcicnd?hl=de