### PR TITLE
Update phpfpm baseimage from alpine 3.8 to 3.9

### DIFF
--- a/data/Dockerfiles/phpfpm/Dockerfile
+++ b/data/Dockerfiles/phpfpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-fpm-alpine3.8
+FROM php:7.3-fpm-alpine3.9
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
 ENV APCU_PECL 5.1.16


### PR DESCRIPTION
Since I didn't find a reason why Alpine 3.8 is still used here, I created a PR with Alpine 3.9, because Alpine 3.9 is also used in this project. 