### PR TITLE
Fix alignment of senders in quarantine detail view

### DIFF
--- a/data/web/css/site/quarantine.css
+++ b/data/web/css/site/quarantine.css
@@ -104,6 +104,8 @@ span.mail-address-item {
   border: 1px solid #ccc;
   padding: 2px 7px;
   margin-right: 7px;
+  display: inline-block;
+  margin: 2px 6px 2px 0;
 }
 
 table tbody tr {


### PR DESCRIPTION
Fixes wrong alignment of senders in the quarantine detail modal if items spread over multiple lines.