### PR TITLE
[web] Duplicating DKIM key corrupts private key

### DIFF
--- a/data/web/inc/functions.dkim.inc.php
+++ b/data/web/inc/functions.dkim.inc.php
@@ -123,7 +123,7 @@ function dkim($_action, $_data = null) {
         try {
           $redis->hSet('DKIM_PUB_KEYS', $to_domain, $from_domain_dkim['pubkey']);
           $redis->hSet('DKIM_SELECTORS', $to_domain, $from_domain_dkim['dkim_selector']);
-          $redis->hSet('DKIM_PRIV_KEYS', $from_domain_dkim['dkim_selector'] . '.' . $to_domain, trim($from_domain_dkim['privkey']));
+          $redis->hSet('DKIM_PRIV_KEYS', $from_domain_dkim['dkim_selector'] . '.' . $to_domain, base64_decode(trim($from_domain_dkim['privkey'])));
         }
         catch (RedisException $e) {
           $_SESSION['return'][] = array(


### PR DESCRIPTION
Missing base64_decode() corrupted private key when duplicating, as `$from_domain_dkim['privkey']` returns the public key base64-encoded.