### PR TITLE
Ignore DKIM/SPF/DMARC scores on mailing lists

### DIFF
--- a/data/conf/rspamd/local.d/composites.conf
+++ b/data/conf/rspamd/local.d/composites.conf
@@ -26,3 +26,9 @@ OLEFY_MACRO {
   score = 20.0;
   policy = "remove_weight";
 }
+# If we have MAILLIST, ignore positive failures of DKIM, SPF and DMARC failures
+# Removing weight causes the symbol to be added, but simply with a rating of zero.
+MAILLIST_RATING {
+  expression = "MAILLIST & (g+:dkim | g+:spf | g+:dmarc)";
+  policy = "remove_weight";
+}


### PR DESCRIPTION
Removing weight and leaving symbol intact makes it easier to debug