### PR TITLE
Use Horizontal Table Scrollbar Instead

### DIFF
--- a/data/web/css/mailbox.css
+++ b/data/web/css/mailbox.css
@@ -9,7 +9,7 @@ table.footable>tbody>tr.footable-empty>td {
   overflow: visible !important;
 }
 .table-responsive {
-  overflow: visible !important;
+  overflow: auto !important;
 }
 @media screen and (max-width: 767px) {
   .table-responsive {


### PR DESCRIPTION
I think it's better to have it this way:
![image](https://user-images.githubusercontent.com/9730242/50559039-e51bbb00-0d2d-11e9-8264-fc4e4996ec43.png)

than this:
![image](https://user-images.githubusercontent.com/9730242/50559045-fa90e500-0d2d-11e9-8b43-e3d522801828.png)