### PR TITLE
Minor adjustments to tables in UI

### DIFF
--- a/data/web/css/site/mailbox.css
+++ b/data/web/css/site/mailbox.css
@@ -53,3 +53,11 @@ table.footable>tbody>tr.footable-empty>td {
   font-family:Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace;
   font-size:smaller;
 }
+
+table tbody tr {
+  cursor: pointer;
+}
+
+table tbody tr td input[type="checkbox"] {
+  cursor: pointer;
+}

--- a/data/web/css/site/quarantine.css
+++ b/data/web/css/site/quarantine.css
@@ -57,3 +57,7 @@ span.mail-address-item {
   padding: 2px 7px;
   margin-right: 7px;
 }
+
+table tbody span.footable-toggle {
+  cursor: pointer;
+}

--- a/data/web/css/site/quarantine.css
+++ b/data/web/css/site/quarantine.css
@@ -61,3 +61,7 @@ span.mail-address-item {
 table tbody span.footable-toggle {
   cursor: pointer;
 }
+
+#quarantinetable tbody tr {
+  cursor: pointer;
+}

--- a/data/web/css/site/quarantine.css
+++ b/data/web/css/site/quarantine.css
@@ -58,10 +58,10 @@ span.mail-address-item {
   margin-right: 7px;
 }
 
-table tbody span.footable-toggle {
+table tbody tr {
   cursor: pointer;
 }
 
-#quarantinetable tbody tr {
+table tbody tr td input[type="checkbox"] {
   cursor: pointer;
 }

--- a/data/web/css/site/user.css
+++ b/data/web/css/site/user.css
@@ -40,3 +40,11 @@ table.footable>tbody>tr.footable-empty>td {
 body {
   overflow-y:scroll;
 }
+
+table tbody tr {
+  cursor: pointer;
+}
+
+table tbody tr td input[type="checkbox"] {
+  cursor: pointer;
+}

--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -300,7 +300,8 @@ jQuery(function($){
         "after.ft.filtering": function(e, ft){
           table_mailbox_ready(ft, 'domain_table');
         }
-      }
+      },
+      "toggleSelector": "table tbody span.footable-toggle"
     });
   }
   function draw_mailbox_table() {
@@ -492,7 +493,8 @@ jQuery(function($){
         "after.ft.filtering": function(e, ft){
           table_mailbox_ready(ft, 'resource_table');
         }
-      }
+      },
+      "toggleSelector": "table tbody span.footable-toggle"
     });
   }
   function draw_bcc_table() {
@@ -560,7 +562,8 @@ jQuery(function($){
         "after.ft.filtering": function(e, ft){
           table_mailbox_ready(ft, 'bcc_table');
         }
-      }
+      },
+      "toggleSelector": "table tbody span.footable-toggle"
     });
   }
   function draw_recipient_map_table() {
@@ -623,7 +626,8 @@ jQuery(function($){
         "after.ft.filtering": function(e, ft){
           table_mailbox_ready(ft, 'recipient_map_table');
         }
-      }
+      },
+      "toggleSelector": "table tbody span.footable-toggle"
     });
   }
   function draw_tls_policy_table() {
@@ -692,7 +696,8 @@ jQuery(function($){
         "after.ft.filtering": function(e, ft){
           table_mailbox_ready(ft, 'tls_policy_table');
         }
-      }
+      },
+      "toggleSelector": "table tbody span.footable-toggle"
     });
   }
   function draw_transport_maps_table() {
@@ -759,7 +764,8 @@ jQuery(function($){
         "after.ft.filtering": function(e, ft){
           table_mailbox_ready(ft, 'transport_maps_table');
         }
-      }
+      },
+      "toggleSelector": "table tbody span.footable-toggle"
     });
   }
   function draw_alias_table() {
@@ -916,7 +922,8 @@ jQuery(function($){
         "after.ft.filtering": function(e, ft){
           table_mailbox_ready(ft, 'aliasdomain_table');
         }
-      }
+      },
+      "toggleSelector": "table tbody span.footable-toggle"
     });
   }
 

