### PR TITLE
imapsync: Connect to database via socket

### DIFF
--- a/data/Dockerfiles/dovecot/imapsync_cron.pl
+++ b/data/Dockerfiles/dovecot/imapsync_cron.pl
@@ -31,7 +31,7 @@ $DBUSER = '';
 $DBPASS = '';
 
 $run_dir="/tmp";
-$dsn = "DBI:mysql:database=" . $DBNAME . ";host=mysql";
+$dsn = "DBI:mysql:database=" . $DBNAME . ";mysql_socket=/var/run/mysqld/mysqld.sock";
 $lock_file = $run_dir . "/imapsync_busy";
 $lockmgr = LockFile::Simple->make(-autoclean => 1, -max => 1);
 $lockmgr->lock($lock_file) || die "can't lock ${lock_file}";


### PR DESCRIPTION
Make the imapsync script connect to mysql via socket and not tcp like all other services do.

Reasoning: consistency. 🤓  And in my case the database does not listen on tcp; just on the socket.