### PR TITLE
Do not create random files when SKIP_HTTP_VERIFICATION == y.

### DIFF
--- a/data/Dockerfiles/acme/docker-entrypoint.sh
+++ b/data/Dockerfiles/acme/docker-entrypoint.sh
@@ -132,13 +132,14 @@ get_ipv6(){
 }
 
 verify_challenge_path(){
-  # verify_challenge_path URL 4|6
-  RANDOM_N=${RANDOM}${RANDOM}${RANDOM}
-  echo ${RANDOM_N} > /var/www/acme/${RANDOM_N}
   if [[ ${SKIP_HTTP_VERIFICATION} == "y" ]]; then
     echo '(skipping check, returning 0)'
     return 0
-  elif [[ "$(curl --insecure -${2} -L http://${1}/.well-known/acme-challenge/${RANDOM_N} --silent)" == "${RANDOM_N}"  ]]; then
+  fi
+  # verify_challenge_path URL 4|6
+  RANDOM_N=${RANDOM}${RANDOM}${RANDOM}
+  echo ${RANDOM_N} > /var/www/acme/${RANDOM_N}
+  if [[ "$(curl --insecure -${2} -L http://${1}/.well-known/acme-challenge/${RANDOM_N} --silent)" == "${RANDOM_N}"  ]]; then
     rm /var/www/acme/${RANDOM_N}
     return 0
   else


### PR DESCRIPTION
I noticed that I got many leftover-files from the mailcow-builtin http verification in data/web/.well-known/acme-challenge. I use SKIP_HTTP_VERIFICATION=y, so those files should never really be created at all.

Previously, the random files were always created and only deleted when SKIP_HTTP_VERIFICATION != y, see https://github.com/mailcow/mailcow-dockerized/blob/cf6ed6b2b41e76bd7e63ba310169ee6030bd5f64/data/Dockerfiles/acme/docker-entrypoint.sh#L139 (files do get created if SKIP_HTTP_VERIFICATION=y, but never deleted).
Either we should also delete them if SKIP_HTTP_VERIFICATION=y, or we should not create them at all in
the first place. This commit goes for the second approach, as it seems cleaner.
