### PR TITLE
[API] Status Codes and only allow valid http method

### DIFF
--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -206,6 +206,14 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
           case "tls-policy-map":
             process_add_return(tls_policy_maps('add', $attr));
           break;
+          default:
+            http_response_code(404);
+            echo json_encode(array(
+              'type' => 'error',
+              'msg' => 'route not found'
+            ));
+            unset($_POST);
+            die();
         }
       break;
       case "get":
@@ -1047,8 +1055,12 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
             }
           break;
           default:
-            echo '{}';
-          break;
+            http_response_code(404);
+            echo json_encode(array(
+              'type' => 'error',
+              'msg' => 'route not found'
+            ));
+            die();
         }
       break;
       case "delete":
@@ -1164,6 +1176,14 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
           case "rlhash":
             echo ratelimit('delete', null, implode($items));
           break;
+          default:
+            http_response_code(404);
+            echo json_encode(array(
+              'type' => 'error',
+              'msg' => 'route not found'
+            ));
+            unset($_POST);
+            die();
         }
       break;
       case "edit":
@@ -1309,10 +1329,18 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               process_edit_return(edit_user_account($attr));
             }
           break;
+          default:
+            http_response_code(404);
+            echo json_encode(array(
+              'type' => 'error',
+              'msg' => 'route not found'
+            ));
+            unset($_POST);
+            die();
         }
       break;
       // return no route found if no case is matched
-      default;
+      default:
         http_response_code(404);
         echo json_encode(array(
           'type' => 'error',

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -1192,6 +1192,15 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
           unset($attr['csrf_token']);
           $items = isset($_POST['items']) ? (array)json_decode($_POST['items'], true) : null;
         }
+        // only allow POST requests to POST API endpoints
+        if ($_SERVER['REQUEST_METHOD'] != 'POST') {
+          http_response_code(405);
+          echo json_encode(array(
+              'type' => 'error',
+              'msg' => 'only POST method is allowed'
+          ));
+          die();
+        }
         switch ($category) {
           case "bcc":
             process_edit_return(bcc('edit', array_merge(array('id' => $items), $attr)));

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -206,6 +206,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
           case "tls-policy-map":
             process_add_return(tls_policy_maps('add', $attr));
           break;
+          // return no route found if no case is matched
           default:
             http_response_code(404);
             echo json_encode(array(
@@ -589,6 +590,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
                 }
                 echo (isset($logs) && !empty($logs)) ? json_encode($logs, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT) : '{}';
               break;
+              // return no route found if no case is matched
               default:
                 http_response_code(404);
                 echo json_encode(array(
@@ -1061,6 +1063,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
                   break;
             }
           break;
+          // return no route found if no case is matched
           default:
             http_response_code(404);
             echo json_encode(array(
@@ -1183,6 +1186,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
           case "rlhash":
             echo ratelimit('delete', null, implode($items));
           break;
+          // return no route found if no case is matched
           default:
             http_response_code(404);
             echo json_encode(array(
@@ -1336,6 +1340,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               process_edit_return(edit_user_account($attr));
             }
           break;
+          // return no route found if no case is matched
           default:
             http_response_code(404);
             echo json_encode(array(

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -589,6 +589,13 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
                 }
                 echo (isset($logs) && !empty($logs)) ? json_encode($logs, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT) : '{}';
               break;
+              default:
+                http_response_code(404);
+                echo json_encode(array(
+                  'type' => 'error',
+                  'msg' => 'route not found'
+                ));
+                die();
             }
           break;
           case "mailbox":

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -134,7 +134,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'type' => 'error',
               'msg' => 'only POST method is allowed'
           ));
-          die();
+          exit();
         }
         switch ($category) {
           case "time_limited_alias":
@@ -213,7 +213,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'msg' => 'route not found'
             ));
             unset($_POST);
-            die();
+            exit();
         }
       break;
       case "get":
@@ -228,7 +228,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'msg' => 'only GET method is allowed'
           ));
           unset($_POST);
