### PR TITLE
Change name of .mobileconfig file

### DIFF
--- a/data/web/mobileconfig.php
+++ b/data/web/mobileconfig.php
@@ -11,9 +11,6 @@ if (!isset($_SESSION['mailcow_cc_role']) || $_SESSION['mailcow_cc_role'] != 'use
 
 error_reporting(0);
 
-header('Content-Type: application/x-apple-aspen-config');
-header('Content-Disposition: attachment; filename="Mailcow.mobileconfig"');
-
 $email = $_SESSION['mailcow_cc_username'];
 $domain = explode('@', $_SESSION['mailcow_cc_username'])[1];
 $identifier = implode('.', array_reverse(explode('.', $domain))) . '.iphoneprofile.mailcow';
@@ -32,6 +29,9 @@ if (!empty($MailboxData['name'])) {
 else {
   $displayname = $email;
 }
+
+header('Content-Type: application/x-apple-aspen-config');
+header('Content-Disposition: attachment; filename="'.$email.'.mobileconfig"');
 
 echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
 ?>


### PR DESCRIPTION
Sets the filename of the mobileconfig as <mailaddr>.mobileconfig.
So the Admin or Domain admin can login as the user and generate the files for his users.
Useful for very inexperienced users.