### PR TITLE
[Suggestion] Allow the Docker host to access the containerised unbound DNS server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
         - ./data/conf/unbound/unbound.conf:/etc/unbound/unbound.conf:ro
       restart: always
       tty: true
+      ports:
+        - "127.0.0.1:53:53/udp"
       networks:
         mailcow-network:
           ipv4_address: ${IPV4_NETWORK:-172.22.1}.254


### PR DESCRIPTION
I have had an issue on my Scaleway server where I have been able to use canonical-livepatch because of persistent DNS lookup failure. Livepatch is also containerised but within the snapcraft framework as opposed to Docker's containerisation.

I'm not sure if there is a conflict between the two containerisation technologies, but somehow enabling a DNS server to be accessed at 127.0.0.1 has fixed this strange faulty behaviour.

I'm confident this isn't of course a bug in mailcow, but it may be in Docker and the way it sets up it's network and IPTables etc. This is PR that mitigates the issue using mailcow's existing unbound service which shouldn't cause issues for users (it only allows DNS requests to take place locally and doesn't conflict with systemd-resolve's resolver at 127.0.0.53), but it may ease this particular pain.

Take it as a suggestion only and feel free to reject it if you don't feel it's appropriate for the project. But there may be other useful purposes in allowing Docker host exposure of mailcow's internal DNS server (e.g. debugging DNS based blocklists, DNSSEC issues etc.)

Cheers,