### PR TITLE
Forward mailcow-ui-domain to the docs

### DIFF
--- a/data/web/user.php
+++ b/data/web/user.php
@@ -76,7 +76,7 @@ elseif (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == '
   $username = $_SESSION['mailcow_cc_username'];
   $mailboxdata = mailbox('get', 'mailbox_details', $username);
 
-  $clientconfigstr = "host=" . urlencode($mailcow_hostname) . "&email=" . urlencode($username) . "&name=" . urlencode($mailboxdata['name']) . "&port=" . urlencode($autodiscover_config['caldav']['port']);
+  $clientconfigstr = "host=" . urlencode($mailcow_hostname) . "&email=" . urlencode($username) . "&name=" . urlencode($mailboxdata['name']) . "&ui=" . urlencode($_SERVER['HTTP_HOST']) . "&port=" . urlencode($autodiscover_config['caldav']['port']);
   if ($autodiscover_config['useEASforOutlook'] == 'yes')
   $clientconfigstr .= "&outlookEAS=1";
   if (file_exists('thunderbird-plugins/version.csv')) {


### PR DESCRIPTION
If the domain used for the mailcow UI differs from the hostname and the user tries to download the mobileconfig that's listet in the documentation, he will end up at the login promt. To prevent this, we need the docs to know the domain that's used to access the mailcow ui (as the mailcow-ui-session is only valid for this domain).
This PR adds the variable "ui" to the url and mailcow-docerized-docs can use this new variable when referring back to the mobileconfig file.