### PR TITLE
remove dns-search property

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -400,7 +400,6 @@ services:
         - solr-vol-1:/opt/solr/server/solr/dovecot/data
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
-      dns_search: mailcow-network
       environment:
         - SOLR_HEAP=${SOLR_HEAP:-1024}
         - SKIP_SOLR=${SKIP_SOLR:-y}


### PR DESCRIPTION
@andryyy the property `dns_search` does not make sense. Have a look at https://docs.docker.com/v17.09/engine/userguide/networking/configure-dns/ .
What was the reason for adding this property?
