### PR TITLE
Fix mailbox garbage collector not working

### DIFF
--- a/data/Dockerfiles/dovecot/docker-entrypoint.sh
+++ b/data/Dockerfiles/dovecot/docker-entrypoint.sh
@@ -189,7 +189,7 @@ IMAPSYNC_TABLE=$(mysql --socket=/var/run/mysqld/mysqld.sock -u ${DBUSER} -p${DBP
 [[ ! -z ${IMAPSYNC_TABLE} ]] && mysql --socket=/var/run/mysqld/mysqld.sock -u ${DBUSER} -p${DBPASS} ${DBNAME} -e "UPDATE imapsync SET is_running='0'"
 
 # Envsubst maildir_gc
-envsubst < /usr/local/bin/maildir_gc.sh > /usr/local/bin/maildir_gc.sh
+echo "$(envsubst < /usr/local/bin/maildir_gc.sh)" > /usr/local/bin/maildir_gc.sh
 
 # Collect SA rules once now
 /usr/local/bin/sa-rules.sh


### PR DESCRIPTION
I just realized that the hourly [`maildir_gc.sh`](https://github.com/mailcow/mailcow-dockerized/blob/master/data/Dockerfiles/dovecot/maildir_gc.sh) cron doesn't work.

The file gets cleared during the [envsubst command in `docker-entrypoint.sh`](https://github.com/mailcow/mailcow-dockerized/blob/60d74e3f17d8527b34975f7f8e7e9a820d0de628/data/Dockerfiles/dovecot/docker-entrypoint.sh#L192), because the one redirection operator opens the file for writing before the other starts reading from it.

This solution is inspired by https://serverfault.com/a/547331 :-)