### PR TITLE
Allow admins to login as email user (without any password)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ data/conf/nginx/*.custom
 data/conf/nginx/*.bak
 data/conf/dovecot/acl_anyone
 data/conf/dovecot/mail_plugins*
+data/conf/dovecot/sogo-sso.conf
 data/conf/dovecot/extra.conf
 data/conf/rspamd/custom/*
 data/conf/portainer/

--- a/data/Dockerfiles/dovecot/docker-entrypoint.sh
+++ b/data/Dockerfiles/dovecot/docker-entrypoint.sh
@@ -118,6 +118,17 @@ default_pass_scheme = SSHA256
 password_query = SELECT password FROM mailbox WHERE active = '1' AND username = '%u' AND domain IN (SELECT domain FROM domain WHERE domain='%d' AND active='1') AND JSON_EXTRACT(attributes, '$.force_pw_update') NOT LIKE '%%1%%'
 EOF
 
+if [[ "${ALLOW_ADMIN_EMAIL_LOGIN}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+    cat <<EOF > /usr/local/etc/dovecot/sogo-sso.conf
+passdb {
+  driver = static
+  args = password= allow_real_nets=${IPV4_NETWORK}.248/32
+}
+EOF
+else
+    rm -f /usr/local/etc/dovecot/sogo-sso.conf
+fi
+
 # Create global sieve_after script
 cat /usr/local/etc/dovecot/sieve_after > /var/vmail/sieve/global.sieve
 

--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -389,4 +389,5 @@ auth_cache_negative_ttl = 0
 auth_cache_ttl = 30 s
 auth_cache_size = 2 M
 !include_try /usr/local/etc/dovecot/extra.conf
+!include_try /usr/local/etc/dovecot/sogo-sso.conf
 default_client_limit = 10400

--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -164,6 +164,17 @@ server {
     client_max_body_size 0;
   }
 
+  # auth_request endpoint if ALLOW_ADMIN_EMAIL_LOGIN is set
+  location /sogo-auth-verify {
+    internal;
+    proxy_set_header  X-Original-URI $request_uri;
+    proxy_set_header  X-Real-IP $remote_addr;
+    proxy_set_header  Host $http_host;
+    proxy_set_header  Content-Length "";
+    proxy_pass        http://127.0.0.1:80/sogo-auth;
+    proxy_pass_request_body off;
+  }
+
   location ^~ /SOGo {
     include /etc/nginx/conf.d/sogo.active;
     proxy_set_header X-Real-IP $remote_addr;

--- a/data/conf/nginx/templates/sogo.auth_request.template.sh
+++ b/data/conf/nginx/templates/sogo.auth_request.template.sh
@@ -1,0 +1,7 @@
+if printf "%s\n" "${ALLOW_ADMIN_EMAIL_LOGIN}" | grep -E '^([yY][eE][sS]|[yY])+$' >/dev/null; then
+    echo '
+auth_request /sogo-auth-verify;
+auth_request_set $user $upstream_http_x_username;
+proxy_set_header x-webobjects-remote-user $user;
+'
+fi

--- a/data/conf/nginx/templates/sogo.auth_request.template.sh
+++ b/data/conf/nginx/templates/sogo.auth_request.template.sh
@@ -1,6 +1,5 @@
-if printf "%s\n" "${ALLOW_ADMIN_EMAIL_LOGIN}" | grep -E '^([yY][eE][sS]|[yY])+$' >/dev/null; then
-    echo '
-auth_request /sogo-auth-verify;
+if [[ "${ALLOW_ADMIN_EMAIL_LOGIN}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+    echo 'auth_request /sogo-auth-verify;
 auth_request_set $user $upstream_http_x_username;
 proxy_set_header x-webobjects-remote-user $user;
 '

--- a/data/conf/nginx/templates/sogo.auth_request.template.sh
+++ b/data/conf/nginx/templates/sogo.auth_request.template.sh
@@ -1,4 +1,4 @@
-if [[ "${ALLOW_ADMIN_EMAIL_LOGIN}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+if printf "%s\n" "${ALLOW_ADMIN_EMAIL_LOGIN}" | grep -E '^([yY][eE][sS]|[yY])+$' >/dev/null; then
     echo 'auth_request /sogo-auth-verify;
 auth_request_set $user $upstream_http_x_username;
 proxy_set_header x-webobjects-remote-user $user;

--- a/data/conf/sogo/sogo.conf
+++ b/data/conf/sogo/sogo.conf
@@ -83,4 +83,6 @@
   //SOGoUIxDebugEnabled = YES;
   //WODontZipResponse = YES;
     WOLogFile = "/dev/sogo_log";
+
+    SOGoTrustProxyAuthentication = YES;
 }

--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -312,7 +312,7 @@ jQuery(function($){
         {"name":"messages","filterable": false,"title":lang.msg_num,"breakpoints":"xs sm md"},
         {"name":"rl","title":"RL","breakpoints":"xs sm md","style":{"width":"125px"}},
         {"name":"active","filterable": false,"title":lang.active},
-        {"name":"action","filterable": false,"sortable": false,"style":{"min-width":"250px","text-align":"right"},"type":"html","title":lang.action,"breakpoints":"xs sm md"}
+        {"name":"action","filterable": false,"sortable": false,"style":{"min-width":"290px","text-align":"right"},"type":"html","title":lang.action,"breakpoints":"xs sm md"}
       ],
       "empty": lang.empty,
       "rows": $.ajax({
@@ -349,8 +349,11 @@ jQuery(function($){
             item.action = '<div class="btn-group">' +
               '<a href="/edit/mailbox/' + encodeURIComponent(item.username) + '" class="btn btn-xs btn-default"><span class="glyphicon glyphicon-pencil"></span> ' + lang.edit + '</a>' +
               '<a href="#" data-action="delete_selected" data-id="single-mailbox" data-api-url="delete/mailbox" data-item="' + encodeURIComponent(item.username) + '" class="btn btn-xs btn-danger"><span class="glyphicon glyphicon-trash"></span> ' + lang.remove + '</a>' +
-              '<a href="/index.php?duallogin=' + encodeURIComponent(item.username) + '" class="login_as btn btn-xs btn-success"><span class="glyphicon glyphicon-user"></span> Login</a>' +
-              '</div>';
+              '<a href="/index.php?duallogin=' + encodeURIComponent(item.username) + '" class="login_as btn btn-xs btn-success"><span class="glyphicon glyphicon-user"></span> Login</a>';
+              if (ALLOW_ADMIN_EMAIL_LOGIN) {
+                item.action += '<a href="/sogo-auth.php?login=' + encodeURIComponent(item.username) + '" class="login_as btn btn-xs btn-primary" target="_blank"><span class="glyphicon glyphicon-envelope"></span> SOGo</a>';
+              }
+              item.action += '</div>';
             }
             else {
             item.action = '<div class="btn-group">' +

--- a/data/web/mailbox.php
+++ b/data/web/mailbox.php
@@ -348,6 +348,11 @@ $is_dual = (!empty($_SESSION["dual-login"]["username"])) ? 'true' : 'false';
 echo "var role = '". $role . "';\n";
 echo "var is_dual = " . $is_dual . ";\n";
 echo "var pagination_size = '". $PAGINATION_SIZE . "';\n";
+$ALLOW_ADMIN_EMAIL_LOGIN = (preg_match(
+	"/^([yY][eE][sS]|[yY])+$/",
+    $_ENV["ALLOW_ADMIN_EMAIL_LOGIN"]
+)) ? "true" : "false";
+echo "var ALLOW_ADMIN_EMAIL_LOGIN = " . $ALLOW_ADMIN_EMAIL_LOGIN . ";\n";
 ?>
 </script>
 <?php

--- a/data/web/sogo-auth.php
+++ b/data/web/sogo-auth.php
@@ -1,10 +1,9 @@
 <?php
-require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
 
 /**
- * currently disabled: we could add auth_request to ningx sogo_eas.template
- * but this seems to be not required with the postfix allow_real_nets option
- */
+* currently disabled: we could add auth_request to ningx sogo_eas.template
+* but this seems to be not required with the postfix allow_real_nets option
+*/
 /*
 if (substr($_SERVER['HTTP_X_ORIGINAL_URI'], 0, 28) === "/Microsoft-Server-ActiveSync") {
   require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
@@ -38,6 +37,7 @@ if (!$ALLOW_ADMIN_EMAIL_LOGIN) {
   exit;
 }
 elseif (isset($_GET['login'])) {
+  require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
   if (isset($_SESSION['mailcow_cc_role']) && $_SESSION['acl']['login_as'] == "1") {
     $login = html_entity_decode(rawurldecode($_GET["login"]));
     if (filter_var($login, FILTER_VALIDATE_EMAIL)) {
@@ -53,9 +53,10 @@ elseif (isset($_GET['login'])) {
 }
 else {
   // this is an nginx auth_request call, we check for an existing sogo-sso-user session variable
+  session_start();
   $username = "";
   if (isset($_SESSION[$session_variable]) && filter_var($_SESSION[$session_variable], FILTER_VALIDATE_EMAIL)) {
-    $username = $_SESSION[$session_variable];
+      $username = $_SESSION[$session_variable];
   }
   // if username is empty, SOGo will display the normal login form
   header("X-Username: $username");

--- a/data/web/sogo-auth.php
+++ b/data/web/sogo-auth.php
@@ -1,4 +1,5 @@
 <?php
+require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
 
 /**
  * currently disabled: we could add auth_request to ningx sogo_eas.template
@@ -6,57 +7,57 @@
  */
 /*
 if (substr($_SERVER['HTTP_X_ORIGINAL_URI'], 0, 28) === "/Microsoft-Server-ActiveSync") {
-    require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
+  require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
 
-    $server=print_r($_SERVER, true);
-    $username = $_SERVER['PHP_AUTH_USER'];
-    $password = $_SERVER['PHP_AUTH_PW'];
-    $login_check = check_login($username, $password);
-    if ($login_check !== 'user') {
-        header('HTTP/1.0 401 Unauthorized');
-        echo 'Invalid login';
-        exit;
-    } else {
-        echo 'Login OK';
-        exit;
-    }
+  $server=print_r($_SERVER, true);
+  $username = $_SERVER['PHP_AUTH_USER'];
+  $password = $_SERVER['PHP_AUTH_PW'];
+  $login_check = check_login($username, $password);
+  if ($login_check !== 'user') {
+      header('HTTP/1.0 401 Unauthorized');
+      echo 'Invalid login';
+      exit;
+  } else {
+      echo 'Login OK';
+      exit;
+  }
 } else {
-    // other code
+  // other code
 }
 */
 
 $ALLOW_ADMIN_EMAIL_LOGIN = (preg_match(
-    "/^([yY][eE][sS]|[yY])+$/",
-    $_ENV["ALLOW_ADMIN_EMAIL_LOGIN"]
+  "/^([yY][eE][sS]|[yY])+$/",
+  $_ENV["ALLOW_ADMIN_EMAIL_LOGIN"]
 ));
 
 $session_variable = 'sogo-sso-user';
 
 if (!$ALLOW_ADMIN_EMAIL_LOGIN) {
-    header("Location: /");
-    exit;
-} else if (isset($_GET['login'])) {
-    require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
-    if (isset($_SESSION['mailcow_cc_role']) && $_SESSION['acl']['login_as'] == "1") {
-        $login = html_entity_decode(rawurldecode($_GET["login"]));
-        if (filter_var($login, FILTER_VALIDATE_EMAIL)) {
-            if (!empty(mailbox('get', 'mailbox_details', $login))) {
-                $_SESSION[$session_variable] = $login;
-                header("Location: /SOGo/");
-                exit;
-            }
-        }
+  header("Location: /");
+  exit;
+}
+elseif (isset($_GET['login'])) {
+  if (isset($_SESSION['mailcow_cc_role']) && $_SESSION['acl']['login_as'] == "1") {
+    $login = html_entity_decode(rawurldecode($_GET["login"]));
+    if (filter_var($login, FILTER_VALIDATE_EMAIL)) {
+      if (!empty(mailbox('get', 'mailbox_details', $login))) {
+        $_SESSION[$session_variable] = $login;
+        header("Location: /SOGo/");
+        exit;
+      }
     }
-    header("Location: /");
-    exit;
-} else {
-    // this is an nginx auth_request call, we check for an existing sogo-sso-user session variable
-    session_start();
-    $username = "";
-    if (isset($_SESSION[$session_variable]) && filter_var($_SESSION[$session_variable], FILTER_VALIDATE_EMAIL)) {
-        $username = $_SESSION[$session_variable];
-    }
-    // if username is empty, SOGo will display the normal login form
-    header("X-Username: $username");
-    exit;
+  }
+  header("Location: /");
+  exit;
+}
+else {
+  // this is an nginx auth_request call, we check for an existing sogo-sso-user session variable
+  $username = "";
+  if (isset($_SESSION[$session_variable]) && filter_var($_SESSION[$session_variable], FILTER_VALIDATE_EMAIL)) {
+    $username = $_SESSION[$session_variable];
+  }
+  // if username is empty, SOGo will display the normal login form
+  header("X-Username: $username");
+  exit;
 }

--- a/data/web/sogo-auth.php
+++ b/data/web/sogo-auth.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * currently disabled: we could add auth_request to ningx sogo_eas.template
+ * but this seems to be not required with the postfix allow_real_nets option
+ */
+/*
+if (substr($_SERVER['HTTP_X_ORIGINAL_URI'], 0, 28) === "/Microsoft-Server-ActiveSync") {
+    require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
+
+    $server=print_r($_SERVER, true);
+    $username = $_SERVER['PHP_AUTH_USER'];
+    $password = $_SERVER['PHP_AUTH_PW'];
+    $login_check = check_login($username, $password);
+    if ($login_check !== 'user') {
+        header('HTTP/1.0 401 Unauthorized');
+        echo 'Invalid login';
+        exit;
+    } else {
+        echo 'Login OK';
+        exit;
+    }
+} else {
+    // other code
+}
+*/
+
+$ALLOW_ADMIN_EMAIL_LOGIN = (preg_match(
+    "/^([yY][eE][sS]|[yY])+$/",
+    $_ENV["ALLOW_ADMIN_EMAIL_LOGIN"]
+));
+
+$session_variable = 'sogo-sso-user';
+
+if (!$ALLOW_ADMIN_EMAIL_LOGIN) {
+    header("Location: /");
+    exit;
+} else if (isset($_GET['login'])) {
+    require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
+    if (isset($_SESSION['mailcow_cc_role']) && $_SESSION['acl']['login_as'] == "1") {
+        $login = html_entity_decode(rawurldecode($_GET["login"]));
+        if (filter_var($login, FILTER_VALIDATE_EMAIL)) {
+            if (!empty(mailbox('get', 'mailbox_details', $login))) {
+                $_SESSION[$session_variable] = $login;
+                header("Location: /SOGo/");
+                exit;
+            }
+        }
+    }
+    header("Location: /");
+    exit;
+} else {
+    // this is an nginx auth_request call, we check for an existing sogo-sso-user session variable
+    session_start();
+    $username = "";
+    if (isset($_SESSION[$session_variable]) && filter_var($_SESSION[$session_variable], FILTER_VALIDATE_EMAIL)) {
+        $username = $_SESSION[$session_variable];
+    }
+    // if username is empty, SOGo will display the normal login form
+    header("X-Username: $username");
+    exit;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,7 @@ services:
         - API_ALLOW_FROM=${API_ALLOW_FROM:-invalid}
         - COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-mailcow-dockerized}
         - SKIP_SOLR=${SKIP_SOLR:-y}
+        - ALLOW_ADMIN_EMAIL_LOGIN=${ALLOW_ADMIN_EMAIL_LOGIN:-n}
       restart: always
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
@@ -185,6 +186,8 @@ services:
         - DBUSER=${DBUSER}
         - DBPASS=${DBPASS}
         - TZ=${TZ}
+        - IPV4_NETWORK=${IPV4_NETWORK:-172.22.1}
+        - ALLOW_ADMIN_EMAIL_LOGIN=${ALLOW_ADMIN_EMAIL_LOGIN:-n}
         - MAILDIR_GC_TIME=${MAILDIR_GC_TIME:-1440}
         - ACL_ANYONE=${ACL_ANYONE:-disallow}
         - SKIP_SOLR=${SKIP_SOLR:-y}
@@ -260,7 +263,8 @@ services:
       command: /bin/sh -c "envsubst < /etc/nginx/conf.d/templates/listen_plain.template > /etc/nginx/conf.d/listen_plain.active &&
         envsubst < /etc/nginx/conf.d/templates/listen_ssl.template > /etc/nginx/conf.d/listen_ssl.active &&
         envsubst < /etc/nginx/conf.d/templates/server_name.template > /etc/nginx/conf.d/server_name.active &&
-        envsubst < /etc/nginx/conf.d/templates/sogo.template > /etc/nginx/conf.d/sogo.active &&
+        . /etc/nginx/conf.d/templates/sogo.auth_request.template.sh > /etc/nginx/conf.d/sogo.active &&
+        envsubst < /etc/nginx/conf.d/templates/sogo.template >> /etc/nginx/conf.d/sogo.active &&
         envsubst < /etc/nginx/conf.d/templates/sogo_eas.template > /etc/nginx/conf.d/sogo_eas.active &&
         nginx -qt &&
         until ping phpfpm -c1 > /dev/null; do sleep 1; done &&
@@ -274,6 +278,7 @@ services:
         - MAILCOW_HOSTNAME=${MAILCOW_HOSTNAME}
         - IPV4_NETWORK=${IPV4_NETWORK:-172.22.1}
         - TZ=${TZ}
+        - ALLOW_ADMIN_EMAIL_LOGIN=${ALLOW_ADMIN_EMAIL_LOGIN:-n}
       volumes:
         - ./data/web:/web:ro
         - ./data/conf/rspamd/dynmaps:/dynmaps:ro

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -200,6 +200,10 @@ SOLR_HEAP=1024
 
 USE_WATCHDOG=n
 
+# Allow admins to log into SOGo as email user (without any password)
+
+ALLOW_ADMIN_EMAIL_LOGIN=n
+
 # Send notifications by mail (no DKIM signature, sent from watchdog@MAILCOW_HOSTNAME)
 # Can by multiple rcpts, NO quotation marks
 

--- a/update.sh
+++ b/update.sh
@@ -130,6 +130,7 @@ CONFIG_ARRAY=(
   "ACL_ANYONE"
   "SOLR_HEAP"
   "SKIP_SOLR"
+  "ALLOW_ADMIN_EMAIL_LOGIN"
 )
 
 sed -i '$a\' mailcow.conf


### PR DESCRIPTION
**general changes**
- add config ALLOW_ADMIN_EMAIL_LOGIN, default=n
- add SOGoTrustProxyAuthentication = YES to SOGo config to allow authentication with x-webobjects-remote-user header
- add dovecot config to allow the sogo container imap access without a password
- add nginx auth_request configs for adding the x-webobjects-remote-user header
- create sogo-auth.php as auth_request backend + redirector for logins
- modify UI to show SOGo login button on email address list
![grafik](https://user-images.githubusercontent.com/3976393/53289368-a0dcf200-3795-11e9-83c2-822c25c0428f.png)

**additional details**
- when clicking on the SOGo link, sogo-auth.php will check permissions and set a session variable 'sogo-sso-user' with the e-mail address. after that it will redirect to /SOGo/
- on every http request in SOGo, auth_request will call sogo-auth.php internally
- sogo-auth.php will then check if the 'sogo-sso-user' session variable exists and return the value accordingly so nginx can set the correct header.
- when accessing SOGo without this session variable, SOGo will display the normal login screen

**drawbacks**
- each SOGo request will cause an additional auth_request to the sogo-auth.php, on larger installations this might cause performance problems, this is not the case if you have the feature disabled with ALLOW_ADMIN_EMAIL_LOGIN=n
- SOGo will not display a logout link, to login normally one has to logout from the mailcow UI so the session is destroyed

**security considerations**
- according to my tests, the dovecot passdb argument allow_real_nets should ensure that only the SOGo container can access imap without a password:
  - when SOGo web UI makes imap requests, dovecot will see the SOGo container IP
  - when SOGo proxies Active-Sync requests, the real client IP should be forwarded and dovecot requires a valid password
  - the following (existing) nginx configs should ensure that the real client IP cannot be spoofed from outside of local networks:
```
  set_real_ip_from 10.0.0.0/8;
  set_real_ip_from 172.16.0.0/12;
  set_real_ip_from 192.168.0.0/16;
  set_real_ip_from fc00::/7;
  real_ip_header X-Forwarded-For;
```
- in sogo-auth.php i copied existing code to ensure the admin user is allowed to login as the destination email address, as far as i could see this is correct, but should be double checked.

