### PR TITLE
Update update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -260,7 +260,7 @@ for option in ${CONFIG_ARRAY[@]}; do
 done
 
 echo -en "Checking internet connection... "
-timeout 3 ping -c 1 8.8.8.8 > /dev/null
+timeout 3 ping -c 1 9.9.9.9 > /dev/null
 if [[ $? != 0 ]]; then
   echo -e "\e[31mfailed\e[0m"
   exit 1

--- a/update.sh
+++ b/update.sh
@@ -260,7 +260,7 @@ for option in ${CONFIG_ARRAY[@]}; do
 done
 
 echo -en "Checking internet connection... "
-curl -o /dev/null 1.1.1.1 -sm3
+timeout 3 ping -c 1 8.8.8.8 > /dev/null
 if [[ $? != 0 ]]; then
   echo -e "\e[31mfailed\e[0m"
   exit 1


### PR DESCRIPTION
*curl* on some systems is failing due to no URL specified (1.1.1.1) and ISP blocking

*curl* needs an URL for working correctly, so sometimes it is failing as it detects **No Internet connection** but there is. In addition, at some countries some ISP did not update their routers and/or network so the Cloudflare DNS `1.1.1.1` are not working either they are blocked. I suggest using `ping` instead of `curl` with a 3 seconds timeout and pinging to Google DNS (8.8.8.8) instead of Cloudflare ones, as they are universally accepted and used.