### PR TITLE
[translation] Individualisierung von 'mailcow_apps_detail'

### DIFF
--- a/data/web/lang/lang.de.php
+++ b/data/web/lang/lang.de.php
@@ -242,7 +242,7 @@ $lang['user']['edit'] = 'Bearbeiten';
 $lang['user']['remove'] = 'Entfernen';
 $lang['user']['create_syncjob'] = 'Neuen Sync-Job erstellen';
 
-$lang['start']['mailcow_apps_detail'] = 'Verwenden Sie mailcow Apps, um E-Mails abzurufen, Kalender- und Kontakte zu verwalten und vieles mehr.';
+$lang['start']['mailcow_apps_detail'] = 'Verwenden Sie eine dieser Apps, um E-Mails abzurufen, Kalender- und Kontakte zu verwalten und vieles mehr.';
 $lang['start']['mailcow_panel_detail'] = '<b>Domain-Administratoren</b> erstellen, verändern oder löschen Mailboxen, verwalten die Domäne und sehen sonstige Einstellungen ein.<br>
 	Als <b>Mailbox-Benutzer</b> erstellen Sie hier zeitlich limitierte Aliasse, ändern das Verhalten des Spamfilters, setzen ein neues Passwort und vieles mehr.';
 $lang['start']['imap_smtp_server_auth_info'] = 'Bitte verwenden Sie Ihre vollständige E-Mail-Adresse sowie das PLAIN-Authentifizierungsverfahren.<br>


### PR DESCRIPTION
'mailcow Apps' kann mittels $UI_TEXTS['apps_name'] individuell umbenannt werden, wird an dieser Stelle jedoch fix mit ''mailcow Apps' übersetzt. Da $UI_TEXTS aber erst später definiert wird kann es nicht in der Übersetzung genutzt werden, sodass ein generischer Text die einfachste Lösung ist.