--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -419,7 +419,8 @@ jQuery(function($){
         "after.ft.filtering": function(e, ft){
           table_mailbox_ready(ft, 'mailbox_table');
         }
-      }
+      },
+      "toggleSelector": "table tbody span.footable-toggle"
     });
   }
   function draw_resource_table() {
@@ -854,7 +855,8 @@ jQuery(function($){
         "after.ft.filtering": function(e, ft){
           table_mailbox_ready(ft, 'alias_table');
         }
-      }
+      },
+      "toggleSelector": "table tbody span.footable-toggle"
     });
   }
 
@@ -995,7 +997,8 @@ jQuery(function($){
         "after.ft.filtering": function(e, ft){
           table_mailbox_ready(ft, 'sync_job_table');
         }
-      }
+      },
+      "toggleSelector": "table tbody span.footable-toggle"
     });
   }
 
@@ -1064,7 +1067,8 @@ jQuery(function($){
         "after.ft.filtering": function(e, ft){
           table_mailbox_ready(ft, 'filter_table');
         }
-      }
+      },
+      "toggleSelector": "table tbody span.footable-toggle"
     });
   };
 

--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -1068,6 +1068,10 @@ jQuery(function($){
     });
   };
 
+  $('body').on('click', 'span.footable-toggle', function () {
+    event.stopPropagation();
+  })
+
   draw_domain_table();
   draw_mailbox_table();
   draw_resource_table();

--- a/data/web/js/site/quarantine.js
+++ b/data/web/js/site/quarantine.js
@@ -59,6 +59,7 @@ jQuery(function($){
       "paging": {"enabled": true,"limit": 5,"size": pagination_size},
       "sorting": {"enabled": true},
       "filtering": {"enabled": true,"position": "left","connectors": false,"placeholder": lang.filter_table},
+      "toggleSelector": "table tbody span.footable-toggle"
     });
   }
 

--- a/data/web/js/site/quarantine.js
+++ b/data/web/js/site/quarantine.js
@@ -114,7 +114,7 @@ jQuery(function($){
     });
   });
 
-  $('table tbody').on('click', 'span.footable-toggle', function () {
+  $('body').on('click', 'span.footable-toggle', function () {
     event.stopPropagation();
   })
 

--- a/data/web/js/site/quarantine.js
+++ b/data/web/js/site/quarantine.js
@@ -114,6 +114,10 @@ jQuery(function($){
     });
   });
 
+  $('table tbody').on('click', 'span.footable-toggle', function () {
+    event.stopPropagation();
+  })
+
   // Initial table drawings
   draw_quarantine_table();
 });

--- a/data/web/js/site/user.js
+++ b/data/web/js/site/user.js
@@ -84,7 +84,8 @@ jQuery(function($){
       "state": {"enabled": true},
       "sorting": {
         "enabled": true
-      }
+      },
+      "toggleSelector": "table tbody span.footable-toggle"
     });
   }
   function draw_sync_job_table() {

--- a/data/web/js/site/user.js
+++ b/data/web/js/site/user.js
@@ -151,7 +151,8 @@ jQuery(function($){
       "state": {"enabled": true},
       "sorting": {
         "enabled": true
-      }
+      },
+      "toggleSelector": "table tbody span.footable-toggle"
     });
   }
   function draw_wl_policy_mailbox_table() {

--- a/data/web/js/site/user.js
+++ b/data/web/js/site/user.js
@@ -236,6 +236,11 @@ jQuery(function($){
       }
     });
   }
+
+  $('body').on('click', 'span.footable-toggle', function () {
+    event.stopPropagation();
+  })
+
   draw_sync_job_table();
   draw_tla_table();
   draw_wl_policy_mailbox_table();


### PR DESCRIPTION
- Restricts the click event to toggle the row details (Rspamd QID) to the footable-toggle icon itself and not the entire row (makes it easy to select a row by just clicking on any row column, e.g. the subject)
- Prevents the click event of the footable-toggle icon from being propagated to the parent row (will not check / uncheck the checkbox anymore)
- Sets a proper cursor (pointer) to the clickable elements of the table (checkbox, footable toggle)