### PR TITLE
Fix SOGo default access comment 

### DIFF
--- a/data/web/inc/vars.inc.php
+++ b/data/web/inc/vars.inc.php
@@ -141,7 +141,7 @@ $MAILBOX_DEFAULT_ATTRIBUTES['tls_enforce_out'] = false;
 // Force password change on next login (only allows login to mailcow UI)
 $MAILBOX_DEFAULT_ATTRIBUTES['force_pw_update'] = false;
 
-// Force password change on next login (only allows login to mailcow UI)
+// Enable SOGo access (set to false to disable access by default)
 $MAILBOX_DEFAULT_ATTRIBUTES['sogo_access'] = true;
 
 // Send notification when quarantine is not empty (never, hourly, daily, weekly)


### PR DESCRIPTION
While setting up a dev environment of mailcow, I came across a stray comment that needed some fixing. This is a very simple PR, but thought it would be helpful to fix!