### PR TITLE
Resolve #2794 Add restore for 'all'

### DIFF
--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -211,6 +211,9 @@ elif [[ ${1} == "restore" ]]; then
     echo "No datasets found"
     exit 1
   fi
+
+  echo "[ 0 ] all"
+  FILE_SELECTION[0]="vmail crypt rspamd postfix mysql redis"
   for file in $(ls -f "${FOLDER_SELECTION[${input_sel}]}"); do
     if [[ ${file} =~ vmail ]]; then
       echo "[ ${i} ] - Mail directory (/var/vmail)"
@@ -240,7 +243,7 @@ elif [[ ${1} == "restore" ]]; then
   done
   echo
   input_sel=0
-  while [[ ${input_sel} -lt 1 ||  ${input_sel} -gt ${i} ]]; do
+  while [[ ${input_sel} -lt 0 ||  ${input_sel} -gt ${i} ]]; do
     read -p "Select a dataset to restore: " input_sel
   done
   echo "Restoring ${FILE_SELECTION[${input_sel}]} from ${RESTORE_POINT}..."

--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -213,7 +213,8 @@ elif [[ ${1} == "restore" ]]; then
   fi
 
   echo "[ 0 ] all"
-  FILE_SELECTION[0]="vmail crypt rspamd postfix mysql redis"
+  # find all files in folder with .tar.gz extension, print their base names, remove backup_, remove .tar, remove .gz
+  FILE_SELECTION[0]=$(find "${FOLDER_SELECTION[${input_sel}]}" -type f -name "*.tar.gz" -printf "%f\n" | sed 's/backup_*//' | sed 's/\.[^.]*$//' | sed 's/\.[^.]*$//')
   for file in $(ls -f "${FOLDER_SELECTION[${input_sel}]}"); do
     if [[ ${file} =~ vmail ]]; then
       echo "[ ${i} ] - Mail directory (/var/vmail)"
@@ -242,7 +243,7 @@ elif [[ ${1} == "restore" ]]; then
     fi
   done
   echo
-  input_sel=0
+  input_sel=-1
   while [[ ${input_sel} -lt 0 ||  ${input_sel} -gt ${i} ]]; do
     read -p "Select a dataset to restore: " input_sel
   done


### PR DESCRIPTION
As mentioned in #2794 it is a real pain to restore a whole mailcow instance, because you need to select every part of mailcow you wish to restore. 

To improve this behaviour this adds a 'all' option to the restore options as pos zero.