-          die();
+          exit();
         }
         switch ($category) {
           case "rspamd":
@@ -595,7 +595,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
                   'type' => 'error',
                   'msg' => 'route not found'
                 ));
-                die();
+                exit();
             }
           break;
           case "mailbox":
@@ -1067,7 +1067,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'type' => 'error',
               'msg' => 'route not found'
             ));
-            die();
+            exit();
         }
       break;
       case "delete":
@@ -1101,7 +1101,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'type' => 'error',
               'msg' => 'only POST method is allowed'
           ));
-          die();
+          exit();
         }
         switch ($category) {
           case "alias":
@@ -1190,7 +1190,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'msg' => 'route not found'
             ));
             unset($_POST);
-            die();
+            exit();
         }
       break;
       case "edit":
@@ -1226,7 +1226,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'type' => 'error',
               'msg' => 'only POST method is allowed'
           ));
-          die();
+          exit();
         }
         switch ($category) {
           case "bcc":
@@ -1343,7 +1343,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'msg' => 'route not found'
             ));
             unset($_POST);
-            die();
+            exit();
         }
       break;
       // return no route found if no case is matched
@@ -1354,7 +1354,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
           'msg' => 'route not found'
         ));
         unset($_POST);
-        die();
+        exit();
     }
   }
 }

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -135,6 +135,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'type' => 'error',
               'msg' => 'Only POST method is allowed!'
           ));
+        }
         switch ($category) {
           case "time_limited_alias":
             process_add_return(mailbox('add', 'time_limited_alias', $attr));
@@ -1080,6 +1081,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'type' => 'error',
               'msg' => 'Only POST method is allowed!'
           ));
+        }
         switch ($category) {
           case "alias":
             process_delete_return(mailbox('delete', 'alias', array('id' => $items)));

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -113,11 +113,9 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
             'msg' => 'Task completed'
           ));
           if ($return === false) {
-            http_response_code(200);
             echo isset($_SESSION['return']) ? json_encode($_SESSION['return']) : $generic_failure;
           }
           else {
-            http_response_code(200);
             echo isset($_SESSION['return']) ? json_encode($_SESSION['return']) : $generic_success;
           }
         }
@@ -1064,11 +1062,9 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
             'msg' => 'Task completed'
           ));
           if ($return === false) {
-            http_response_code(200);
             echo isset($_SESSION['return']) ? json_encode($_SESSION['return']) : $generic_failure;
           }
           else {
-            http_response_code(200);
             echo isset($_SESSION['return']) ? json_encode($_SESSION['return']) : $generic_success;
           }
         }
@@ -1181,11 +1177,9 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
             'msg' => 'Task completed'
           ));
           if ($return === false) {
-            http_response_code(200);
             echo isset($_SESSION['return']) ? json_encode($_SESSION['return']) : $generic_failure;
           }
           else {
-            http_response_code(200);
             echo isset($_SESSION['return']) ? json_encode($_SESSION['return']) : $generic_success;
           }
         }

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -1357,4 +1357,9 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
         exit();
     }
   }
+  if ($_SESSION['mailcow_cc_api'] === true) {
+    if (isset($_SESSION['mailcow_cc_api']) && $_SESSION['mailcow_cc_api'] === true) {
+      unset($_SESSION['return']);
+    }
+  }
 }

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -135,6 +135,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'type' => 'error',
               'msg' => 'Only POST method is allowed!'
           ));
+          die();
         }
         switch ($category) {
           case "time_limited_alias":
@@ -1081,6 +1082,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'type' => 'error',
               'msg' => 'Only POST method is allowed!'
           ));
+          die();
         }
         switch ($category) {
           case "alias":

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -129,11 +129,12 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
           $attr = (array)json_decode($_POST['attr'], true);
           unset($attr['csrf_token']);
         }
