### PR TITLE
Update Dovecot to v2.3.6 and Pigeonhole to v0.5.6

### DIFF
--- a/data/Dockerfiles/dovecot/Dockerfile
+++ b/data/Dockerfiles/dovecot/Dockerfile
@@ -3,8 +3,8 @@ LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL C
-ENV DOVECOT_VERSION 2.3.5.2
-ENV PIGEONHOLE_VERSION 0.5.5
+ENV DOVECOT_VERSION 2.3.6
+ENV PIGEONHOLE_VERSION 0.5.6
 
 RUN apt-get update && apt-get -y --no-install-recommends install \
   automake \


### PR DESCRIPTION
This is my first PR to mailcow-dockerized, so please be patient...

Update Dovecot to v2.3.6 (full [changelog](https://dovecot.org/list/dovecot-news/2019-April/000408.html)):
```
* CVE-2019-11494: Submission-login crashed with signal 11 due to null pointer access when authentication was aborted by disconnecting.
* CVE-2019-11499: Submission-login crashed when authentication was started over TLS secured channel and invalid authentication message was sent.
...
```

Update Pigeonhole to v0.5.6 (see [NEWS](https://raw.githubusercontent.com/dovecot/pigeonhole/0.5.6/NEWS)):
```
	+ sieve: Redirect loop prevention is sometimes ineffective. Improve
	  existing loop detection by also recognizing the
	  X-Sieve-Redirected-From header in incoming messages and dropping
	  redirect actions when it points to the sending account. This header
	  is already added by the redirect action, so this improvement only
	  adds an additional use of this header.
	- sieve: Prevent execution of implicit keep upon temporary failure
	  occurring at runtime.
```