### PR TITLE
Increase db version for merge #2594

### DIFF
--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -3,7 +3,7 @@ function init_db_schema() {
   try {
     global $pdo;
 
-    $db_version = "04052019_1210";
+    $db_version = "09062019_1208";
 
     $stmt = $pdo->query("SHOW TABLES LIKE 'versions'");
     $num_results = count($stmt->fetchAll(PDO::FETCH_ASSOC));


### PR DESCRIPTION
With Merge #2594 the database init script was adapted, but the version was not increased.
Existing Mailcow installations will not update the database.

Every mailcow instance that has been updated causes an SQL error when opening the domain overview.