+        // only allow POST requests to POST API endpoints
         if ($_SERVER['REQUEST_METHOD'] != 'POST') {
           http_response_code(405);
           echo json_encode(array(
               'type' => 'error',
-              'msg' => 'Only POST method is allowed!'
+              'msg' => 'only POST method is allowed'
           ));
           die();
         }
@@ -213,11 +214,12 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
         function process_get_return($data) {
           echo (!isset($data) || empty($data)) ? '{}' : json_encode($data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
         }
+        // only allow GET requests to GET API endpoints
         if ($_SERVER['REQUEST_METHOD'] != 'GET') {
           http_response_code(405);
           echo json_encode(array(
               'type' => 'error',
-              'msg' => 'Only GET method is allowed!'
+              'msg' => 'only GET method is allowed'
           ));
           die();
         }
@@ -1076,11 +1078,12 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
         else {
           $items = (array)json_decode($_POST['items'], true);
         }
+        // only allow POST requests to POST API endpoints
         if ($_SERVER['REQUEST_METHOD'] != 'POST') {
           http_response_code(405);
           echo json_encode(array(
               'type' => 'error',
-              'msg' => 'Only POST method is allowed!'
+              'msg' => 'only POST method is allowed'
           ));
           die();
         }
@@ -1304,6 +1307,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
           break;
         }
       break;
+      // return no route found if no case is matched
       default;
         http_response_code(404);
         echo json_encode(array(

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -211,7 +211,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'type' => 'error',
               'msg' => 'Only GET method is allowed!'
           ));
-          exit
+          die();
         }
         switch ($category) {
           case "rspamd":

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -205,7 +205,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
         function process_get_return($data) {
           echo (!isset($data) || empty($data)) ? '{}' : json_encode($data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
         }
-        if ($action != 'get' ) {
+        if ($_SERVER['REQUEST_METHOD'] === 'GET') {
           http_response_code(400);
           echo json_encode(array(
               'type' => 'error',

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -69,6 +69,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
 
       // check for valid json
       if ($action != 'get' && $requestDecoded === null) {
+        http_response_code(400);
         echo json_encode(array(
             'type' => 'error',
             'msg' => 'Request body doesn\'t contain valid json!'
@@ -112,9 +113,11 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
             'msg' => 'Task completed'
           ));
           if ($return === false) {
+            http_response_code(200);
             echo isset($_SESSION['return']) ? json_encode($_SESSION['return']) : $generic_failure;
           }
           else {
+            http_response_code(200);
             echo isset($_SESSION['return']) ? json_encode($_SESSION['return']) : $generic_success;
           }
         }
@@ -201,6 +204,14 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
       case "get":
         function process_get_return($data) {
           echo (!isset($data) || empty($data)) ? '{}' : json_encode($data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+        }
+        if ($action != 'get' ) {
+          http_response_code(400);
+          echo json_encode(array(
+              'type' => 'error',
+              'msg' => 'Only GET method is allowed!'
+          ));
+          exit
         }
         switch ($category) {
           case "rspamd":
@@ -1042,9 +1053,11 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
             'msg' => 'Task completed'
           ));
           if ($return === false) {
+            http_response_code(200);
             echo isset($_SESSION['return']) ? json_encode($_SESSION['return']) : $generic_failure;
           }
           else {
+            http_response_code(200);
             echo isset($_SESSION['return']) ? json_encode($_SESSION['return']) : $generic_success;
           }
         }
@@ -1148,9 +1161,11 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
             'msg' => 'Task completed'
           ));
           if ($return === false) {
+            http_response_code(200);
             echo isset($_SESSION['return']) ? json_encode($_SESSION['return']) : $generic_failure;
           }
           else {
+            http_response_code(200);
             echo isset($_SESSION['return']) ? json_encode($_SESSION['return']) : $generic_success;
           }
         }
@@ -1273,6 +1288,14 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
           break;
         }
       break;
+      default;
+        http_response_code(404);
+        echo json_encode(array(
+          'type' => 'error',
+          'msg' => 'route not found'
+        ));
+        unset($_POST);
+        die();
     }
   }
 }

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -129,6 +129,12 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
           $attr = (array)json_decode($_POST['attr'], true);
           unset($attr['csrf_token']);
         }
