### PR TITLE
U2F: Don't check for Firefox, check only if U2F API is implemented

### DIFF
--- a/data/web/js/u2f-api.js
+++ b/data/web/js/u2f-api.js
@@ -20,10 +20,9 @@
      * Modification:
      * Only continue load this library if window.u2f is not already supplied by the browser.
      */
-    var isFirefox = navigator.userAgent.indexOf('Firefox') !== -1 || navigator.userAgent.indexOf('Gecko/') !== -1;
     var browserImplementsU2f = !!((typeof root.u2f !== 'undefined') && root.u2f.register);
 
-    if (isFirefox && browserImplementsU2f) {
+    if (browserImplementsU2f) {
         root.u2f.isSupported = true;
         return;
     }


### PR DESCRIPTION
I don't quite get, why there is a check for "Firefox" in this...
If you use Safari and have installed this extension https://github.com/Safari-FIDO-U2F/Safari-FIDO-U2F you can use the U2F authentication quite fine.

I removed the check for Firefox and can now use U2F on macOS with Safari if I install the above mentioned extension.