### PR TITLE
[Web] Fix showing domain with disabled sender check

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -676,7 +676,7 @@ function user_get_alias_details($username) {
   while ($row = array_shift($run)) {
     $data['aliases_also_send_as'] = $row['send_as'];
   }
-  $stmt = $pdo->prepare("SELECT IFNULL(CONCAT(GROUP_CONCAT(DISTINCT `send_as` SEPARATOR ', '), ', ', GROUP_CONCAT(DISTINCT CONCAT('@',`alias_domain`) SEPARATOR ', ')), '&#10008;') AS `send_as` FROM `sender_acl` LEFT JOIN `alias_domain` ON `alias_domain`.`target_domain` =  TRIM(LEADING '@' FROM `send_as`) WHERE `logged_in_as` = :username AND `send_as` LIKE '@%';");
+  $stmt = $pdo->prepare("SELECT CONCAT_WS(', ', IFNULL(GROUP_CONCAT(DISTINCT `send_as` SEPARATOR ', '), '&#10008;'), GROUP_CONCAT(DISTINCT CONCAT('@',`alias_domain`) SEPARATOR ', ')) AS `send_as` FROM `sender_acl` LEFT JOIN `alias_domain` ON `alias_domain`.`target_domain` =  TRIM(LEADING '@' FROM `send_as`) WHERE `logged_in_as` = :username AND `send_as` LIKE '@%';");
   $stmt->execute(array(':username' => $username));
   $run = $stmt->fetchAll(PDO::FETCH_ASSOC);
   while ($row = array_shift($run)) {


### PR DESCRIPTION
If a mailbox is allowed to send as any address under its domain (+ alias
domains) and the domain itself has no aliases configured, no information
about this fact is shown to the user. That is to say, the "Do not check
sender access for the following domain(s) and its alias domains" field
under mailbox details is empty.

The above is happening because the second GROUP_CONCAT() returns NULL
making the enclosing CONCAT() return NULL as well. Fix this by using
CONCAT_WS() which correctly handles the case of zero domain aliases.

Furthermore, move the IFNULL() to the first GROUP_CONCAT() because
CONCAT_WS() returns an empty string when both GROUP_CONCAT()'s are
NULL. We can be certain that when the first GROUP_CONCAT() is NULL
the second one will be as well, so it's safe to use IFNULL() there.