### PR TITLE
Update clamd.conf

### DIFF
--- a/data/conf/clamav/clamd.conf
+++ b/data/conf/clamav/clamd.conf
@@ -26,7 +26,7 @@ DetectPUA yes
 #IncludePUA RAT
 HeuristicAlerts yes
 ScanOLE2 yes
-AlertOLE2Macros yes
+AlertOLE2Macros no
 ScanPDF yes
 ScanSWF yes
 ScanXMLDOCS yes


### PR DESCRIPTION
**if you want to keep it to enabled, please close the pull.

AlertOLE2Macros, default should be set to NO

With this option enabled OLE2 files containing VBA macros, which were NOT detected by signatures will be marked as "Heuristics.OLE2.ContainsMacros".

This causes most microsoft office document files which contains macros to be blocked. Majority of corporate documents mailed contain macros. When the option is set to NO, emails are still checked for known malicious macros.

Due to any message failing clamav being set to a 2000 score, this causes all legitimate emails with harmless macros to be blocked.

The default for debian/ubuntu is to set this to NO
cPanel, iredmail, etc all have this option set to NO