### PR TITLE
disable sieve_max_redirects limit

### DIFF
--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -277,7 +277,7 @@ plugin {
   sieve_pipe_bin_dir = /usr/local/lib/dovecot/sieve
   sieve_global_extensions = +vnd.dovecot.pipe +vnd.dovecot.execute
   sieve_max_script_size = 1M
-  sieve_max_redirects = 30
+  sieve_max_redirects = 0
   sieve_quota_max_scripts = 0
   sieve_quota_max_storage = 0
   listescape_char = "\\"


### PR DESCRIPTION
see:  #1728

I don't think there are any disadvantages.

sieve_quota_max_scripts and sieve_quota_max_storage are also set to 0. Otherwise, an error message or error handling makes sense, otherwise you will not notice that you are exceeding a limit.