### PR TITLE
Remove score from R_DKIM_PERMFAIL

### DIFF
--- a/data/conf/rspamd/local.d/policies_group.conf
+++ b/data/conf/rspamd/local.d/policies_group.conf
@@ -11,9 +11,6 @@ symbols = {
     "R_DKIM_REJECT" {
         score = 10.0;
     }
-    "R_DKIM_PERMFAIL" {
-        score = 10.0;
-    }
     "DMARC_POLICY_REJECT" {
         weight = 20.0;
         description = "DMARC reject policy";


### PR DESCRIPTION
This error happens when there is no public key in DNS for that selector. According to RFC 6376, such a signature should silently be ignored. If no other signature is present, the message should be treated as unsigned.

> In the following description, text reading "return status
   (explanation)" (where "status" is one of "PERMFAIL" or "TEMPFAIL")
   means that the Verifier MUST immediately cease processing that
   signature.  The Verifier SHOULD proceed to the next signature, if one
> is present, and completely ignore the bad signature.

> 3. If the query for the public key fails because the corresponding
       key record does not exist, the Verifier MUST immediately return
       PERMFAIL (no key for signature).

> 5. If the result returned from the query does not adhere to the
       format defined in this specification, the Verifier MUST ignore
       the key record and return PERMFAIL (key syntax error).

Fixes #2785 
