### PR TITLE
Remove DMARC descriptions from polices_group

### DIFF
--- a/data/conf/rspamd/local.d/policies_group.conf
+++ b/data/conf/rspamd/local.d/policies_group.conf
@@ -16,14 +16,11 @@ symbols = {
     }
     "DMARC_POLICY_REJECT" {
         weight = 20.0;
-        description = "DMARC reject policy";
     }
     "DMARC_POLICY_QUARANTINE" {
         weight = 10.0;
-        description = "DMARC quarantine policy";
     }
     "DMARC_POLICY_SOFTFAIL" {
         weight = 2.0;
-        description = "DMARC failed";
     }
 }


### PR DESCRIPTION
Remove descriptions as they are inherited from the default rspamd configuration anyway