### PR TITLE
Fix rejected mails not being quarantized properly if they are tagged

### DIFF
--- a/data/conf/rspamd/meta_exporter/pipe.php
+++ b/data/conf/rspamd/meta_exporter/pipe.php
@@ -84,6 +84,9 @@ $rcpt_final_mailboxes = array();
 
 // Loop through all rcpts
 foreach (json_decode($rcpts, true) as $rcpt) {
+  // Remove tag
+  $rcpt = preg_replace('/^(.*?)\+.*(@.*)$/', '$1$2', $rcpt);
+  
   // Break rcpt into local part and domain part
   $parsed_rcpt = parse_email($rcpt);
   


### PR DESCRIPTION
Mails sent to mailbox+something@example.com that got rejected by rspamd do not show up in the quarantine, because the [alias resolution in pipe.php](https://github.com/OpenLarry/mailcow-dockerized/blob/40a826a3471db61349eb64f58dd35bdddd0ae19e/data/conf/rspamd/meta_exporter/pipe.php#L122-L134) doesn't find any mailboxes.

This PR solves the issue by removing the tag from the local part of the address before resolving aliases.
