### PR TITLE
Create sieve filter to drop mail if user has catch-all active

### DIFF
--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -65,8 +65,8 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           if($count > 0){
             $stmt = $pdo->prepare("INSERT INTO `sieve_filters` (`username`, `script_data`, `script_desc`, `script_name`, `filter_type`)
             VALUES (:username, :script_data, :script_desc, :script_name, :filter_type)");
-            $prefilter_tempEmail = 'if address :is "To" "' .  $temp_email . '" {
-              discard;
+            $prefilter_tempEmail = 'require ["reject"];if address :is "To" "' .  $temp_email . '" {
+              reject "Not Accepted";
             }';
             $stmt->execute(array(
               ':username' => $username,

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -71,8 +71,8 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             $stmt->execute(array(
               ':username' => $username,
               ':script_data' => $prefilter_tempEmail,
-              ':script_desc' => "Temp email " . $temp_email  ." drop",
-              ':script_name' => "active",
+              ':script_desc' => $temp_email . " drop",
+              ':script_name' => "inactive",
               ':filter_type' => "prefilter"
             ));
           }

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -44,18 +44,38 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             return false;
           }
           $stmt = $pdo->prepare("SELECT `domain` FROM `mailbox` WHERE `username` = :username");
-          $stmt->execute(array(':username' => $_SESSION['mailcow_cc_username']));
+          $username = $_SESSION['mailcow_cc_username'];
+          $stmt->execute(array(':username' => $username));
           $domain = $stmt->fetch(PDO::FETCH_ASSOC)['domain'];
           $validity = strtotime("+".$_data["validity"]." hour"); 
           $letters = 'abcefghijklmnopqrstuvwxyz1234567890';
           $random_name = substr(str_shuffle($letters), 0, 24);
+          $temp_email = ($random_name . '@' . $domain);
           $stmt = $pdo->prepare("INSERT INTO `spamalias` (`address`, `goto`, `validity`) VALUES
             (:address, :goto, :validity)");
           $stmt->execute(array(
-            ':address' => $random_name . '@' . $domain,
+            ':address' => $temp_email,
             ':goto' => $username,
             ':validity' => $validity
           ));
+          $stmt = $pdo->prepare("SELECT `id` FROM `alias` WHERE `address`=:domain AND `goto` = :username");
+          $stmt->execute(array(':username' => $username, ':domain' => '@' . $domain));
+          $count =  $stmt->rowCount();
+          
+          if($count > 0){
+            $stmt = $pdo->prepare("INSERT INTO `sieve_filters` (`username`, `script_data`, `script_desc`, `script_name`, `filter_type`)
+            VALUES (:username, :script_data, :script_desc, :script_name, :filter_type)");
+            $prefilter_tempEmail = 'if address :is "To" "' .  $temp_email . '" {
+              discard;
+            }';
+            $stmt->execute(array(
+              ':username' => $username,
+              ':script_data' => $prefilter_tempEmail,
+              ':script_desc' => "Temp email " . $temp_email  ." drop",
+              ':script_name' => "active",
+              ':filter_type' => "prefilter"
+            ));
+          }
           $_SESSION['return'][] = array(
             'type' => 'success',
             'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -971,6 +971,7 @@ DELIMITER //
 CREATE EVENT clean_spamalias 
 ON SCHEDULE EVERY 1 DAY DO 
 BEGIN
+  UPDATE sieve_filters SET script_name = \'active\' WHERE left(script_desc, LENGTH(script_desc)-5) IN (select address from spamalias where validity < UNIX_TIMESTAMP());
   DELETE FROM spamalias WHERE validity < UNIX_TIMESTAMP();
 END;
 //


### PR DESCRIPTION
Hi.

The purpose of temporary email aliases is that they don't bug you anymore after its time period has expired, I noticed however that if the user has a catch-all active for a domain to his account, this will of course not work and emails to the generated email addresses aren't dropped but will be delivered to the user.

This code checks, after creating the temp email, if the user has a catch-all that is redirected to his email address. If this is the case, the code will create a pre-filter sieve to drop any emails to this temp address.