### PR TITLE
Downgrade rspamd deb repository

### DIFF
--- a/data/Dockerfiles/rspamd/Dockerfile
+++ b/data/Dockerfiles/rspamd/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
 	gnupg2 \
 	apt-transport-https \
 	&& apt-key adv --fetch-keys https://rspamd.com/apt/gpg.key \
-	&& echo "deb https://rspamd.com/apt/ bionic main" > /etc/apt/sources.list.d/rspamd.list \
+	&& echo "deb https://rspamd.com/apt-stable/ bionic main" > /etc/apt/sources.list.d/rspamd.list \
 	&& apt-get update && apt-get install -y rspamd \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& echo '.include $LOCAL_CONFDIR/local.d/rspamd.conf.local' > /etc/rspamd/rspamd.conf.local \


### PR DESCRIPTION
Hi together,

yesterday the rspamd version has been updated in the master branch by these following three actions:

* Changing deb repository from: deb https://rspamd.com/apt-stable/ to deb https://rspamd.com/apt/ in the Dockerfile of rspamd
* Disabling metadata_exporter.lua script in the Dockerfile of rspamd
* Increasing the rspamd docker image version in the docker-compose.yml file

Shortly after a downgrade commit has been pushed, reverting two of the three actions:

* Enabling metadata_exporter.lua script
* Decreasing the rspamd docker image version number

That means, that if I pull the image, I will get the old (working) version. If I build it, it will build the old version number but with the new deb repository. And this new version is not working for me (at least for me).

So this pull request fixes this by also reverting the third step of the rspamd upgrade.