### PR TITLE
"Repaired" shebang for check_translations.rb

### DIFF
--- a/helper-scripts/check_translations.rb
+++ b/helper-scripts/check_translations.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 MASTER="en"
 


### PR DESCRIPTION
Most work was done in 7dc0a05a71d958918644339649ac6874c821eacb, though
the `check_translation.rb` still had a hardcoded shebang. This is now
fixed.