### PR TITLE
fix sogo-tool errors related 

### DIFF
--- a/data/conf/sogo/sogo.conf
+++ b/data/conf/sogo/sogo.conf
@@ -83,4 +83,18 @@
   //SOGoUIxDebugEnabled = YES;
   //WODontZipResponse = YES;
     WOLogFile = "/dev/sogo_log";
+
+  //////////////////////////////////////////////////////////////////////////////////////
+  // DO NOT CHANGE OR ADD CONTENT BELOW THIS LINE                                     //
+  // dynamic content will be created for mysql connections, time zone                 //
+  // and for multi-domain setup, content will be automatically                        //
+  // deleted and recreated each time the sogo container is started                    //
+  //////////////////////////////////////////////////////////////////////////////////////
+
+  // START AUTOMATIC SECTION
+  // END AUTOMATIC SECTION
+
+  //////////////////////////////////////////////////////////////////////////////////////
+  // DO NOT CHANGE CONTENT ABOVE THIS LINE it will be dynamically created and deleted //
+  //////////////////////////////////////////////////////////////////////////////////////
 }


### PR DESCRIPTION
Migrating users from another self-hosted SOGo 4 instance to mailcow-dockerized, I spent the entire weekend troubleshooting why I could not use the cmd line utilily sogo-tool that ships with SOGo.

The restore process for user calendars, contacts, etc. did not work properly no matter, what I tried, in fact the entire sogo-tool commands seemed to refuse doing their work.

I had all users mailboxes properly created and did a log-in for each user in SOGo so it was created, everything worked fine, but when I attached the sogo-mailcow container, to do the restore/migration, things just did not work at all.

If I, for example, used the following command to restore a known user's folders, like calendars and contacts
`sogo-tool restore -f ALL alex@mydomain.com`

sogo-tool threw several errors like:

- `ERROR(+[GCSFolderManager defaultFolderManager]): default 'OCSFolderInfoURL' is not configured.`

- `[SOGoUserManager]> No authentication sources defined - nobody will be able to login. Check your defaults`

- `sogo-tool[5437:5437] user 'alex' unknown`

Well after some hours of research, I figured out why, because sogo-tool for whatever reason does not use `/var/lib/sogo/GNUstep/Defaults/sogod.plist` to get its configuration, it wants it from `/etc/sogo/sogo.conf` but the values it looked for were not defined in `/etc/sogo/sogo.conf`, so it didn't find them.

So I decided to move all configuration from `sogod.plist` to `sogo.conf` by modifying the `/data/Dockerfiles/sogo/bootstrap-sogo.sh` script and also adjusting the `sogo.conf` with a dedicated are, so that it could receive the dynamic domain and sql configuration each time the sogo-mailcow container is restarted via the bootstrap script and some sed commands.

After moving the configuration to `sogo.conf` everything worked perfectly, sogo-tool did its job properly, all data was restored and accessible, everyone can log and all are happy again :)

So I decided to share my efforts, that's why I created this pull request, so others who use the sogo-tool may benefit from it as well and it also consolidates the entire sogo configuration into the one file `sogo.conf`, which I think makes it also a bit easier to get an overview what is really configured.

Kind regards,
Robert