### PR TITLE
Add rspamd score and symbols to quarantine detail view

### DIFF
--- a/data/web/css/site/quarantine.css
+++ b/data/web/css/site/quarantine.css
@@ -1,40 +1,49 @@
 table.footable>tbody>tr.footable-empty>td {
-  font-size:15px !important;
-  font-style:italic;
+  font-size: 15px !important;
+  font-style: italic;
 }
+
 .pagination a {
   text-decoration: none !important;
 }
+
 .panel panel-default {
   overflow: visible !important;
 }
+
 .table-responsive {
   overflow: visible !important;
 }
+
 @media screen and (max-width: 767px) {
   .table-responsive {
     overflow-x: scroll !important;
   }
 }
+
 .footer-add-item {
-  display:block;
+  display: block;
   text-align: center;
   font-style: italic;
   padding: 10px;
   background: #F5F5F5;
 }
+
 @media (min-width: 992px) {
   .container {
-      width: 80%;
+    width: 80%;
   }
 }
+
 .mass-actions-quarantine {
   user-select: none;
-  padding:10px 0 10px 10px;
+  padding: 10px 0 10px 10px;
 }
+
 .inputMissingAttr {
   border-color: #FF4136;
 }
+
 .dot-danger {
   height: 10px;
   width: 10px;
@@ -42,12 +51,51 @@ table.footable>tbody>tr.footable-empty>td {
   border-radius: 50%;
   display: inline-block;
 }
+
 .dot-neutral {
   height: 10px;
   width: 10px;
   background-color: #d4d4d4;
   border-radius: 50%;
   display: inline-block;
+}
+
+.modal#qidDetailModal p {
+  word-break: break-all;
+}
+
+span#qid_detail_score {
+  font-weight: 700;
+  margin-left: 5px;
+}
+
+span.rspamd-symbol {
+  display: inline-block;
+  margin: 2px 6px 2px 0px;
+  border-radius: 4px;
+  padding: 0px 7px;
+}
+
+span.rspamd-symbol.positive {
+  background: #4CAF50;
+  border: 1px solid #4CAF50;
+  color: white;
+}
+
+span.rspamd-symbol.negative {
+  background: #ff4136;
+  border: 1px solid #ff4136;
+  color: white;
+}
+
+span.rspamd-symbol.neutral {
+  background: #f5f5f5;
+  color: #333;
+  border: 1px solid #ccc;
+}
+
+span.rspamd-symbol span.score {
+  font-weight: 700;
 }
 
 span.mail-address-item {

--- a/data/web/inc/ajax/qitem_details.php
+++ b/data/web/inc/ajax/qitem_details.php
@@ -54,6 +54,10 @@ if (!empty($_GET['id']) && ctype_alnum($_GET['id'])) {
       $data['recipients'] = $recipientsList;
     }
 
+    // Get rspamd score
+    $data['score'] = $mailc['score'];
+    // Get rspamd symbols
+    $data['symbols'] = json_decode($mailc['symbols']);
     // Get text/plain content
     $data['text_plain'] = $mail_parser->getMessageBody('text');
     // Get html content and convert to text

--- a/data/web/inc/functions.quarantine.inc.php
+++ b/data/web/inc/functions.quarantine.inc.php
@@ -678,7 +678,7 @@ function quarantine($_action, $_data = null) {
       if (!is_numeric($_data) || empty($_data)) {
         return false;
       }
-      $stmt = $pdo->prepare('SELECT `rcpt`, `symbols`, `msg`, `domain` FROM `quarantine` WHERE `id`= :id');
+      $stmt = $pdo->prepare('SELECT `rcpt`, `score`, `symbols`, `msg`, `domain` FROM `quarantine` WHERE `id`= :id');
       $stmt->execute(array(':id' => $_data));
       $row = $stmt->fetch(PDO::FETCH_ASSOC);
       if (hasMailboxObjectAccess($_SESSION['mailcow_cc_username'], $_SESSION['mailcow_cc_role'], $row['rcpt'])) {

--- a/data/web/js/site/quarantine.js
+++ b/data/web/js/site/quarantine.js
@@ -92,6 +92,23 @@ jQuery(function($){
         $('#qid_detail_text').text(data.text_plain);
         $('#qid_detail_text_from_html').text(data.text_html);
 
+        $('#qid_detail_score').text(data.score);
+        $('#qid_detail_symbols').html('');
+        if (typeof data.symbols !== 'undefined') {
+          data.symbols.sort(function (a, b) {
+            if (a.score === 0) return 1
+            if (b.score === 0) return -1
+            return b.score - a.score
+          })
+          $.each(data.symbols, function (index, value) {
+            var highlightClass = ''
+            if (value.score > 0) highlightClass = 'negative'
+            else if (value.score < 0) highlightClass = 'positive'
+            else highlightClass = 'neutral'
+            $('#qid_detail_symbols').append('<span class="rspamd-symbol ' + highlightClass + '" title="' + (value.options ? value.options.join(', ') : '') + '">' + value.name + ' (<span class="score">' + value.score + '</span>)</span>');
+          });
+        }
+
         $('#qid_detail_recipients').html('');
         if (typeof data.recipients !== 'undefined') {
           $.each(data.recipients, function(index, value) {

--- a/data/web/lang/lang.de.php
+++ b/data/web/lang/lang.de.php
@@ -790,6 +790,7 @@ $lang['quarantine']['sender'] = "Sender";
 $lang['quarantine']['show_item'] = "Details";
 $lang['quarantine']['check_hash'] = "Checksumme auf VirusTotal suchen";
 $lang['quarantine']['qitem'] = "Quarantäneeintrag";
+$lang['quarantine']['rspamd_result'] = "Rspamd Ergebnis";
 $lang['quarantine']['subj'] = "Betreff";
 $lang['quarantine']['recipients'] = "Empfänger";
 $lang['quarantine']['text_plain_content'] = "Inhalt (text/plain)";

--- a/data/web/lang/lang.en.php
+++ b/data/web/lang/lang.en.php
@@ -807,6 +807,7 @@ $lang['quarantine']['sender'] = "Sender";
 $lang['quarantine']['show_item'] = "Show item";
 $lang['quarantine']['check_hash'] = "Search file hash @ VT";
 $lang['quarantine']['qitem'] = "Quarantine item";
+$lang['quarantine']['rspamd_result'] = "Rspamd result";
 $lang['quarantine']['subj'] = "Subject";
 $lang['quarantine']['recipients'] = "Recipients";
 $lang['quarantine']['text_plain_content'] = "Content (text/plain)";

--- a/data/web/modals/quarantine.php
+++ b/data/web/modals/quarantine.php
@@ -14,6 +14,11 @@ if (!isset($_SESSION['mailcow_cc_role'])) {
       <div class="modal-body">
         <div id="qid_error" style="display:none" class="alert alert-danger"></div>
         <div class="form-group">
+          <label for="qid_detail_symbols"><h4><?=$lang['quarantine']['rspamd_result'];?>:</h4></label>
+          <p><?=$lang['quarantine']['spam_score'];?>: <span id="qid_detail_score"></span></p>
+          <p id="qid_detail_symbols"></p>
+        </div>
+        <div class="form-group">
           <label for="qid_detail_subj"><h4><?=$lang['quarantine']['subj'];?>:</h4></label>
           <p id="qid_detail_subj"></p>
         </div>


### PR DESCRIPTION
Adds the rspamd score and all symbols with their single scores and their options to the quarantine detail view. The options can be inspected by hovering over the symbols.