### PR TITLE
Add a "Virtual/All Mail" folder

### DIFF
--- a/data/Dockerfiles/dovecot/docker-entrypoint.sh
+++ b/data/Dockerfiles/dovecot/docker-entrypoint.sh
@@ -93,13 +93,13 @@ EOF
 echo -n ${ACL_ANYONE} > /usr/local/etc/dovecot/acl_anyone
 
 if [[ "${SKIP_SOLR}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
-echo -n 'quota acl zlib listescape mail_crypt mail_crypt_acl mail_log notify' > /usr/local/etc/dovecot/mail_plugins
-echo -n 'quota imap_quota imap_acl acl zlib imap_zlib imap_sieve listescape mail_crypt mail_crypt_acl notify mail_log' > /usr/local/etc/dovecot/mail_plugins_imap
-echo -n 'quota sieve acl zlib listescape mail_crypt mail_crypt_acl' > /usr/local/etc/dovecot/mail_plugins_lmtp
+echo -n 'quota acl zlib listescape mail_crypt mail_crypt_acl mail_log notify virtual' > /usr/local/etc/dovecot/mail_plugins
+echo -n 'quota imap_quota imap_acl acl zlib imap_zlib imap_sieve listescape mail_crypt mail_crypt_acl notify mail_log virtual' > /usr/local/etc/dovecot/mail_plugins_imap
+echo -n 'quota sieve acl zlib listescape mail_crypt mail_crypt_acl virtual' > /usr/local/etc/dovecot/mail_plugins_lmtp
 else
-echo -n 'quota acl zlib listescape mail_crypt mail_crypt_acl mail_log notify fts fts_solr' > /usr/local/etc/dovecot/mail_plugins
-echo -n 'quota imap_quota imap_acl acl zlib imap_zlib imap_sieve listescape mail_crypt mail_crypt_acl notify mail_log fts fts_solr' > /usr/local/etc/dovecot/mail_plugins_imap
-echo -n 'quota sieve acl zlib listescape mail_crypt mail_crypt_acl fts fts_solr' > /usr/local/etc/dovecot/mail_plugins_lmtp
+echo -n 'quota acl zlib listescape mail_crypt mail_crypt_acl mail_log notify fts fts_solr virtual' > /usr/local/etc/dovecot/mail_plugins
+echo -n 'quota imap_quota imap_acl acl zlib imap_zlib imap_sieve listescape mail_crypt mail_crypt_acl notify mail_log fts fts_solr virtual' > /usr/local/etc/dovecot/mail_plugins_imap
+echo -n 'quota sieve acl zlib listescape mail_crypt mail_crypt_acl fts fts_solr virtual' > /usr/local/etc/dovecot/mail_plugins_lmtp
 fi
 chmod 644 /usr/local/etc/dovecot/mail_plugins /usr/local/etc/dovecot/mail_plugins_imap /usr/local/etc/dovecot/mail_plugins_lmtp /templates/quarantine.tpl
 

--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -214,6 +214,19 @@ namespace {
     subscriptions = no
     list = children
 }
+
+# Create a virtual namespace for "all mail" to make searching across all folders
+# easier
+imap_capability = +XDOVECOT
+namespace Virtual {
+  prefix = Virtual/
+  separator = /
+  hidden = yes
+  list = no
+  subscriptions = no
+  location = virtual:/usr/local/etc/dovecot/virtual:INDEX=/var/vmail/%d/%n/virtual
+}
+
 protocols = imap sieve lmtp pop3
 service dict {
   unix_listener dict {

--- a/data/conf/dovecot/virtual/All Mail/dovecot-virtual
+++ b/data/conf/dovecot/virtual/All Mail/dovecot-virtual
@@ -1,0 +1,40 @@
+*
+-INBOX/Trash
+-INBOX/Trash/*
+-INBOX/Spam
+-INBOX/Spam/*
+-INBOX/Deleted\ Messages
+-INBOX/Deleted\ Messages/*
+-INBOX/Deleted\ Items
+-INBOX/Deleted\ Items/*
+-INBOX/Rubbish
+-INBOX/Rubbish/*
+-INBOX/Gelöschte\ Objekte
+-INBOX/Gelöschte\ Objekte/*
+-INBOX/Gelöschte\ Elemente
+-INBOX/Gelöschte\ Elemente/*
+-INBOX/Papierkorb
+-INBOX/Papierkorb/*
+-INBOX/Itens\ Excluidos
+-INBOX/Itens\ Excluídos/*
+-INBOX/Lixeira
+-INBOX/Lixeira/*
+-INBOX/Prullenbak
+-INBOX/Prullenbak/*
+-INBOX/Verwijderde
+-INBOX/Verwijderde/*
+-INBOX/Junk
+-INBOX/Junk/*
+-INBOX/Junk-E-Mail
+-INBOX/Junk-E-Mail/*
+-INBOX/Junk\ E-Mail
+-INBOX/Junk\ E-Mail/*
+-INBOX/Lixo\ Eletrônico
+-INBOX/Lixo\ Eletrônico/*
+-INBOX/Ongewenste\ e-mail
+-INBOX/Ongewenste\ e-mail/*
+-INBOX/Nevyžádaná\ pošta
+-INBOX/Nevyžádaná\ pošta/*
+-INBOX/Odstraněná\ pošta
+-INBOX/Odstraněná\ pošta/*
+  all


### PR DESCRIPTION
This doesn't appear in LIST and isn't subscribable, but it allows a user
to search across all folders at once (for example, with fts).

This should work as it is, but I'm not sure if it is overly helpful yet.

It would be useful to have an improvement to SOGo to search this folder. For example, what OX do: http://documentation.open-xchange.com/7.8.2/middleware/components/search/crossfolder_fts_in_mail.html

Additionally it appears that K-9 mail (on android), only searches the subject, to, and from fields on server-side search so its use is limited too.

Finally I'm not sure how other clients handle their server-side search. For me, thunderbird isn't using imap search which is something else I want to solve.

Having said all that, some users could find it useful to have an "All Mail" folder if we wanted to make it visible (perhaps via config)