### PR TITLE
Outlook-Folder-Alias

### DIFF
--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -75,6 +75,9 @@ namespace inbox {
   mailbox "Gelöschte Objekte" {
     special_use = \Trash
   }
+  mailbox "Gelöschte Elemente" {
+    special_use = \Trash
+  }
   mailbox "Papierkorb" {
     special_use = \Trash
   }
@@ -126,6 +129,9 @@ namespace inbox {
     special_use = \Sent
   }
   mailbox "Gesendete Objekte" {
+    special_use = \Sent
+  }
+  mailbox "Gesendete Elemente" {
     special_use = \Sent
   }
   mailbox "Itens Enviados" {


### PR DESCRIPTION
Neben "Gesendete Objekte" und "Gelöschte Objekte" bin ich auf meiner Mailcow-Instanz auch auf "Gesendete Elemente" und "Gelöschte Elemente" gestoßen. Ich vermute hier Outlook 2010 als Übeltäter.