### PR TITLE
Multiply instances

### DIFF
--- a/data/Dockerfiles/acme/docker-entrypoint.sh
+++ b/data/Dockerfiles/acme/docker-entrypoint.sh
@@ -60,9 +60,9 @@ mkdir -p ${ACME_BASE}/acme
 reload_configurations(){
   # Reading container IDs
   # Wrapping as array to ensure trimmed content when calling $NGINX etc.
-  local NGINX=($(curl --silent --insecure https://dockerapi/containers/json | jq -r '.[] | {name: .Config.Labels["com.docker.compose.service"], id: .Id}' | jq -rc 'select( .name | tostring | contains("nginx-mailcow")) | .id' | tr "\n" " "))
-  local DOVECOT=($(curl --silent --insecure https://dockerapi/containers/json | jq -r '.[] | {name: .Config.Labels["com.docker.compose.service"], id: .Id}' | jq -rc 'select( .name | tostring | contains("dovecot-mailcow")) | .id' | tr "\n" " "))
-  local POSTFIX=($(curl --silent --insecure https://dockerapi/containers/json | jq -r '.[] | {name: .Config.Labels["com.docker.compose.service"], id: .Id}' | jq -rc 'select( .name | tostring | contains("postfix-mailcow")) | .id' | tr "\n" " "))
+  local NGINX=($(curl --silent --insecure https://dockerapi/containers/json | jq -r ".[] | select(.Config.Labels[\"com.docker.compose.project\"] == \"$COMPOSE_PROJECT_NAME\") | select(.Config.Labels[\"com.docker.compose.service\"] == \"nginx-mailcow\") | .Id"))
+  local DOVECOT=($(curl --silent --insecure https://dockerapi/containers/json | jq -r ".[] | select(.Config.Labels[\"com.docker.compose.project\"] == \"$COMPOSE_PROJECT_NAME\") | select(.Config.Labels[\"com.docker.compose.service\"] == \"dovecot-mailcow\") | .Id"))
+  local POSTFIX=($(curl --silent --insecure https://dockerapi/containers/json | jq -r ".[] | select(.Config.Labels[\"com.docker.compose.project\"] == \"$COMPOSE_PROJECT_NAME\") | select(.Config.Labels[\"com.docker.compose.service\"] == \"postfix-mailcow\") | .Id"))
   # Reloading
   echo "Reloading Nginx..."
   NGINX_RELOAD_RET=$(curl -X POST --insecure https://dockerapi/containers/${NGINX}/exec -d '{"cmd":"reload", "task":"nginx"}' --silent -H 'Content-type: application/json' | jq -r .type)

--- a/data/Dockerfiles/dovecot/sa-rules.sh
+++ b/data/Dockerfiles/dovecot/sa-rules.sh
@@ -13,10 +13,7 @@ if [[ -f /tmp/sa-rules.tar.gz ]]; then
   cat /tmp/sa-rules-heinlein/*cf > /etc/rspamd/custom/sa-rules-heinlein
   # Only restart rspamd-mailcow when rules changed
   if [[ $(cat /etc/rspamd/custom/sa-rules-heinlein | md5sum | cut -d' ' -f1) != ${HASH_SA_RULES} ]]; then
-    CONTAINER_NAME=rspamd-mailcow
-    CONTAINER_ID=$(curl --silent --insecure https://dockerapi/containers/json | \
-      jq -r ".[] | {name: .Config.Labels[\"com.docker.compose.service\"], id: .Id}" | \
-      jq -rc "select( .name | tostring | contains(\"${CONTAINER_NAME}\")) | .id")
+    CONTAINER_ID=$(curl --silent --insecure https://dockerapi/containers/json | jq -r ".[] | select(.Config.Labels[\"com.docker.compose.project\"] == \"$COMPOSE_PROJECT_NAME\") | select(.Config.Labels[\"com.docker.compose.service\"] == \"rspamd-mailcow\") | .Id")
     if [[ ! -z ${CONTAINER_ID} ]]; then
       curl --silent --insecure -XPOST --connect-timeout 15 --max-time 120 https://dockerapi/containers/${CONTAINER_ID}/restart
     fi

--- a/data/Dockerfiles/phpfpm/docker-entrypoint.sh
+++ b/data/Dockerfiles/phpfpm/docker-entrypoint.sh
@@ -32,7 +32,7 @@ CONTAINER_ID=
 # This can happen due to a broken sogo_view
 [ -s /mysql_upgrade_loop ] && SQL_LOOP_C=$(cat /mysql_upgrade_loop)
 until [[ ! -z "${CONTAINER_ID}" ]] && [[ "${CONTAINER_ID}" =~ ^[[:alnum:]]*$ ]]; do
-  CONTAINER_ID=$(curl --silent --insecure https://dockerapi/containers/json | jq -r ".[] | {project: .Config.Labels["com.docker.compose.project"], name: .Config.Labels["com.docker.compose.service"], id: .Id}" | jq -rc "select( .name | tostring | contains("mysql-mailcow")) | select( .project == "$COMPOSE_PROJECT_NAME") | .id" 2> /dev/null)
+  CONTAINER_ID=$(curl --silent --insecure https://dockerapi/containers/json | jq -r ".[] | select(.Config.Labels[\"com.docker.compose.project\"] == \"$COMPOSE_PROJECT_NAME\") | select(.Config.Labels[\"com.docker.compose.service\"] == \"mysql-mailcow\") | .Id")
 done
 echo "MySQL @ ${CONTAINER_ID}"
 SQL_UPGRADE_RETURN=$(curl --silent --insecure -XPOST https://dockerapi/containers/${CONTAINER_ID}/exec -d '{"cmd":"system", "task":"mysql_upgrade"}' --silent -H 'Content-type: application/json' | jq -r .type)

--- a/data/Dockerfiles/phpfpm/docker-entrypoint.sh
+++ b/data/Dockerfiles/phpfpm/docker-entrypoint.sh
@@ -32,7 +32,7 @@ CONTAINER_ID=
 # This can happen due to a broken sogo_view
 [ -s /mysql_upgrade_loop ] && SQL_LOOP_C=$(cat /mysql_upgrade_loop)
 until [[ ! -z "${CONTAINER_ID}" ]] && [[ "${CONTAINER_ID}" =~ ^[[:alnum:]]*$ ]]; do
-  CONTAINER_ID=$(curl --silent --insecure https://dockerapi/containers/json | jq -r ".[] | {name: .Config.Labels[\"com.docker.compose.service\"], id: .Id}" 2> /dev/null | jq -rc "select( .name | tostring | contains(\"mysql-mailcow\")) | .id" 2> /dev/null)
+  CONTAINER_ID=$(curl --silent --insecure https://dockerapi/containers/json | jq -r ".[] | {project: .Config.Labels["com.docker.compose.project"], name: .Config.Labels["com.docker.compose.service"], id: .Id}" | jq -rc "select( .name | tostring | contains("mysql-mailcow")) | select( .project == "$COMPOSE_PROJECT_NAME") | .id" 2> /dev/null)
 done
 echo "MySQL @ ${CONTAINER_ID}"
 SQL_UPGRADE_RETURN=$(curl --silent --insecure -XPOST https://dockerapi/containers/${CONTAINER_ID}/exec -d '{"cmd":"system", "task":"mysql_upgrade"}' --silent -H 'Content-type: application/json' | jq -r .type)


### PR DESCRIPTION
As I already mentioned before in issue created some time ago => with this solution it's possible to run multiply instances of mailcow on one host.

All is about to consider COMPOSE_PROJECT_NAME when selecting data from docker api.

in this commit I made some review and change it in all files where CONTENER_D is assigned.

Please merge this in to project ==> this is not impacting any security or performance part it's just extended select.