### PR TITLE
always check basic auth against user database for EAS and SOGo if ALLOW_ADMIN_EMAIL_LOGIN is enabled

### DIFF
--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -142,7 +142,19 @@ server {
     try_files /autoconfig.php =404;
   }
 
+  # auth_request endpoint if ALLOW_ADMIN_EMAIL_LOGIN is set
+  location /sogo-auth-verify {
+    internal;
+    proxy_set_header  X-Original-URI $request_uri;
+    proxy_set_header  X-Real-IP $remote_addr;
+    proxy_set_header  Host $http_host;
+    proxy_set_header  Content-Length "";
+    proxy_pass        http://127.0.0.1:80/sogo-auth;
+    proxy_pass_request_body off;
+  }
+
   location ^~ /Microsoft-Server-ActiveSync {
+    include /etc/nginx/conf.d/sogo_proxy_auth.active;
     include /etc/nginx/conf.d/sogo_eas.active;
     proxy_connect_timeout 4000;
     proxy_next_upstream timeout error;
@@ -164,34 +176,9 @@ server {
     client_max_body_size 0;
   }
 
-  # auth_request endpoint if ALLOW_ADMIN_EMAIL_LOGIN is set
-  location /sogo-auth-verify {
-    internal;
-    proxy_set_header  X-Original-URI $request_uri;
-    proxy_set_header  X-Real-IP $remote_addr;
-    proxy_set_header  Host $http_host;
-    proxy_set_header  Content-Length "";
-    proxy_pass        http://127.0.0.1:80/sogo-auth;
-    proxy_pass_request_body off;
-  }
-
   location ^~ /SOGo {
-    include /etc/nginx/conf.d/sogo_main.active;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
-    proxy_set_header x-webobjects-server-protocol HTTP/1.0;
-    proxy_set_header x-webobjects-remote-host $remote_addr;
-    proxy_set_header x-webobjects-server-name $server_name;
-    proxy_set_header x-webobjects-server-url $client_req_scheme://$http_host;
-    proxy_set_header x-webobjects-server-port $server_port;
-    client_body_buffer_size 128k;
-    client_max_body_size 0;
-    break;
-  }
-
-  location ^~ /SOGo/dav {
-    include /etc/nginx/conf.d/sogo_dav.active;
+    include /etc/nginx/conf.d/sogo_proxy_auth.active;
+    include /etc/nginx/conf.d/sogo.active;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;

--- a/data/web/sogo-auth.php
+++ b/data/web/sogo-auth.php
@@ -57,8 +57,8 @@ elseif (isset($_GET['login'])) {
 }
 // do not check for admin-login / sogo-sso for EAS and DAV requests, SOGo can check auth itself if no authorization header is set
 elseif (
-    substr($_SERVER['HTTP_X_ORIGINAL_URI'], 0, 28) !== "/Microsoft-Server-ActiveSync" &&
-    substr($_SERVER['HTTP_X_ORIGINAL_URI'], 0, 9) !== "/SOGo/dav"
+  strcasecmp(substr($_SERVER['HTTP_X_ORIGINAL_URI'], 0, 28), "/Microsoft-Server-ActiveSync") == 0 &&
+  strcasecmp(substr($_SERVER['HTTP_X_ORIGINAL_URI'], 0, 9), "/SOGo/dav") == 0
 ) {
   // this is an nginx auth_request call, we check for existing sogo-sso session variables
   session_start();

--- a/data/web/sogo-auth.php
+++ b/data/web/sogo-auth.php
@@ -57,8 +57,8 @@ elseif (isset($_GET['login'])) {
 }
 // do not check for admin-login / sogo-sso for EAS and DAV requests, SOGo can check auth itself if no authorization header is set
 elseif (
-  strcasecmp(substr($_SERVER['HTTP_X_ORIGINAL_URI'], 0, 28), "/Microsoft-Server-ActiveSync") == 0 &&
-  strcasecmp(substr($_SERVER['HTTP_X_ORIGINAL_URI'], 0, 9), "/SOGo/dav") == 0
+  strcasecmp(substr($_SERVER['HTTP_X_ORIGINAL_URI'], 0, 28), "/Microsoft-Server-ActiveSync") !== 0 &&
+  strcasecmp(substr($_SERVER['HTTP_X_ORIGINAL_URI'], 0, 9), "/SOGo/dav") !== 0
 ) {
   // this is an nginx auth_request call, we check for existing sogo-sso session variables
   session_start();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -268,10 +268,9 @@ services:
       command: /bin/sh -c "envsubst < /etc/nginx/conf.d/templates/listen_plain.template > /etc/nginx/conf.d/listen_plain.active &&
         envsubst < /etc/nginx/conf.d/templates/listen_ssl.template > /etc/nginx/conf.d/listen_ssl.active &&
         envsubst < /etc/nginx/conf.d/templates/server_name.template > /etc/nginx/conf.d/server_name.active &&
-        . /etc/nginx/conf.d/templates/sogo.auth_request.template.sh > /etc/nginx/conf.d/sogo_main.active &&
-        envsubst < /etc/nginx/conf.d/templates/sogo.template >> /etc/nginx/conf.d/sogo_main.active &&
-        envsubst < /etc/nginx/conf.d/templates/sogo.template >> /etc/nginx/conf.d/sogo_dav.active &&
+        envsubst < /etc/nginx/conf.d/templates/sogo.template > /etc/nginx/conf.d/sogo.active &&
         envsubst < /etc/nginx/conf.d/templates/sogo_eas.template > /etc/nginx/conf.d/sogo_eas.active &&
+        . /etc/nginx/conf.d/templates/sogo.auth_request.template.sh > /etc/nginx/conf.d/sogo_proxy_auth.active &&
         nginx -qt &&
         until ping phpfpm -c1 > /dev/null; do sleep 1; done &&
         until ping sogo -c1 > /dev/null; do sleep 1; done &&


### PR DESCRIPTION
This took a bit more time than expected @andryyy :

After some more testing with your feedback about DAV, i found out that if SOGoTrustProxyAuthentication is enabled, SOGo will always trust the username in the authorization header and not validate the password..!
This is true for CardDAV, CalDAV and even EAS calendar / contact sync...

So this forces us to always validate the credentials in the Authorization header (if set) at the proxy level.

I implemented this by re-adding the code i previously removed and cleaned everything a bit up.
The additional nginx directive for /SOGo/dav could also be removed again because we have to add auth_request to all SOGo calls anyway.

After validating the Authorization header, it is forwarded correctly to SOGo so there should be no unnecessary credential popups in the email clients.

One thing I'd like you to confirm:
- Does check_login($username, $password) === 'user' properly ensure a valid email login?