### PR TITLE
[Web] Replaced die(); with exit(); due to code conventions

### DIFF
--- a/data/web/inc/ajax/dns_diagnostics.php
+++ b/data/web/inc/ajax/dns_diagnostics.php
@@ -23,12 +23,12 @@ if (isset($_GET['domain'])) {
     }
     else {
       echo "No such domain in context";
-      die();
+      exit();
     }
   }
   else {
     echo "Invalid domain name";
-    die();
+    exit();
   }
 }
 
@@ -422,6 +422,6 @@ foreach ($records as $record) {
 <?php
 } else {
   echo "Session invalid";
-  die();
+  exit();
 }
 ?>

--- a/data/web/inc/lib/vendor/bshaffer/oauth2-server-php/src/OAuth2/Controller/ResourceControllerInterface.php
+++ b/data/web/inc/lib/vendor/bshaffer/oauth2-server-php/src/OAuth2/Controller/ResourceControllerInterface.php
@@ -13,7 +13,7 @@ use OAuth2\ResponseInterface;
  * @code
  *     if (!$resourceController->verifyResourceRequest(OAuth2\Request::createFromGlobals(), $response = new OAuth2\Response())) {
  *         $response->send(); // authorization failed
- *         die();
+ *         exit();
  *     }
  *     return json_encode($resource); // valid token!  Send the stuff!
  * @endcode

--- a/data/web/inc/sessions.inc.php
+++ b/data/web/inc/sessions.inc.php
@@ -66,7 +66,7 @@ if (!empty($_SERVER['HTTP_X_API_KEY'])) {
         'msg' => 'api access denied for ip ' . $_SERVER['REMOTE_ADDR']
       ));
       unset($_POST);
-      die();
+      exit();
     }
   }
   else {
@@ -78,7 +78,7 @@ if (!empty($_SERVER['HTTP_X_API_KEY'])) {
       'msg' => 'authentication failed'
     ));
     unset($_POST);
-    die();
+    exit();
   }
 }
 


### PR DESCRIPTION
Most of the time exit(); is used in the mailcow project. But sometimes die(); is also used. We should only use one of them since both do the same. 

https://www.php.net/manual/en/function.die.php
https://www.php.net/manual/en/function.exit.php