### PR TITLE
Update admin.js 

### DIFF
--- a/data/web/js/site/admin.js
+++ b/data/web/js/site/admin.js
@@ -280,7 +280,7 @@ jQuery(function($){
       });
     } else if (table == 'adminstable') {
       $.each(data, function (i, item) {
-        if (admin_username == item.username) {
+        if (admin_username.toLowerCase() == item.username.toLowerCase()) {
           item.usr = '→ ' + item.username;
         } else {
           item.usr = item.username;


### PR DESCRIPTION
Hey
The "→" is not displayed when username has a uppercase letters.
But let the pictures speak:
See bevor:  https://i.tobias.bayern/9XGMoS5g.png (Backup link: https://ibb.co/mtb4SFy)
See after change: https://i.tobias.bayern/QvupZ23j.png (Backup link: https://ibb.co/nMmgWbK)

well you cant created now a user with Uppercase letters so i dont know if it is important for all mailcow users