+        if ($_SERVER['REQUEST_METHOD'] != 'POST') {
+          http_response_code(405);
+          echo json_encode(array(
+              'type' => 'error',
+              'msg' => 'Only POST method is allowed!'
+          ));
         switch ($category) {
           case "time_limited_alias":
             process_add_return(mailbox('add', 'time_limited_alias', $attr));
@@ -206,7 +212,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
           echo (!isset($data) || empty($data)) ? '{}' : json_encode($data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
         }
         if ($_SERVER['REQUEST_METHOD'] != 'GET') {
-          http_response_code(400);
+          http_response_code(405);
           echo json_encode(array(
               'type' => 'error',
               'msg' => 'Only GET method is allowed!'
@@ -1068,6 +1074,12 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
         else {
           $items = (array)json_decode($_POST['items'], true);
         }
+        if ($_SERVER['REQUEST_METHOD'] != 'POST') {
+          http_response_code(405);
+          echo json_encode(array(
+              'type' => 'error',
+              'msg' => 'Only POST method is allowed!'
+          ));
         switch ($category) {
           case "alias":
             process_delete_return(mailbox('delete', 'alias', array('id' => $items)));

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -205,7 +205,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
         function process_get_return($data) {
           echo (!isset($data) || empty($data)) ? '{}' : json_encode($data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
         }
-        if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+        if ($_SERVER['REQUEST_METHOD'] != 'GET') {
           http_response_code(400);
           echo json_encode(array(
               'type' => 'error',

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -221,6 +221,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'type' => 'error',
               'msg' => 'only GET method is allowed'
           ));
+          unset($_POST);
           die();
         }
         switch ($category) {

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -213,7 +213,6 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'type' => 'error',
               'msg' => 'route not found'
             ));
-            unset($_POST);
             exit();
         }
       break;
@@ -228,7 +227,6 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'type' => 'error',
               'msg' => 'only GET method is allowed'
           ));
-          unset($_POST);
           exit();
         }
         switch ($category) {
@@ -1193,7 +1191,6 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'type' => 'error',
               'msg' => 'route not found'
             ));
-            unset($_POST);
             exit();
         }
       break;
@@ -1347,7 +1344,6 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
               'type' => 'error',
               'msg' => 'route not found'
             ));
-            unset($_POST);
             exit();
         }
       break;
@@ -1358,7 +1354,6 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
           'type' => 'error',
           'msg' => 'route not found'
         ));
-        unset($_POST);
         exit();
     }
   }


### PR DESCRIPTION
This PR adds:
- Correct http status codes
- a new response when no API route is matched
- Only allow POST (for add / delete routes) and GET (only for GET routes)

How to test this PR:
- Use the WebUI normally and check if anything is broken or not working anymore.
- Use curl or another tool to test the API

~~Questions that still need to be answered:~~
~~- which status code should be returned when a $generic_failure occurs. Does the UI have to updated when sending a status code other then 200 OK ?~~

Example HTTP POST on GET only Route:
```
curl --request POST \
  --url https://mailcow.host/api/v1/get/logs/acme/1 \
  --header 'content-type: application/json' \
  --header 'x-api-key: apikey' 
```
Output (http status 405):
```
{
  "type": "error",
  "msg": "only GET method is allowed"
}
```

Example GET on POST only route:
```
curl --request GET \
  --url https://mailcow.host/api/v1/add/tls-policy-map \
  --header 'content-type: application/json' \
  --header 'x-api-key: apikey' 
```
Output (http status 405):
```
{
  "type": "error",
  "msg": "only POST method is allowed"
}
```

