### PR TITLE
grep -i "BusyBox"

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -2,11 +2,11 @@
 
 set -o pipefail
 
-if grep --help 2>&1 | grep -q -i "busybox"; then
+if grep --help 2>&1 | grep -i "BusyBox"; then
   echo "BusybBox grep detected, please install gnu grep, \"apk add --no-cache --upgrade grep\""
   exit 1
 fi
-if cp --help 2>&1 | grep -q -i "busybox"; then
+if cp --help 2>&1 | grep -i "BusyBox"; then
   echo "BusybBox cp detected, please install coreutils, \"apk add --no-cache --upgrade coreutils\""
   exit 1
 fi


### PR DESCRIPTION
Hi;
I was testing if mailcow will run on Alpine Linux than during my validation I found this 

grep -i "BusyBox"
because grep -q -i "busybox" return nothing