### PR TITLE
rspamd - Switch form Ubuntu to Debian

### DIFF
--- a/data/Dockerfiles/rspamd/Dockerfile
+++ b/data/Dockerfiles/rspamd/Dockerfile
@@ -8,7 +8,7 @@ ENV LC_ALL C
 RUN apt-get update && apt-get install -y \
   tzdata \
   ca-certificates \
-  gnupg \
+  gnupg2 \
   apt-transport-https \
   dnsutils \
   && apt-key adv --fetch-keys https://rspamd.com/apt-stable/gpg.key \

--- a/data/Dockerfiles/rspamd/Dockerfile
+++ b/data/Dockerfiles/rspamd/Dockerfile
@@ -1,22 +1,26 @@
-FROM ubuntu:bionic
+FROM debian:buster-slim
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG CODENAME=buster
 ENV LC_ALL C
 
 RUN apt-get update && apt-get install -y \
   tzdata \
-	ca-certificates \
-	gnupg2 \
-	apt-transport-https \
-	&& apt-key adv --fetch-keys https://rspamd.com/apt/gpg.key \
-	&& echo "deb https://rspamd.com/apt-stable/ bionic main" > /etc/apt/sources.list.d/rspamd.list \
-	&& apt-get update && apt-get install -y rspamd dnsutils \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& apt-get autoremove --purge \
-	&& apt-get clean \
-	&& mkdir -p /run/rspamd \
-	&& chown _rspamd:_rspamd /run/rspamd
+  ca-certificates \
+  gnupg \
+  apt-transport-https \
+  dnsutils \
+  && apt-key adv --fetch-keys https://rspamd.com/apt-stable/gpg.key \
+  && echo "deb [arch=amd64] https://rspamd.com/apt-stable/ $CODENAME main" > /etc/apt/sources.list.d/rspamd.list \
+  && echo "deb-src [arch=amd64] https://rspamd.com/apt-stable/ $CODENAME main" >> /etc/apt/sources.list.d/rspamd.list \
+  && apt-get update \
+  && apt-get --no-install-recommends -y install rspamd \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get autoremove --purge \
+  && apt-get clean \
+  && mkdir -p /run/rspamd \
+  && chown _rspamd:_rspamd /run/rspamd
 
 COPY settings.conf /etc/rspamd/settings.conf
 COPY docker-entrypoint.sh /docker-entrypoint.sh


### PR DESCRIPTION
I know there are no pull requests desired that contain an update of the base image, so see this as a suggestion. Rpamd is the last mailcow (own) image based on ubuntu, because [postfix has already been ported to debian](https://github.com/mailcow/mailcow-dockerized/commit/3136e020f6c0afed83feaddddbd05fff2029fc92#diff-ff63e3fee9825bf5e0806f90529d6eb7). 
Therefore i think it would be good if the mailcow own images were based only on Alpine and Debian. 

I used the following instructions https://rspamd.com/downloads.html.
I did a rudimental test with the new images, so you should try again yourself. 
