### PR TITLE
Fix small german grammar glitch

### DIFF
--- a/data/web/lang/lang.de.php
+++ b/data/web/lang/lang.de.php
@@ -589,10 +589,10 @@ $lang['admin']['transports_hint'] = 'Transport Maps <b>überwiegen</b> senderabh
   Ein Eintrag in der TLS Policy Map kann eine Verschlüsselung erzwingen.<br>
   Die Authentifizierung wird anhand des Host Parameters ermittelt, hierbei würde bei einem beispielhaften Next Hop "[host]:25" immer zuerst "host" abfragt und <b>erst im Anschluss</b> "[host]:25".<br>
   Dieses Verhalten schließt die <b>gleichzeitige Verwendung</b> von Einträgen der Art "host" sowie "[host]:25" aus.';
-$lang['admin']['add_relayhost_hint'] = 'Bitte beachten Sie, dass Anmeldedaten klartext gespeichert werden.<br>
+$lang['admin']['add_relayhost_hint'] = 'Bitte beachten Sie, dass Anmeldedaten unverschlüsselt gespeichert werden.<br>
   Angelegte Transporte dieser Art sind <b>senderabhängig</b> und müssen erst einer Domain zugewiesen werden, bevor sie als Transport verwendet werden.<br>
   Diese Einstellungen entsprechen demach <i>nicht</i> dem "relayhost" Parameter in Postfix.';
-$lang['admin']['add_transports_hint'] = 'Bitte beachten Sie, dass Anmeldedaten klartext gespeichert werden.';
+$lang['admin']['add_transports_hint'] = 'Bitte beachten Sie, dass Anmeldedaten unverschlüsselt gespeichert werden.';
 $lang['admin']['host'] = 'Host';
 $lang['admin']['source'] = 'Quelle';
 $lang['admin']['add_forwarding_host'] = 'Weiterleitungs-Host hinzufügen';


### PR DESCRIPTION
There is no adjective "klartext".  🤓🤗 Eine Alternative zu meinem Vorschlag wäre "im Klartext".
![grammar police](https://i.imgflip.com/1j57fn.jpg)