### PR TITLE
Security Fix/Extension for #2360 - Allow Admin Login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 rebuild-images.sh
 data/conf/sogo/sieve.creds
+data/conf/phpfpm/sogo-sso/sogo-sso.pass
 data/conf/dovecot/dovecot-master.passwd
 data/conf/dovecot/dovecot-master.userdb
 mailcow.conf

--- a/data/Dockerfiles/sogo/bootstrap-sogo.sh
+++ b/data/Dockerfiles/sogo/bootstrap-sogo.sh
@@ -88,6 +88,13 @@ mkdir -p /var/lib/sogo/GNUstep/Defaults/
 # Force-remove lines from sogo.conf
 sed -i '/SOGoIMAPServer/d' /etc/sogo/sogo.conf
 
+if [[ "${ALLOW_ADMIN_EMAIL_LOGIN}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+  TRUST_PROXY="YES"
+else
+  TRUST_PROXY="NO"
+fi
+RAND_PASS=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 24 | head -n 1)
+
 # Generate plist header with timezone data
 cat <<EOF > /var/lib/sogo/GNUstep/Defaults/sogod.plist
 <?xml version="1.0" encoding="UTF-8"?>
@@ -98,6 +105,10 @@ cat <<EOF > /var/lib/sogo/GNUstep/Defaults/sogod.plist
     <string>mysql://${DBUSER}:${DBPASS}@%2Fvar%2Frun%2Fmysqld%2Fmysqld.sock/${DBNAME}/sogo_acl</string>
     <key>SOGoIMAPServer</key>
     <string>imap://${IPV4_NETWORK}.250:143/?tls=YES</string>
+    <key>SOGoTrustProxyAuthentication</key>
+    <string>${TRUST_PROXY}</string>
+    <key>SOGoEncryptionKey</key>
+    <string>${RAND_PASS}</string>
     <key>OCSCacheFolderURL</key>
     <string>mysql://${DBUSER}:${DBPASS}@%2Fvar%2Frun%2Fmysqld%2Fmysqld.sock/${DBNAME}/sogo_cache_folder</string>
     <key>OCSEMailAlarmsFolderURL</key>

--- a/data/Dockerfiles/sogo/bootstrap-sogo.sh
+++ b/data/Dockerfiles/sogo/bootstrap-sogo.sh
@@ -83,19 +83,16 @@ EOF
 done
 
 
-mkdir -p /var/lib/sogo/GNUstep/Defaults/
-
-# Force-remove lines from sogo.conf
-sed -i '/SOGoIMAPServer/d' /etc/sogo/sogo.conf
-
 if [[ "${ALLOW_ADMIN_EMAIL_LOGIN}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
   TRUST_PROXY="YES"
 else
   TRUST_PROXY="NO"
 fi
-RAND_PASS=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 24 | head -n 1)
+# cat /dev/urandom seems to hang here occasionally and is not recommended anyway, better use openssl
+RAND_PASS=$(openssl rand -base64 16 | tr -dc _A-Z-a-z-0-9)
 
 # Generate plist header with timezone data
+mkdir -p /var/lib/sogo/GNUstep/Defaults/
 cat <<EOF > /var/lib/sogo/GNUstep/Defaults/sogod.plist
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//GNUstep//DTD plist 0.9//EN" "http://www.gnustep.org/plist-0_9.xml">

--- a/data/conf/nginx/templates/sogo.auth_request.template.sh
+++ b/data/conf/nginx/templates/sogo.auth_request.template.sh
@@ -1,8 +1,10 @@
 if printf "%s\n" "${ALLOW_ADMIN_EMAIL_LOGIN}" | grep -E '^([yY][eE][sS]|[yY])+$' >/dev/null; then
     echo 'auth_request /sogo-auth-verify;
-auth_request_set $user $upstream_http_x_username;
-proxy_set_header x-webobjects-remote-user $user;
-if ($args ~* (.*)(account=(?!0))(.*)) {
-  return 401;
-}'
+auth_request_set $user $upstream_http_x_user;
+auth_request_set $auth $upstream_http_x_auth;
+auth_request_set $auth_type $upstream_http_x_auth_type;
+proxy_set_header x-webobjects-remote-user "$user";
+proxy_set_header Authorization "$auth";
+proxy_set_header x-webobjects-auth-type "$auth_type";
+'
 fi

--- a/data/conf/sogo/sogo.conf
+++ b/data/conf/sogo/sogo.conf
@@ -82,6 +82,4 @@
   //SOGoUIxDebugEnabled = YES;
   //WODontZipResponse = YES;
     WOLogFile = "/dev/sogo_log";
-
-    SOGoTrustProxyAuthentication = YES;
 }

--- a/data/web/sogo-auth.php
+++ b/data/web/sogo-auth.php
@@ -1,30 +1,5 @@
 <?php
 
-/**
-* currently disabled: we could add auth_request to ningx sogo_eas.template
-* but this seems to be not required with the postfix allow_real_nets option
-*/
-/*
-if (substr($_SERVER['HTTP_X_ORIGINAL_URI'], 0, 28) === "/Microsoft-Server-ActiveSync") {
-  require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
-
-  $server=print_r($_SERVER, true);
-  $username = $_SERVER['PHP_AUTH_USER'];
-  $password = $_SERVER['PHP_AUTH_PW'];
-  $login_check = check_login($username, $password);
-  if ($login_check !== 'user') {
-      header('HTTP/1.0 401 Unauthorized');
-      echo 'Invalid login';
-      exit;
-  } else {
-      echo 'Login OK';
-      exit;
-  }
-} else {
-  // other code
-}
-*/
-
 $ALLOW_ADMIN_EMAIL_LOGIN = (preg_match(
   "/^([yY][eE][sS]|[yY])+$/",
   $_ENV["ALLOW_ADMIN_EMAIL_LOGIN"]
@@ -34,28 +9,34 @@ $session_var_user = 'sogo-sso-user';
 $session_var_pass = 'sogo-sso-pass';
 
 if (!$ALLOW_ADMIN_EMAIL_LOGIN) {
-  header("Location: /");
+  header('HTTP/1.0 401 Forbidden');
+  echo "this feature is disabled";
   exit;
 }
 elseif (isset($_GET['login'])) {
+  // load prerequisites only when required
   require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
+  // check permissions
   if (isset($_SESSION['mailcow_cc_role']) && $_SESSION['acl']['login_as'] == "1") {
     $login = html_entity_decode(rawurldecode($_GET["login"]));
     if (filter_var($login, FILTER_VALIDATE_EMAIL)) {
       if (!empty(mailbox('get', 'mailbox_details', $login))) {
+        // load master password
         $sogo_sso_pass = file_get_contents("/etc/sogo-sso/sogo-sso.pass");
+        // register username and password in session
         $_SESSION[$session_var_user] = $login;
         $_SESSION[$session_var_pass] = $sogo_sso_pass;
+        // redirect to sogo (sogo will get the correct credentials via nginx auth_request
         header("Location: /SOGo/");
         exit;
       }
     }
   }
-  header("Location: /");
+  header('HTTP/1.0 401 Forbidden');
   exit;
 }
 else {
-  // this is an nginx auth_request call, we check for an existing sogo-sso-user session variable
+  // this is an nginx auth_request call, we check for existing sogo-sso session variables
   session_start();
   if (isset($_SESSION[$session_var_user]) && filter_var($_SESSION[$session_var_user], FILTER_VALIDATE_EMAIL)) {
       $username = $_SESSION[$session_var_user];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
         - mysql-socket-vol-1:/var/run/mysqld/
         - ./data/conf/sogo/:/etc/sogo/
         - ./data/conf/rspamd/meta_exporter:/meta_exporter:ro
+        - ./data/conf/phpfpm/sogo-sso/:/etc/sogo-sso/
         - ./data/conf/phpfpm/php-fpm.d/pools.conf:/usr/local/etc/php-fpm.d/z-pools.conf
         - ./data/conf/phpfpm/php-conf.d/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini
         - ./data/conf/phpfpm/php-conf.d/upload.ini:/usr/local/etc/php/conf.d/upload.ini
@@ -175,6 +176,7 @@ services:
         - ./data/conf/dovecot:/usr/local/etc/dovecot
         - ./data/assets/ssl:/etc/ssl/mail/:ro
         - ./data/conf/sogo/:/etc/sogo/
+        - ./data/conf/phpfpm/sogo-sso/:/etc/phpfpm/
         - vmail-vol-1:/var/vmail
         - vmail-attachments-vol-1:/var/attachments
         - crypt-vol-1:/mail_crypt/


### PR DESCRIPTION
As mentioned in https://github.com/mailcow/mailcow-dockerized/pull/2360, this should fix most security concerns

There is no documentation mentioning it, but after finding [SOGoProxyAuthenticator.passwordInContext](https://github.com/inverse-inc/sogo/blob/master/SoObjects/SOGo/SOGoProxyAuthenticator.m#L108) I finally found a solution to pass a password to SOGo with proxy authentication. While this is not documented, the code is there since a while so i guess it will not be removed / changed soon.

1. We have to set the following headers which tells sogo to extract the password from the basic auth header:
```
x-webobjects-auth-type: Basic
x-webobjects-remote-user: username
Authorization: base64(username:masterpass)
```
The headers are injected by the nginx reverse proxy and not visible to the user.

2. Because we don't have the users passwords (they are encrypted) we have to generate a random dovecot master password which is valid for all users (but only from the sogo container) and re-generated on each dovecot restart
```
passdb {
  driver = static
  args = allow_real_nets=172.22.1.248/32 password={plain}xyz
}
```

This solves the security issue mentioned here: https://github.com/mailcow/mailcow-dockerized/pull/2360#issuecomment-466812291 and generally removes a lot of the attack surface as there i no empty dovecot master password anymore.

*edit: Additionally, SOGoEncryptionKey is set so stored remote calendar passwords are encrypted during proxy-auth