### PR TITLE
fix(imapsync): Delete from source when completed

### DIFF
--- a/data/Dockerfiles/dovecot/imapsync_cron.pl
+++ b/data/Dockerfiles/dovecot/imapsync_cron.pl
@@ -133,7 +133,7 @@ while ($row = $sth->fetchrow_arrayref()) {
   ($maxbytespersecond eq "0" ? () : ('--maxbytespersecond', $maxbytespersecond)),
   ($delete2duplicates ne "1" ? () : ('--delete2duplicates')),
   ($subscribeall  ne "1" ? () : ('--subscribeall')),
-  ($delete1 ne "1" ? () : ('--delete')),
+  ($delete1 ne "1" ? () : ('--delete1')),
   ($delete2 ne "1" ? () : ('--delete2')),
   ($automap ne "1" ? () : ('--automap')),
   ($skipcrossduplicates ne "1" ? () : ('--skipcrossduplicates')),


### PR DESCRIPTION
Change the argument from --delete to --delete1

I noticed this functionality wasn't working and discovered that --delete does not exist (https://imapsync.lamiral.info/README). I believe it should be --delete1

**Update**

Turns out this is not working for me for other unknown reasons. `--delete` and `--delete1` are aliases.

Still, consider merging this change as it's recommended to use `--delete1`.

From the release notes:

> Usability: Options --delete1 and --delete are now aliases. Option --delete1 is preferable over --delete (--delete is still supported).