### PR TITLE
imapsync command execution changed

### DIFF
--- a/data/Dockerfiles/dovecot/imapsync_cron.pl
+++ b/data/Dockerfiles/dovecot/imapsync_cron.pl
@@ -146,7 +146,6 @@ while ($row = $sth->fetchrow_arrayref()) {
     $update = $dbh->prepare("UPDATE imapsync SET last_run = NOW(), is_running = 0 WHERE id = ?");
     $update->bind_param( 1, ${id} );
     $update->execute();
-    $lockmgr->unlock($lock_file);
   };
 
 

--- a/data/Dockerfiles/dovecot/imapsync_cron.pl
+++ b/data/Dockerfiles/dovecot/imapsync_cron.pl
@@ -93,10 +93,6 @@ while ($row = $sth->fetchrow_arrayref()) {
   $timeout1            = @$row[19];
   $timeout2            = @$row[20];
 
-  $is_running = $dbh->prepare("UPDATE imapsync SET is_running = 1 WHERE id = ?");
-  $is_running->bind_param( 1, ${id} );
-  $is_running->execute();
-
   if ($enc1 eq "TLS") { $enc1 = "--tls1"; } elsif ($enc1 eq "SSL") { $enc1 = "--ssl1"; } else { undef $enc1; }
 
   my $template = $run_dir . '/imapsync.XXXXXXX';
@@ -134,6 +130,9 @@ while ($row = $sth->fetchrow_arrayref()) {
   ($custom_params eq "" ? () : ($command .= qq` ${custom_params}`));
 
   try {
+    $is_running = $dbh->prepare("UPDATE imapsync SET is_running = 1 WHERE id = ?");
+    $is_running->bind_param( 1, ${id} );
+    $is_running->execute();
     my $stdout = `${command}`
     $update = $dbh->prepare("UPDATE imapsync SET returned_text = ?, last_run = NOW(), is_running = 0 WHERE id = ?");
     $update->bind_param( 1, ${stdout} );

--- a/data/Dockerfiles/dovecot/imapsync_cron.pl
+++ b/data/Dockerfiles/dovecot/imapsync_cron.pl
@@ -140,11 +140,16 @@ while ($row = $sth->fetchrow_arrayref()) {
     $update->bind_param( 2, ${id} );
     $update->execute();
   } catch {
-    $update = $dbh->prepare("UPDATE imapsync SET returned_text = 'Could not start or finish imapsync', last_run = NOW(), is_running = 0 WHERE id = ?");
+    $update = $dbh->prepare("UPDATE imapsync SET returned_text = 'Could not start or finish imapsync' WHERE id = ?");
+    $update->bind_param( 1, ${id} );
+    $update->execute();
+  } finally {
+    $update = $dbh->prepare("UPDATE imapsync SET last_run = NOW(), is_running = 0 WHERE id = ?");
     $update->bind_param( 1, ${id} );
     $update->execute();
     $lockmgr->unlock($lock_file);
   };
+
 
 }
 

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -3,7 +3,7 @@ function init_db_schema() {
   try {
     global $pdo;
 
-    $db_version = "30032019_1905";
+    $db_version = "04052019_1210";
 
     $stmt = $pdo->query("SHOW TABLES LIKE 'versions'");
     $num_results = count($stmt->fetchAll(PDO::FETCH_ASSOC));
@@ -502,7 +502,7 @@ function init_db_schema() {
           "timeout2" => "SMALLINT NOT NULL DEFAULT '600'",
           "subscribeall" => "TINYINT(1) NOT NULL DEFAULT '1'",
           "is_running" => "TINYINT(1) NOT NULL DEFAULT '0'",
-          "returned_text" => "MEDIUMTEXT",
+          "returned_text" => "LONGTEXT",
           "last_run" => "TIMESTAMP NULL DEFAULT NULL",
           "created" => "DATETIME(0) NOT NULL DEFAULT NOW(0)",
           "modified" => "DATETIME ON UPDATE CURRENT_TIMESTAMP",


### PR DESCRIPTION
The imapsync_cron.pl script changed to solve users expectation of the provided parameters.
The execution of imapsync command line is now combined one command string instead of array of parameters. This allows the users to use special characters (like " ' | { } space) in the Username, Sync into subfolder on destination, Exclude objects (regex) and Custom parameters fields.
The user must now use quotes string values, like they already expected in the first place. It behaves now as if the parameters are provided on the CLI.
Example Custom parameters: --addheader --resyncflags --f1f2 "Deleted Messages"=Trash
Solve issues: #2534, #2017

Other fixes:
- Removed second unlock file statement
- Changed database schema: In table imapsync with column returned_text type has been changed into longtext. When imapsync is running on a large mailbox and for example --debugflags parameter has been provided then the returned_text output can be >16Mb.
- Changed the setting "is_running" status. There was a possibility to stuck into running state when an exception occurred.