### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       volumes:
         - mysql-vol-1:/var/lib/mysql/
         - ./data/conf/mysql/:/etc/mysql/conf.d/:ro
+        - mysql-sock:/var/run/mysqld/
       environment:
         - TZ=${TZ}
         - MYSQL_ROOT_PASSWORD=${DBROOT}
@@ -168,6 +169,7 @@ services:
         - vmail-vol-1:/var/vmail
         - crypt-vol-1:/mail_crypt/
         - rspamd-sock:/rspamd-sock
+        - mysql-sock:/var/run/mysqld/:ro
       environment:
         - LOG_LINES=${LOG_LINES:-9999}
         - DBNAME=${DBNAME}
@@ -397,3 +399,4 @@ volumes:
   postfix-vol-1:
   crypt-vol-1:
   rspamd-sock:
+  mysql-sock:


### PR DESCRIPTION
update for latest dovecot mysql db error

after latest update dovecot stopped working

auth-worker(113): Error: mysql(/var/run/mysqld/mysqld.sock): Connect failed to database (mailcow): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2 "No such file or directory") - waiting for 1 seconds before retry

this will add a volume for the socket
