### PR TITLE
environment variable TZ for olefy, memcached, ipv6nat

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,6 +260,8 @@ services:
     memcached-mailcow:
       image: memcached:alpine
       restart: always
+      environment:
+        - TZ=${TZ}  
       networks:
         mailcow-network:
           aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,7 +259,9 @@ services:
 
     memcached-mailcow:
       image: memcached:alpine
-      restart: always 
+      restart: always
+      environment:
+        - TZ=${TZ}
       networks:
         mailcow-network:
           aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,8 +260,6 @@ services:
     memcached-mailcow:
       image: memcached:alpine
       restart: always
-      environment:
-        - TZ=${TZ}
       networks:
         mailcow-network:
           aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,8 +260,6 @@ services:
     memcached-mailcow:
       image: memcached:alpine
       restart: always
-      dns:
-        - ${IPV4_NETWORK:-172.22.1}.254
       environment:
         - TZ=${TZ}  
       networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,9 +259,7 @@ services:
 
     memcached-mailcow:
       image: memcached:alpine
-      restart: always
-      environment:
-        - TZ=${TZ}  
+      restart: always 
       networks:
         mailcow-network:
           aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -262,6 +262,8 @@ services:
       restart: always
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
+      environment:
+        - TZ=${TZ}  
       networks:
         mailcow-network:
           aliases:
@@ -435,6 +437,7 @@ services:
       restart: always
       build: ./data/Dockerfiles/olefy
       environment:
+        - TZ=${TZ}
         - OLEFY_BINDADDRESS=0.0.0.0
         - OLEFY_BINDPORT=10055
         - OLEFY_TMPDIR=/tmp
@@ -470,6 +473,8 @@ services:
       restart: always
       privileged: true
       network_mode: "host"
+      environment:
+        - TZ=${TZ}
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock:ro
         - /lib/modules:/lib/modules:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,8 +260,6 @@ services:
     memcached-mailcow:
       image: memcached:alpine
       restart: always
-      environment:
-        - TZ=${TZ}  
       networks:
         mailcow-network:
           aliases:


### PR DESCRIPTION
i just noticed that the olefy container has a wrong timezone, so i added the TZ environment variable, '[tzdata' is already included in the image](https://github.com/christianbur/mailcow-dockerized/blob/80747e99f365fc87df46ffd2cd2c2440d18ccdea/data/Dockerfiles/olefy/Dockerfile#L8). 

I also added the TZ environment variable to memcached and ipv6nat, these conatiners also have a wrong time zone. Unfortunately, the 'tzdata' is not included in both images (no mailcow own images), so the variable has no effect, but it probably doesn't do any harm. 