### PR TITLE
[Web] Add hint to DKIM key import for RSA PKCS#8

### DIFF
--- a/data/web/admin.php
+++ b/data/web/admin.php
@@ -333,7 +333,7 @@ $tfa_data = get_tfa();
             <input class="form-control input-sm" name="dkim_selector" value="dkim" required>
           </div>
           <div class="form-group">
-            <label for="private_key_file"><?=$lang['admin']['private_key'];?>:</label>
+            <label for="private_key_file"><?=$lang['admin']['private_key'];?>: (RSA PKCS#8)</label>
             <textarea class="form-control input-sm" rows="10" name="private_key_file" id="private_key_file" required placeholder="-----BEGIN RSA KEY-----"></textarea>
           </div>
           <button class="btn btn-sm btn-default" data-action="add_item" data-id="dkim_import" data-api-url='add/dkim_import' data-api-attr='{}' href="#"><span class="glyphicon glyphicon-plus"></span> <?=$lang['admin']['import'];?></button>


### PR DESCRIPTION
Adding hint to explicitly provide a RSA Private key in the newer PKCS#8 format, as the webinterface denies the key with a cryptic error message otherwise: `Private key error: error:0EFFF06C:configuration file routines:CRYPTO_internal:no value`. To prevent frustrated users I'd add a simple notice which format is expected. PKCS#8 is also the default format when generating keys directly in the webinterface.

Some interesting resources:
https://stackoverflow.com/questions/20065304/differences-between-begin-rsa-private-key-and-begin-private-key
https://stackoverflow.com/questions/17733536/how-to-convert-a-private-key-to-an-rsa-private-key

This might be relevant/helpful for people generating their keys outside mailcow webinterface, e.g. using standard openssl command on Ubuntu. (or from previous setups, etc)