### PR TITLE
google-style wildcard-emails

### DIFF
--- a/data/Dockerfiles/postfix/postfix.sh
+++ b/data/Dockerfiles/postfix/postfix.sh
@@ -14,7 +14,7 @@ newaliases;
 cat <<EOF > /opt/postfix/conf/sql/mysql_relay_recipient_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 query = SELECT DISTINCT
   CASE WHEN '%d' IN (
@@ -32,7 +32,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_tls_enforce_in_policy.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 query = SELECT IF(EXISTS(
   SELECT 'TLS_ACTIVE' FROM alias
@@ -49,7 +49,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_sender_dependent_default_transport_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 query = SELECT GROUP_CONCAT(transport SEPARATOR '') AS transport_maps
   FROM (
@@ -80,7 +80,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_sasl_passwd_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 query = SELECT CONCAT_WS(':', username, password) AS auth_data FROM relayhosts
   WHERE id IN (
@@ -96,7 +96,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_alias_domain_catchall_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 query = SELECT goto FROM alias, alias_domain
   WHERE alias_domain.alias_domain = '%d'
@@ -107,7 +107,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_alias_domain_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 query = SELECT username FROM mailbox, alias_domain
   WHERE alias_domain.alias_domain = '%d'
@@ -119,22 +119,22 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_alias_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
-# original
+# Original
 #query = SELECT goto FROM alias
 #  WHERE address='%s'
 #    AND active='1';
 #google-style email+wildcardnaming@example.org - first character of regex is wildchard / needs to be escaped by \ when +
-#query = SELECT goto FROM alias WHERE address=(SELECT REGEXP_REPLACE('%s','\+[^@]+@','@')) AND active = '1'
+query = SELECT goto FROM alias WHERE address=(SELECT REGEXP_REPLACE('%s','\+[^@]+@','@')) AND active = '1'
 # Minus-style email-wildcard@example.org
-query = SELECT goto FROM alias WHERE address=(SELECT REGEXP_REPLACE('%s','\-[^@]+@','@')) AND active = '1'
+#query = SELECT goto FROM alias WHERE address=(SELECT REGEXP_REPLACE('%s','\-[^@]+@','@')) AND active = '1'
 EOF
 
 cat <<EOF > /opt/postfix/conf/sql/mysql_recipient_bcc_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 query = SELECT bcc_dest FROM bcc_maps
   WHERE local_dest='%s'
@@ -145,7 +145,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_sender_bcc_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 query = SELECT bcc_dest FROM bcc_maps
   WHERE local_dest='%s'
@@ -156,7 +156,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_recipient_canonical_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 query = SELECT new_dest FROM recipient_maps
   WHERE old_dest='%s'
@@ -166,7 +166,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_domains_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 query = SELECT alias_domain from alias_domain WHERE alias_domain='%s' AND active='1'
   UNION
@@ -179,7 +179,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_mailbox_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 query = SELECT maildir FROM mailbox WHERE username='%s' AND active = '1'
 EOF
@@ -187,7 +187,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_relay_domain_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 query = SELECT domain FROM domain WHERE domain='%s' AND backupmx = '1' AND active = '1'
 EOF
@@ -195,7 +195,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_sender_acl.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 # First select queries domain and alias_domain to determine if domains are active.
 query = SELECT goto FROM alias
@@ -236,7 +236,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_spamalias_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = mysql
+hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 query = SELECT goto FROM spamalias
   WHERE address='%s'

--- a/data/Dockerfiles/postfix/postfix.sh
+++ b/data/Dockerfiles/postfix/postfix.sh
@@ -243,17 +243,6 @@ query = SELECT goto FROM spamalias
     AND validity >= UNIX_TIMESTAMP()
 EOF
 
-#cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_email_extension.cf
-#user = ${DBUSER}
-#password = ${DBPASS}
-#hosts = mysql
-#dbname = ${DBNAME}
-#google-style email+wildcardnaming@example.org - first character of regex is wildchard / needs to be escaped by \ when +
-#query = SELECT goto FROM alias WHERE address=(SELECT REGEXP_REPLACE('%s','\+[^@]+@','@')) AND active = '1'
-# Minus--style email-wildcard@example.org
-#query = SELECT goto FROM alias WHERE address=(SELECT REGEXP_REPLACE('%s','\-[^@]+@','@')) AND active = '1'
-#EOF
-
 # Reset GPG key permissions
 mkdir -p /var/lib/zeyple/keys
 chmod 700 /var/lib/zeyple/keys

--- a/data/Dockerfiles/postfix/postfix.sh
+++ b/data/Dockerfiles/postfix/postfix.sh
@@ -14,7 +14,7 @@ newaliases;
 cat <<EOF > /opt/postfix/conf/sql/mysql_relay_recipient_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
 query = SELECT DISTINCT
   CASE WHEN '%d' IN (
@@ -32,7 +32,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_tls_enforce_in_policy.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
 query = SELECT IF(EXISTS(
   SELECT 'TLS_ACTIVE' FROM alias
@@ -49,7 +49,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_sender_dependent_default_transport_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
 query = SELECT GROUP_CONCAT(transport SEPARATOR '') AS transport_maps
   FROM (
@@ -80,7 +80,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_sasl_passwd_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
 query = SELECT CONCAT_WS(':', username, password) AS auth_data FROM relayhosts
   WHERE id IN (
@@ -96,7 +96,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_alias_domain_catchall_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
 query = SELECT goto FROM alias, alias_domain
   WHERE alias_domain.alias_domain = '%d'
@@ -107,7 +107,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_alias_domain_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
 query = SELECT username FROM mailbox, alias_domain
   WHERE alias_domain.alias_domain = '%d'
@@ -119,17 +119,22 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_alias_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
-query = SELECT goto FROM alias
-  WHERE address='%s'
-    AND active='1';
+# original
+#query = SELECT goto FROM alias
+#  WHERE address='%s'
+#    AND active='1';
+#google-style email+wildcardnaming@example.org - first character of regex is wildchard / needs to be escaped by \ when +
+#query = SELECT goto FROM alias WHERE address=(SELECT REGEXP_REPLACE('%s','\+[^@]+@','@')) AND active = '1'
+# Minus-style email-wildcard@example.org
+query = SELECT goto FROM alias WHERE address=(SELECT REGEXP_REPLACE('%s','\-[^@]+@','@')) AND active = '1'
 EOF
 
 cat <<EOF > /opt/postfix/conf/sql/mysql_recipient_bcc_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
 query = SELECT bcc_dest FROM bcc_maps
   WHERE local_dest='%s'
@@ -140,7 +145,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_sender_bcc_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
 query = SELECT bcc_dest FROM bcc_maps
   WHERE local_dest='%s'
@@ -151,7 +156,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_recipient_canonical_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
 query = SELECT new_dest FROM recipient_maps
   WHERE old_dest='%s'
@@ -161,7 +166,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_domains_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
 query = SELECT alias_domain from alias_domain WHERE alias_domain='%s' AND active='1'
   UNION
@@ -174,7 +179,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_mailbox_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
 query = SELECT maildir FROM mailbox WHERE username='%s' AND active = '1'
 EOF
@@ -182,7 +187,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_relay_domain_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
 query = SELECT domain FROM domain WHERE domain='%s' AND backupmx = '1' AND active = '1'
 EOF
@@ -190,7 +195,7 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_sender_acl.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
 # First select queries domain and alias_domain to determine if domains are active.
 query = SELECT goto FROM alias
@@ -231,12 +236,23 @@ EOF
 cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_spamalias_maps.cf
 user = ${DBUSER}
 password = ${DBPASS}
-hosts = unix:/var/run/mysqld/mysqld.sock
+hosts = mysql
 dbname = ${DBNAME}
 query = SELECT goto FROM spamalias
   WHERE address='%s'
     AND validity >= UNIX_TIMESTAMP()
 EOF
+
+#cat <<EOF > /opt/postfix/conf/sql/mysql_virtual_email_extension.cf
+#user = ${DBUSER}
+#password = ${DBPASS}
+#hosts = mysql
+#dbname = ${DBNAME}
+#google-style email+wildcardnaming@example.org - first character of regex is wildchard / needs to be escaped by \ when +
+#query = SELECT goto FROM alias WHERE address=(SELECT REGEXP_REPLACE('%s','\+[^@]+@','@')) AND active = '1'
+# Minus--style email-wildcard@example.org
+#query = SELECT goto FROM alias WHERE address=(SELECT REGEXP_REPLACE('%s','\-[^@]+@','@')) AND active = '1'
+#EOF
 
 # Reset GPG key permissions
 mkdir -p /var/lib/zeyple/keys


### PR DESCRIPTION
This pull-request enables google-style wild-card emails. for example you can use 
`email+shopname@example.org` for one shop and
`email+othershop@example.org` for another shop - and all are going into the same account `email@example.org`.

I'm using this technique about 10 years - and in combination with sieve this generates a big plus on where are my mails stolen from and to shut them finaly without terminating an account.

One flaw is present - the seperator - in this case the '+' is not allowed any longer as a regular part of the username. 

The config has no impact on mails not using the wildcard-symbol.