### PR TITLE
Added charset for watchdog mails

### DIFF
--- a/data/Dockerfiles/watchdog/watchdog.sh
+++ b/data/Dockerfiles/watchdog/watchdog.sh
@@ -77,6 +77,7 @@ function mail_error() {
     fi
     [ -f "/tmp/${1}" ] && BODY="/tmp/${1}"
     ./smtp-cli --missing-modules-ok \
+      --charset=UTF-8 \
       --subject="${SUBJECT}" \
       --body-plain="${BODY}" \
       --to=${rcpt} \


### PR DESCRIPTION
Added charset parameter to get rid of the negative rating of rspamd R_MISSING_CHARSET (2.5).