### PR TITLE
Add portainer and docker-compose.override.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ data/conf/nginx/*.custom
 data/conf/nginx/*.bak
 data/conf/dovecot/extra.conf
 data/conf/rspamd/custom/*
+data/conf/portainer/
+docker-compose.override.yml


### PR DESCRIPTION
Adding portainer and docker-compose.override.yml removes git merge errors while updating.