### PR TITLE
Make the update check in update.sh readonly

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -66,7 +66,7 @@ while (($#)); do
       if [ $? -ne 0 ]; then
         echo "A problem occurred while trying to fetch the latest revision from github."
         exit 99
-	  fi
+      fi
       if [[ -z $(git log HEAD --pretty=format:"%H" | grep "${LATEST_REV}") ]]; then
         echo "Updated code is available."
         exit 0

--- a/update.sh
+++ b/update.sh
@@ -62,8 +62,12 @@ while (($#)); do
   case "${1}" in
     --check|-c)
       echo "Checking remote code for updates..."
-      git fetch origin #${BRANCH}
-      if [[ -z $(git log HEAD --pretty=format:"%H" | grep $(git rev-parse origin/${BRANCH})) ]]; then
+      LATEST_REV=$(git ls-remote --exit-code --refs --quiet https://github.com/mailcow/mailcow-dockerized ${BRANCH} | cut -f1)
+      if [ $? -ne 0 ]; then
+        echo "A problem occurred while trying to fetch the latest revision from github."
+        exit 99
+	  fi
+      if [[ -z $(git log HEAD --pretty=format:"%H" | grep "${LATEST_REV}") ]]; then
         echo "Updated code is available."
         exit 0
       else


### PR DESCRIPTION
Currently, the update check in update.sh (`update.sh --check`) runs `git fetch` to fetch the newest revision from Github before using it to check if there is a newer version of mailcow available.

While this is working, it does need write access to update the working copy. If you want to use that script with an automatic monitoring system like zabbix, you possibly don't want the user executing the script to be able to modify (any) files within mailcow's directory.

This PR replaces `git fetch` followed by `git rev-parse` by `git ls-remote`. This way, only read access is necessary for the script to determine if an update is available.