### PR TITLE
revert solr config change

### DIFF
--- a/data/conf/solr/solr-schema-7.7.0.xml
+++ b/data/conf/solr/solr-schema-7.7.0.xml
@@ -18,6 +18,7 @@
     </analyzer>
     <analyzer type="query">
       <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.EdgeNGramFilterFactory" minGramSize="3" maxGramSize="20"/>
       <filter class="solr.SynonymGraphFilterFactory" expand="true" ignoreCase="true" synonyms="synonyms.txt"/>
       <filter class="solr.FlattenGraphFilterFactory"/>
       <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="true"/>


### PR DESCRIPTION
reverts https://github.com/mailcow/mailcow-dockerized/pull/2417

no more search results shown after removing EdgeNGramFilterFactory from query part of solr scheme,
this reverts the change and puts EdgeNGramFilterFactory back 
