### PR TITLE
[Postfix] Security: Prefer server-side ciphers

### DIFF
--- a/data/conf/postfix/main.cf
+++ b/data/conf/postfix/main.cf
@@ -99,6 +99,7 @@ lmtp_tls_protocols = !SSLv2, !SSLv2, !SSLv3
 smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3
 smtpd_tls_protocols = !SSLv2, !SSLv3
 smtpd_tls_security_level = may
+tls_preempt_cipherlist = yes
 tls_ssl_options = NO_COMPRESSION
 smtpd_tls_mandatory_ciphers = high
 virtual_alias_maps = proxy:mysql:/opt/postfix/conf/sql/mysql_virtual_alias_maps.cf,


### PR DESCRIPTION
Prefer server-side ciphers to prevent client-side cipher downgrade. Already enabled in Dovecot.

For more information: http://www.postfix.org/TLS_README.html