### PR TITLE
Faster backup and restore

### DIFF
--- a/data/Dockerfiles/archiver/Dockerfile
+++ b/data/Dockerfiles/archiver/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:latest
+RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+	    tar mariadb-client zstd 


### PR DESCRIPTION
This is my proposal to speed up the backup and restore process. Any feedback is welcome :smile:

<details>
   <summary>Questions already answered</summary> 
### What compression to choose?
I considered `gzip`, `xz` and `bzip2`. I chose `bzip2`, because it is common enough to have its own flag in gnutar ( `-j`) and seems to offer a good compromise between compression time, decompression time and compression ratio, but I'm open to hear your opinion on this topic.

### What Tape Archiver to use?
Most people will opt for gnutar, because they are used to it. And its highly available. Somehow I made the discovery, that gnutar was by far slower in comparision to schily tar, when only creating tar archives (without compression at all). However, this has to be investigated more, a friend of mine had contradictory findings when comparing the two on his system. This seems to be a second order priority, right now the big margin in speed can be made using a parallel, fast compression algo, IMHO.

Please share your thoughts on this.

### Update 1

After some testing, I came to the conclusion that there is no measurable benefit in using schily tar, performance wise. So probably gnutar will do fine.

</details>
<details> 
  <summary>Measurements of questionable accuracy</summary> 

### Update 2

Did some initial measurement using the current solution:
```
1.66s user 1.54s system 0% cpu 21:55.73 total
total 9.6G
517 backup_crypt.tar.gz
2.1M backup_mysql.gz
1.4K backup_postfix.tar.gz
9.9M backup_redis.tar.gz
3.8M backup_rspamd.tar.gz
9.6G backup_vmail.tar.gz
4.2K mailcow.conf
```

### Update 3

Using `lbzip2`, I got better results:
```
1.92s user 1.54s system 0% cpu 10:23.68 total
total 9.5G
1.2K backup_postfix.tar.bz2
9.2M backup_redis.tar.bz2
3.3M backup_rspamd.tar.bz2
9.5G backup_vmail.tar.bz2
4.2K mailcow.conf
```

### Update 4

Using `lz4`, I got more results:
```
1.67s user 1.58s system 0% cpu 5:30.03 total
total 13G

1.2K backup_postfix.tar.bz2
9.2M backup_redis.tar.bz2
3.3M backup_rspamd.tar.bz2
9.5G backup_vmail.tar.bz2
4.2K mailcow.conf
```

### Update 5
Obviously some volumes where missing in the above tests. I'm going to focus on `vmail` only for now, as it is probably the biggest volume for most people.

</details>

### Benchmark based on vmail
|compressor|time result|file size|
|---|---|---|
|`zstd -T0`|4:18.01|9.4G|
|none (only tar)|4:52.28|14G|
|`lz4 -2`|4:57.72|13G|
| `lz4`| 5:11.35 |13G|
|`pigz`| 6:00.88 |9.6G|
|`lbzip2`|10:09.34|9.5G|
|`zstd -T0 --adapt`|24:50.76|9.1G|
|`pixz`| I stopped it after 35 minutes|7.7G|

### Worth noting

+ omitting `--verbose` on tar gives a small performance boost
+ `lz4` is almost as fast as no compressor at all both for compression and decompression
+ ~to get 100% cpu usage with `lz4`, your storage will have to be extremely fast~
+ `lz4` is really fast, but does not support multi threading.
+ `lbzip2` gives me 100% load on all cores
+ `pixz` with default options is stronger than my patience 
+ `zstd --adapt` does not help in our use case
+ `zstd -T0` is my favorite (below 100% cpu usage, fast, good compression)

My explanation regarding `zstd -T0` being faster as plain tar is this: writing costs speed, so if your disk writes more, you have less read performance. So comes that `tar` + `zstd` being faster than plain tar, because more disk IO is available for reading.

### Conclusion

We should use `zstd`.

### Note

Currently, the sql dump is not compressed. The reason is simple: in contrast to all other backup processes, the image used for creating the dumps is not arbitrary. We do use exactly the same image, which also hosts the database in production. This image unfortunately does not come with `zstd`. A way to workaround this would be to run another image after creating the dump, which then compresses it. Taking into account, that most mysql dumps tend to be quiet small, this is of questionable value. However, I'm open to hear your feedback on this.