### PR TITLE
Don't print 'Collecting garbage...' twice

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -12,7 +12,6 @@ DATE=$(date +%Y-%m-%d_%H_%M_%S)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 docker_garbage() {
-  echo -e "\e[32mCollecting garbage...\e[0m"
   IMGS_TO_DELETE=()
   for container in $(grep -oP "image: \Kmailcow.+" docker-compose.yml); do
     REPOSITORY=${container/:*}
@@ -74,6 +73,7 @@ while (($#)); do
       MERGE_STRATEGY=ours
     ;;
     --gc)
+      echo -e "\e[32mCollecting garbage...\e[0m"
       docker_garbage
       exit 0
     ;;


### PR DESCRIPTION
When updating mailcow and it finished it printed 'Collecting garbage..,' twice since in docker_garbage() and before running the code we have the echo command.
Now it's printing the line before running docker_garbage()