### PR TITLE
Only generate a LE certificate for domains that have a mailbox

### DIFF
--- a/data/Dockerfiles/acme/docker-entrypoint.sh
+++ b/data/Dockerfiles/acme/docker-entrypoint.sh
@@ -256,7 +256,7 @@ while true; do
   # IP and webroot challenge verification #
   while read domains; do
     SQL_DOMAIN_ARR+=("${domains}")
-  done < <(mysql --socket=/var/run/mysqld/mysqld.sock -u ${DBUSER} -p${DBPASS} ${DBNAME} -e "SELECT domain FROM domain WHERE backupmx=0" -Bs)
+  done < <(mysql --socket=/var/run/mysqld/mysqld.sock -u ${DBUSER} -p${DBPASS} ${DBNAME} -e "SELECT d.domain as domain from domain d left join (select domain, count(username) as mailboxes from mailbox group by domain) m on m.domain = d.domain where m.mailboxes > 0 and d.backupmx=0" -Bs)
 
   for SQL_DOMAIN in "${SQL_DOMAIN_ARR[@]}"; do
     for SUBDOMAIN in "${ADDITIONAL_WC_ARR[@]}"; do


### PR DESCRIPTION
This SQL query will just provide Domains that have a Mailbox created.
With this change we can reduce the amount of certificate requests that are not necessary.