### PR TITLE
Added domain alias handling to quarantine mails and added recipients row to quarantine mail display

### DIFF
--- a/data/web/css/site/quarantine.css
+++ b/data/web/css/site/quarantine.css
@@ -49,3 +49,11 @@ table.footable>tbody>tr.footable-empty>td {
   border-radius: 50%;
   display: inline-block;
 }
+
+span.mail-address-item {
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  padding: 2px 7px;
+  margin-right: 7px;
+}

--- a/data/web/js/site/quarantine.js
+++ b/data/web/js/site/quarantine.js
@@ -87,8 +87,16 @@ jQuery(function($){
         $('#qid_detail_text').text(data.text_plain);
         $('#qid_detail_text_from_html').text(data.text_html);
 
+        $('#qid_detail_recipients').html('');
+        if (typeof data.recipients !== 'undefined') {
+          $.each(data.recipients, function(index, value) {
+            var displayStr = value.address + (value.type != 'to' ? (' (' + value.type.toUpperCase() + ')') : '');
+            $('#qid_detail_recipients').append('<span class="mail-address-item")>' + displayStr + '</span>');
+          });
+        }
+
+        var qAtts = $("#qid_detail_atts");
         if (typeof data.attachments !== 'undefined') {
-          qAtts = $("#qid_detail_atts");
           qAtts.text('');
           $.each(data.attachments, function(index, value) {
             qAtts.append(

--- a/data/web/js/site/quarantine.js
+++ b/data/web/js/site/quarantine.js
@@ -90,8 +90,9 @@ jQuery(function($){
         $('#qid_detail_recipients').html('');
         if (typeof data.recipients !== 'undefined') {
           $.each(data.recipients, function(index, value) {
-            var displayStr = value.address + (value.type != 'to' ? (' (' + value.type.toUpperCase() + ')') : '');
-            $('#qid_detail_recipients').append('<span class="mail-address-item")>' + displayStr + '</span>');
+            var elem = $('<span class="mail-address-item"></span>');
+            elem.text(value.address + (value.type != 'to' ? (' (' + value.type.toUpperCase() + ')') : ''));
+            $('#qid_detail_recipients').append(elem);
           });
         }
 

--- a/data/web/lang/lang.ca.php
+++ b/data/web/lang/lang.ca.php
@@ -498,6 +498,7 @@ $lang['quarantine']['show_item'] = "Mostrar";
 $lang['quarantine']['check_hash'] = "Comprovar el hash del fitxer a VT";
 $lang['quarantine']['qitem'] = "Element en quarantena";
 $lang['quarantine']['subj'] = "Assumpte";
+$lang['quarantine']['recipients'] = "Recipients";
 $lang['quarantine']['text_plain_content'] = "Contingut (text/plain)";
 $lang['quarantine']['text_from_html_content'] = "Contingut (a partir del HTML)";
 $lang['quarantine']['atts'] = "Adjunts";

--- a/data/web/lang/lang.cs.php
+++ b/data/web/lang/lang.cs.php
@@ -712,6 +712,7 @@ $lang['quarantine']['show_item'] = "Zobrazit položku";
 $lang['quarantine']['check_hash'] = "Hledat hash @ VT souboru";
 $lang['quarantine']['qitem'] = "Položka v karanténě";
 $lang['quarantine']['subj'] = "Předmět";
+$lang['quarantine']['recipients'] = "Příjemci";
 $lang['quarantine']['text_plain_content'] = "Obsah (text/plain)";
 $lang['quarantine']['text_from_html_content'] = "Obsah (konvertované html)";
 $lang['quarantine']['atts'] = "Přílohy";

--- a/data/web/lang/lang.de.php
+++ b/data/web/lang/lang.de.php
@@ -732,6 +732,7 @@ $lang['quarantine']['show_item'] = "Details";
 $lang['quarantine']['check_hash'] = "Checksumme auf VirusTotal suchen";
 $lang['quarantine']['qitem'] = "Quarantäneeintrag";
 $lang['quarantine']['subj'] = "Betreff";
+$lang['quarantine']['recipients'] = "Empfänger";
 $lang['quarantine']['text_plain_content'] = "Inhalt (text/plain)";
 $lang['quarantine']['text_from_html_content'] = "Inhalt (html, konvertiert)";
 $lang['quarantine']['atts'] = "Anhänge";

--- a/data/web/lang/lang.en.php
+++ b/data/web/lang/lang.en.php
@@ -754,6 +754,7 @@ $lang['quarantine']['show_item'] = "Show item";
 $lang['quarantine']['check_hash'] = "Search file hash @ VT";
 $lang['quarantine']['qitem'] = "Quarantine item";
 $lang['quarantine']['subj'] = "Subject";
+$lang['quarantine']['recipients'] = "Recipients";
 $lang['quarantine']['text_plain_content'] = "Content (text/plain)";
 $lang['quarantine']['text_from_html_content'] = "Content (converted html)";
 $lang['quarantine']['atts'] = "Attachments";

--- a/data/web/lang/lang.lv.php
+++ b/data/web/lang/lang.lv.php
@@ -494,6 +494,7 @@ $lang['quarantine']['show_item'] = "Parādīt vienumus";
 $lang['quarantine']['check_hash'] = "Meklēt faila hašu @ VT";
 $lang['quarantine']['qitem'] = "Karantīnas vienumi";
 $lang['quarantine']['subj'] = "Priekšmets";
+$lang['quarantine']['recipients'] = "Adresāts";
 $lang['quarantine']['text_plain_content'] = "Saturs (teksts/vienkāršs)";
 $lang['quarantine']['text_from_html_content'] = "Saturs (konvertēts html)";
 $lang['quarantine']['atts'] = "Pielikumi";

--- a/data/web/lang/lang.nl.php
+++ b/data/web/lang/lang.nl.php
@@ -731,6 +731,7 @@ $lang['quarantine']['show_item'] = "Laat item zien";
 $lang['quarantine']['check_hash'] = "Zoek bestandshash op in VT";
 $lang['quarantine']['qitem'] = "Quarantaine-item";
 $lang['quarantine']['subj'] = "Onderwerp";
+$lang['quarantine']['recipients'] = "Ontvangers";
 $lang['quarantine']['text_plain_content'] = "Inhoud (tekst)";
 $lang['quarantine']['text_from_html_content'] = "Inhoud (geconverteerde html)";
 $lang['quarantine']['atts'] = "Bijlagen";

--- a/data/web/modals/quarantine.php
+++ b/data/web/modals/quarantine.php
@@ -18,6 +18,10 @@ if (!isset($_SESSION['mailcow_cc_role'])) {
           <p id="qid_detail_subj"></p>
         </div>
         <div class="form-group">
+          <label for="qid_detail_recipients"><h4><?=$lang['quarantine']['recipients'];?>:</h4></label>
+          <p id="qid_detail_recipients"></p>
+        </div>
+        <div class="form-group">
           <label for="qid_detail_text"><h4><?=$lang['quarantine']['text_plain_content'];?>:</h4></label>
           <pre id="qid_detail_text"></pre>
         </div>


### PR DESCRIPTION
If a mail is sent to a domain alias domain and rejected, mailcow does not currently store the mail in quarantine.
This commit adds domain alias handling to the reject code and should fix this behavior.

Also added displaying of recipient addresses into the quarantine mail dialog to be able to see what mail address was "leaked".

Dialog:
![image](https://user-images.githubusercontent.com/1498918/56998885-47d27580-6bad-11e9-88b6-09e853282e0c.png)
