### PR TITLE
[Dovecot] FTS: Exclude autoindex for Junk/Trash

### DIFF
--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -308,6 +308,8 @@ plugin {
   acl = vfile
   fts = solr
   fts_autoindex = yes
+  fts_autoindex_exclude = \Junk
+  fts_autoindex_exclude2 = \Trash
   fts_solr = url=http://solr:8983/solr/dovecot/
   quota = dict:Userquota::proxy::sqlquota
   quota_rule2 = Trash:storage=+100%%


### PR DESCRIPTION
Indexing Junk and Trash folder are not really necessary, specially Junk.