### PR TITLE
[Rspamd] Enable history compression

### DIFF
--- a/data/conf/rspamd/local.d/history_redis.conf
+++ b/data/conf/rspamd/local.d/history_redis.conf
@@ -1,1 +1,2 @@
 nrows = 1000;
+compress = true;


### PR DESCRIPTION
This PR enables the history compression for Rspamd as documented here: 
https://www.rspamd.com/doc/modules/history_redis.html