### PR TITLE
Disable SSL ticket support in dovecot

### DIFF
--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -34,7 +34,7 @@ ssl_prefer_server_ciphers = yes
 ssl_cipher_list = ALL:!ADH:!LOW:!SSLv2:!SSLv3:!EXP:!aNULL:!eNULL:!3DES:!MD5:!PSK:!DSS:!RC4:!SEED:!IDEA:+HIGH:+MEDIUM
 
 # Default in Dovecot 2.3
-ssl_options = no_compression
+ssl_options = no_compression no_ticket
 
 # New in Dovecot 2.3
 ssl_dh=</etc/ssl/mail/dhparams.pem


### PR DESCRIPTION
Because tickets are normally only generated on service start, we should disable it to provide better PFS.