### PR TITLE
Add option to download quarantine item as eml

### DIFF
--- a/data/web/inc/ajax/qitem_details.php
+++ b/data/web/inc/ajax/qitem_details.php
@@ -91,6 +91,19 @@ if (!empty($_GET['id']) && ctype_alnum($_GET['id'])) {
         );
       }
     }
+    if (isset($_GET['eml'])) {
+      $dl_filename = str_replace('/', '_', $data['subject']);
+      header('Pragma: public');
+      header('Expires: 0');
+      header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
+      header('Cache-Control: private', false);
+      header('Content-Type: message/rfc822');
+      header('Content-Disposition: attachment; filename="'. $dl_filename . '.eml";');
+      header('Content-Transfer-Encoding: binary');
+      header('Content-Length: ' . strlen($mailc['msg']));
+      echo $mailc['msg'];
+      exit;
+    }
     if (isset($_GET['att'])) {
       if ($_SESSION['acl']['quarantine_attachments'] == 0) {
         exit(json_encode('Forbidden'));

--- a/data/web/lang/lang.de.php
+++ b/data/web/lang/lang.de.php
@@ -777,6 +777,7 @@ $lang['quarantine']['quarantine'] = "Quarantäne";
 $lang['quarantine']['qinfo'] = 'Das Quarantänesystem speichert abgelehnte Nachrichten in der Datenbank. Dem Sender wird <em>nicht</em> signalisiert, dass seine E-Mail zugestellt wurde.
   <br>"' . $lang['quarantine']['learn_spam_delete'] . '" lernt Nachrichten nach bayesscher Statistik als Spam und erstellt Fuzzy Hashes ausgehend von der jeweiligen Nachricht, um ähnliche Inhalte zukünftig zu unterbinden.
   <br>Der Prozess des Lernens kann abhängig vom System zeitintensiv sein.';
+$lang['quarantine']['download_eml'] = "Herunterladen (.eml)";
 $lang['quarantine']['release'] = "Freigeben";
 $lang['quarantine']['empty'] = 'Keine Einträge';
 $lang['quarantine']['toggle_all'] = 'Alle auswählen';

--- a/data/web/lang/lang.en.php
+++ b/data/web/lang/lang.en.php
@@ -794,6 +794,7 @@ $lang['quarantine']['learn_spam_delete'] = "Learn as spam and delete";
 $lang['quarantine']['qinfo'] = 'The quarantine system will save rejected mail to the database, while the sender will <em>not</em> be given the impression of a delivered mail.
   <br>"' . $lang['quarantine']['learn_spam_delete'] . '" will learn a message as spam via Bayesian theorem and also calculate fuzzy hashes to deny similar messages in the future.
   <br>Please be aware that learning multiple messages can be - depending on your system - time consuming.';
+$lang['quarantine']['download_eml'] = "Download (.eml)";
 $lang['quarantine']['release'] = "Release";
 $lang['quarantine']['empty'] = 'No results';
 $lang['quarantine']['toggle_all'] = 'Toggle all';

--- a/data/web/modals/quarantine.php
+++ b/data/web/modals/quarantine.php
@@ -46,6 +46,8 @@ if (!isset($_SESSION['mailcow_cc_role'])) {
             <li role="separator" class="divider"></li>
             <li><a data-action="edit_selected" data-id="qitems_single" data-item="" data-api-url='edit/qitem' data-api-attr='{"action":"learnspam"}' href="#"><?=$lang['quarantine']['learn_spam_delete'];?></a></li>
             <li role="separator" class="divider"></li>
+            <li><a data-id="qitems_single" data-item="" onclick="window.open('/inc/ajax/qitem_details.php?id=' + $(this).data('item') + '&eml', '_blank')" href="#"><?=$lang['quarantine']['download_eml'];?></a></li>
+            <li role="separator" class="divider"></li>
             <li><a data-action="delete_selected" data-id="qitems_single" data-item="" data-api-url='delete/qitem' href="#"><?=$lang['quarantine']['remove'];?></a></li>
           </ul>
         </div>


### PR DESCRIPTION
Adds an action to the detail view of quarantine items to download the raw mail as an eml file for direct inspection in any mail client.