### PR TITLE
increase values for spf, dkim

### DIFF
--- a/data/conf/rspamd/local.d/policies_group.conf
+++ b/data/conf/rspamd/local.d/policies_group.conf
@@ -3,15 +3,15 @@ symbols = {
         score = 0.0;
     }
     "R_SPF_FAIL" {
-        score = 7.0;
+        score = 10.0;
     }
     "R_SPF_PERMFAIL" {
-        score = 7.0;
+        score = 10.0;
     }
     "R_DKIM_REJECT" {
-        score = 7.0;
+        score = 10.0;
     }
     "R_DKIM_PERMFAIL" {
-        score = 7.0;
+        score = 10.0;
     }
 }


### PR DESCRIPTION
The default value for move an e-mail to spam is now at 8 points. (commit: https://github.com/mailcow/mailcow-dockerized/commit/94d79528022cd15908742ca806a031c18a96fa37)
Today I had an email with an invalid dkim key, but the email was not in the spam directory.
I think if an email violates dkim or spf, the email should definitely be moved to the Spam folder.

Or is there a reason why these emails are not moved to the spam directory?