### PR TITLE
[ClamAV] Update to 0.101.4

### DIFF
--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stretch-slim
 LABEL maintainer "André Peters <andre.peters@servercow.de>"
 
 # Installation
-ENV CLAMAV 0.101.3
+ENV CLAMAV 0.101.4
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \


### PR DESCRIPTION
0.101.4 fixes CVE-2019-12625 (zipbombs-issue).
Changelog: https://blog.clamav.net/2019/08/clamav-01014-security-patch-release-has.html