### PR TITLE
[NGINX] always redirect to https

### DIFF
--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -17,6 +17,15 @@ map $sent_http_content_type $expires {
 }
 
 server {
+  include /etc/nginx/conf.d/listen_plain.active;
+  include /etc/nginx/conf.d/server_name.active;
+
+  location / {
+    return 301 https://$host$request_uri;
+  }
+}
+
+server {
   include /etc/nginx/mime.types;
   charset utf-8;
   override_charset on;
@@ -41,7 +50,6 @@ server {
 
   client_max_body_size 0;
 
-  include /etc/nginx/conf.d/listen_plain.active;
   include /etc/nginx/conf.d/listen_ssl.active;
   include /etc/nginx/conf.d/server_name.active;
 


### PR DESCRIPTION
The current nginx configuration does not redirect from http to https, even though the HSTS header will ensure the usage of https it is not recommended to send HSTS Headers via http initially.

Therefore we should actively redirect to https using a seperate server block for http.

Letsencrypt does follow the redirect and is working with snakeoil certificates.

Is there any reason for not redirecting to https?

Regards,
D3luxee