### PR TITLE
Change rspamd debug log and quarantine symbols

### DIFF
--- a/data/web/js/site/debug.js
+++ b/data/web/js/site/debug.js
@@ -468,7 +468,17 @@ jQuery(function($){
       else {
         item.rcpt = item.rcpt_smtp.join(", ");
       }
-      Object.keys(item.symbols).map(function(key) {
+      Object.keys(item.symbols).sort(function (a, b) {
+        if (item.symbols[a].score === 0) return 1
+        if (item.symbols[b].score === 0) return -1
+        if (item.symbols[b].score < 0 && item.symbols[a].score < 0) {
+          return item.symbols[a].score - item.symbols[b].score
+        }
+        if (item.symbols[b].score > 0 && item.symbols[a].score > 0) {
+          return item.symbols[b].score - item.symbols[a].score
+        }
+        return item.symbols[b].score - item.symbols[a].score
+      }).map(function(key) {
         var sym = item.symbols[key];
         if (sym.score < 0) {
           sym.score_formatted = '(<span class="text-success"><b>' + sym.score + '</b></span>)'

--- a/data/web/js/site/debug.js
+++ b/data/web/js/site/debug.js
@@ -470,8 +470,11 @@ jQuery(function($){
       }
       Object.keys(item.symbols).map(function(key) {
         var sym = item.symbols[key];
-        if (sym.score <= 0) {
+        if (sym.score < 0) {
           sym.score_formatted = '(<span class="text-success"><b>' + sym.score + '</b></span>)'
+        }
+        else if (sym.score === 0) {
+          sym.score_formatted = '(<span><b>' + sym.score + '</b></span>)'
         }
         else {
           sym.score_formatted = '(<span class="text-danger"><b>' + sym.score + '</b></span>)'

--- a/data/web/js/site/debug.js
+++ b/data/web/js/site/debug.js
@@ -468,7 +468,7 @@ jQuery(function($){
       else {
         item.rcpt = item.rcpt_smtp.join(", ");
       }
-      Object.keys(item.symbols).sort(function (a, b) {
+      item.symbols = Object.keys(item.symbols).sort(function (a, b) {
         if (item.symbols[a].score === 0) return 1
         if (item.symbols[b].score === 0) return -1
         if (item.symbols[b].score < 0 && item.symbols[a].score < 0) {
@@ -493,17 +493,9 @@ jQuery(function($){
         if (sym.options) {
           str += ' [' + sym.options.join(", ") + "]";
         }
-        item.symbols[key].str = str;
-      });
+        return str
+      }).join('<br>\n');
       item.subject = escapeHtml(item.subject);
-      item.symbols = Object.keys(item.symbols).
-      map(function(key) {
-        return item.symbols[key];
-      }).sort(function(e1, e2) {
-        return Math.abs(e1.score) < Math.abs(e2.score);
-      }).map(function(e) {
-        return e.str;
-      }).join("<br>\n");
       var scan_time = item.time_real.toFixed(3) + ' / ' + item.time_virtual.toFixed(3);
       item.scan_time = {
         "options": {

--- a/data/web/js/site/debug.js
+++ b/data/web/js/site/debug.js
@@ -481,7 +481,7 @@ jQuery(function($){
         }
         var str = '<strong>' + key + '</strong> ' + sym.score_formatted;
         if (sym.options) {
-          str += ' [' + sym.options.join(",") + "]";
+          str += ' [' + sym.options.join(", ") + "]";
         }
         item.symbols[key].str = str;
       });

--- a/data/web/js/site/quarantine.js
+++ b/data/web/js/site/quarantine.js
@@ -98,6 +98,12 @@ jQuery(function($){
           data.symbols.sort(function (a, b) {
             if (a.score === 0) return 1
             if (b.score === 0) return -1
+            if (b.score < 0 && a.score < 0) {
+              return a.score - b.score
+            }
+            if (b.score > 0 && a.score > 0) {
+              return b.score - a.score
+            }
             return b.score - a.score
           })
           $.each(data.symbols, function (index, value) {


### PR DESCRIPTION
Changes the appearance of the symbols in the rspamd log according to #3026.

Additionaly improves the sorting of the symbols in the debug log as well as in the quarantine in a way that the smbols with scores that contribute more to the final score are shown first in every group of symbols. E.g. [10, 9, -20, -10, 0, 0]. So far the negative scores (green) were only sorted in a mathematical correct way (-10, -20).

Quarantine:
![image](https://user-images.githubusercontent.com/5374007/66700938-c99b0300-ecf6-11e9-8c1f-00e5a48a79cf.png)

Rspamd debug log:
![image](https://user-images.githubusercontent.com/5374007/66700967-036c0980-ecf7-11e9-8c8f-83a535a017c8.png)

