### PR TITLE
Fix rspamd v1.47 debug log

### DIFF
--- a/data/web/js/site/debug.js
+++ b/data/web/js/site/debug.js
@@ -496,7 +496,10 @@ jQuery(function($){
         return str
       }).join('<br>\n');
       item.subject = escapeHtml(item.subject);
-      var scan_time = item.time_real.toFixed(3) + ' / ' + item.time_virtual.toFixed(3);
+      var scan_time = item.time_real.toFixed(3);
+      if (item.time_virtual) {
+        scan_time += ' / ' + item.time_virtual.toFixed(3);
+      }
       item.scan_time = {
         "options": {
           "sortValue": item.time_real


### PR DESCRIPTION
Fixes the debug log of rspamd for v1.47. The `time_virtual` value was missing for some mails and caused the log to stop rendering the receiver address and the symbols (exception was thrown inside the process_table_data loop).

Now showing only the `time_real` value for "Scan time" when no virtual time set.