### PR TITLE
added additional san check for autoconfig hostname and AUTOCONFIG_MAP…

### DIFF
--- a/data/web/autoconfig.php
+++ b/data/web/autoconfig.php
@@ -8,7 +8,7 @@ $autodiscover_config = array_merge($default_autodiscover_config, $autodiscover_c
 
 error_reporting(0);
 
-if (empty($mailcow_hostname)) {
+if (empty($autoconfig_hostname)) {
   exit();
 }
 
@@ -27,7 +27,7 @@ header('Content-Type: application/xml');
 ?>
 <?= '<?xml version="1.0"?>'; ?>
 <clientConfig version="1.1">
-    <emailProvider id="<?=$mailcow_hostname; ?>">
+    <emailProvider id="<?=$autoconfig_hostname; ?>">
       <domain>%EMAILDOMAIN%</domain>
       <displayName>A mailcow mail server</displayName>
       <displayShortName>mail server</displayShortName>
@@ -85,7 +85,7 @@ if (count($records) == 0 || $records[0]['target'] != '') { ?>
          <authentication>password-cleartext</authentication>
       </outgoingServer>
 
-      <enable visiturl="https://<?=$mailcow_hostname; ?><?php if ($port != 443) echo ':'.$port; ?>/admin.php">
+      <enable visiturl="https://<?=$autoconfig_hostname; ?><?php if ($port != 443) echo ':'.$port; ?>/admin.php">
          <instruction>If you didn't change the password given to you by the administrator or if you didn't change it in a long time, please consider doing that now.</instruction>
          <instruction lang="de">Sollten Sie das Ihnen durch den Administrator vergebene Passwort noch nicht geändert haben, empfehlen wir dies nun zu tun. Auch ein altes Passwort sollte aus Sicherheitsgründen geändert werden.</instruction>
       </enable>
@@ -93,6 +93,6 @@ if (count($records) == 0 || $records[0]['target'] != '') { ?>
     </emailProvider>
 
     <webMail>
-      <loginPage url="https://<?=$mailcow_hostname; ?><?php if ($port != 443) echo ':'.$port; ?>/SOGo/" />
+      <loginPage url="https://<?=$autoconfig_hostname; ?><?php if ($port != 443) echo ':'.$port; ?>/SOGo/" />
     </webMail>
 </clientConfig>

--- a/data/web/inc/vars.inc.php
+++ b/data/web/inc/vars.inc.php
@@ -17,6 +17,34 @@ $database_name = getenv('DBNAME');
 // Other variables
 $mailcow_hostname = getenv('MAILCOW_HOSTNAME');
 
+$autoconfig_hostname = $mailcow_hostname;
+
+$additionalSan = getenv('ADDITIONAL_SAN');
+if ($additionalSan) {
+    $arrSan = explode(',', $additionalSan);
+
+    foreach ($arrSan as $i => $san) {
+        if ($san && $_SERVER['HTTP_HOST'] == $san) {
+            $autoconfig_hostname = $san;
+
+            $mapping = getEnv('AUTOCONFIG_MAPPING');
+            $mappingLines = explode(",", $mapping);
+
+            foreach ($mappingLines as $mappingLine) {
+                if (false !== strstr($mappingLine, '->')) {
+                    list($from, $to) = explode('->', trim($mappingLine));
+                    if ($from == $autoconfig_hostname) {
+                        $autoconfig_hostname = $to;
+                        break;
+                    }
+                }
+            }
+            break;
+        }
+    }
+}
+
+
 // Autodiscover settings
 // ===
 // Auto-detect HTTPS port =>
@@ -40,29 +68,29 @@ $autodiscover_config = array(
   // The autodiscover service will always point to SMTPS and IMAPS (TLS-wrapped services).
   // The autoconfig service will additionally announce the STARTTLS-enabled ports, specified in the "tlsport" variable.
   'imap' => array(
-    'server' => $mailcow_hostname,
+    'server' => $autoconfig_hostname,
     'port' => array_pop(explode(':', getenv('IMAPS_PORT'))),
     'tlsport' => array_pop(explode(':', getenv('IMAP_PORT'))),
   ),
   'pop3' => array(
-    'server' => $mailcow_hostname,
+    'server' => $autoconfig_hostname,
     'port' => array_pop(explode(':', getenv('POPS_PORT'))),
     'tlsport' => array_pop(explode(':', getenv('POP_PORT'))),
   ),
   'smtp' => array(
-    'server' => $mailcow_hostname,
+    'server' => $autoconfig_hostname,
     'port' => array_pop(explode(':', getenv('SMTPS_PORT'))),
     'tlsport' => array_pop(explode(':', getenv('SUBMISSION_PORT'))),
   ),
   'activesync' => array(
-    'url' => 'https://'.$mailcow_hostname.($https_port == 443 ? '' : ':'.$https_port).'/Microsoft-Server-ActiveSync',
+    'url' => 'https://'.$autoconfig_hostname.($https_port == 443 ? '' : ':'.$https_port).'/Microsoft-Server-ActiveSync',
   ),
   'caldav' => array(
-    'server' => $mailcow_hostname,
+    'server' => $autoconfig_hostname,
     'port' => $https_port,
   ),
   'carddav' => array(
-    'server' => $mailcow_hostname,
+    'server' => $autoconfig_hostname,
     'port' => $https_port,
   ),
 );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,8 @@ services:
         - API_KEY=${API_KEY:-invalid}
         - API_ALLOW_FROM=${API_ALLOW_FROM:-invalid}
         - COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-mailcow-dockerized}
+        - ADDITIONAL_SAN=${ADDITIONAL_SAN:-}
+        - AUTOCONFIG_MAPPING=${AUTOCONFIG_MAPPING:-}
       restart: always
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254


### PR DESCRIPTION
Quick and dirty rewrite for domain in autoconfig xml response.

With this change it's possible to define the domain which gets printed in autoconfig xml instead of the mailcow hostname.
If nothing is defined or the domain from $_SERVER['HTTP_HOST'] is not configured in ADDITIONAL_SAN the MAILCOW_HOSTNAME is used (as usual).

When the domain in $_SERVER['HTTP_HOST'] matches any domain in ADDITIONAL_SAN this gets used.

As I use mailcow for some domains with their subdomain "mx" this does not fully work.

For example:
mailcow hostname: example1.com
additional san: mx.example2.com
mail address: test@example2.com

example2.com is a website which runs on a different server.
When I add test@example2.com, thunderbird will try autoconfig.example2.com which points to the mailcow instance. 
With the normal san match it will print "autoconfig.example2.com" in the xml which is not correct.

For that case it's possible to add AUTOCONFIG_MAPPING to the .env file with the value "autoconfig.example2.com->mx.example2.com". This will override the value once more so that the correct domain "mx.example2.com" gets printed.

As the commit message says it's just quick and dirty but works for me with Thunderbird 52.

.env for this example:
```
MAILCOW_HOSTNAME=example1.com
ADDITIONAL_SAN=mx.example1.com,mx.example2.com,autoconfig.example2.com,autodiscover.example2.com,mx.example3.com,autoconfig.example3.com,autodiscover.example3.com
AUTOCONFIG_MAPPING=autoconfig.example2.com->mx.example2.com,autoconfig.example3.com->mx.example3.com
```