### PR TITLE
Enabling OCSP Stapling

### DIFF
--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -29,6 +29,8 @@ server {
   ssl_session_cache shared:SSL:50m;
   ssl_session_timeout 1d;
   ssl_session_tickets off;
+  ssl_stapling on;
+  ssl_stapling_verify on;
 
   add_header Strict-Transport-Security "max-age=15768000; includeSubDomains";
   add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
This enables OCSP stapling so that nginx already submits the certificate revocation status (good or revoked) to the client. So the client does not need to do it and thus more anonymity.

https://www.digicert.com/ssl-support/nginx-enable-ocsp-stapling-on-server.htm
https://en.wikipedia.org/wiki/OCSP_stapling

