### PR TITLE
Fixing #2555 by updating Dockerfile to use the correct dovecot.org url (and fixing the http 304 curl redirect problem)

### DIFF
--- a/data/Dockerfiles/dovecot/Dockerfile
+++ b/data/Dockerfiles/dovecot/Dockerfile
@@ -78,7 +78,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
   syslog-ng-core \
   syslog-ng-mod-redis \
   && rm -rf /var/lib/apt/lists/* \
-  && curl https://www.dovecot.org/releases/2.3/dovecot-$DOVECOT_VERSION.tar.gz | tar xvz  \
+  && curl https://dovecot.org/releases/2.3/dovecot-$DOVECOT_VERSION.tar.gz | tar xvz  \
   && cd dovecot-$DOVECOT_VERSION \
   && ./configure --with-solr --with-mysql --with-ldap --with-lzma --with-lz4 --with-ssl=openssl --with-notify=inotify --with-storages=mdbox,sdbox,maildir,mbox,imapc,pop3c --with-bzlib --with-zlib --enable-hardening \
   && make -j3 \


### PR DESCRIPTION
Just a quick fix to have to dovecot image in a buildable state again :)