### PR TITLE
cache JS- and CSS-File to reduce response-time

### DIFF
--- a/data/web/inc/footer.inc.php
+++ b/data/web/inc/footer.inc.php
@@ -3,7 +3,14 @@ require_once $_SERVER['DOCUMENT_ROOT'] . '/modals/footer.php';
 logger();
 ?>
 <div style="margin-bottom: 100px;"></div>
-<script type='text/javascript'><?=$js_minifier->minify();?></script>
+<script type='text/javascript'><?php
+    $JSPath = '/tmp/' . $js_minifier->getDataHash() . '.js';
+    if(file_exists($JSPath)) {
+        echo file_get_contents($JSPath);
+    } else {
+        echo $js_minifier->minify($JSPath);
+    }
+    ?></script>
 <script>
 <?php
 $lang_footer = json_encode($lang['footer']);

--- a/data/web/inc/footer.inc.php
+++ b/data/web/inc/footer.inc.php
@@ -9,6 +9,7 @@ logger();
         echo file_get_contents($JSPath);
     } else {
         echo $js_minifier->minify($JSPath);
+        cleanupCSS($css_minifier->getDataHash());
     }
     ?></script>
 <script>

--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -1612,4 +1612,22 @@ function solr_status() {
   }
   return false;
 }
+
+function cleanupJS($ignore = '', $folder = '/tmp/*.js') {
+    foreach (glob($folder) as $filename) {
+        if(strpos($filename, $ignore) !== false) {
+            continue;
+        }
+        unlink($filename);
+    }
+}
+
+function cleanupCSS($ignore = '', $folder = '/tmp/*.css') {
+    foreach (glob($folder) as $filename) {
+        if(strpos($filename, $ignore) !== false) {
+            continue;
+        }
+        unlink($filename);
+    }
+}
 ?>

--- a/data/web/inc/header.inc.php
+++ b/data/web/inc/header.inc.php
@@ -36,6 +36,7 @@
           echo file_get_contents($CSSPath);
       } else {
           echo $css_minifier->minify($CSSPath);
+          cleanupCSS($css_minifier->getDataHash());
       }
       ?></style>
   <?php if (strtolower(trim($DEFAULT_THEME)) != "lumen"): ?>

--- a/data/web/inc/header.inc.php
+++ b/data/web/inc/header.inc.php
@@ -30,7 +30,14 @@
       $css_minifier->add('/web/css/site/index.css');
     }
   ?>
-  <style><?=$css_minifier->minify();?></style>
+  <style><?php
+      $CSSPath = '/tmp/' . $css_minifier->getDataHash() . '.css';
+      if(file_exists($CSSPath)) {
+          echo file_get_contents($CSSPath);
+      } else {
+          echo $css_minifier->minify($CSSPath);
+      }
+      ?></style>
   <?php if (strtolower(trim($DEFAULT_THEME)) != "lumen"): ?>
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/<?= strtolower(trim($DEFAULT_THEME)); ?>/bootstrap.min.css">
   <?php endif; ?>

--- a/data/web/inc/lib/CSSminifierExtended.php
+++ b/data/web/inc/lib/CSSminifierExtended.php
@@ -1,0 +1,18 @@
+<?php
+
+use MatthiasMullie\Minify\CSS;
+
+class CSSminifierExtended extends CSS {
+
+    public function getDataHash() {
+        return sha1(json_encode($this->accessProtected($this,'data')));
+    }
+
+    private function accessProtected($obj, $prop) {
+        $reflection = new ReflectionClass($obj);
+        $property = $reflection->getProperty($prop);
+        $property->setAccessible(true);
+        return $property->getValue($obj);
+    }
+
+}

--- a/data/web/inc/lib/JSminifierExtended.php
+++ b/data/web/inc/lib/JSminifierExtended.php
@@ -1,0 +1,18 @@
+<?php
+
+use MatthiasMullie\Minify\JS;
+
+class JSminifierExtended extends JS {
+
+    public function getDataHash() {
+        return sha1(json_encode($this->accessProtected($this,'data')));
+    }
+
+    private function accessProtected($obj, $prop) {
+        $reflection = new ReflectionClass($obj);
+        $property = $reflection->getProperty($prop);
+        $property->setAccessible(true);
+        return $property->getValue($obj);
+    }
+
+}

--- a/data/web/inc/prerequisites.inc.php
+++ b/data/web/inc/prerequisites.inc.php
@@ -19,16 +19,20 @@ require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/lib/vendor/autoload.php';
 // Load Sieve
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/lib/sieve/SieveParser.php';
 
+// minifierExtended
+require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/lib/JSminifierExtended.php';
+require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/lib/CSSminifierExtended.php';
+
 // Minify JS
 use MatthiasMullie\Minify;
-$js_minifier = new Minify\JS();
+$js_minifier = new JSminifierExtended();
 $js_dir = array_diff(scandir('/web/js/build'), array('..', '.'));
 foreach ($js_dir as $js_file) {
   $js_minifier->add('/web/js/build/' . $js_file);
 }
 
 // Minify CSS
-$css_minifier = new Minify\CSS();
+$css_minifier = new CSSminifierExtended();
 $css_dir = array_diff(scandir('/web/css/build'), array('..', '.'));
 foreach ($css_dir as $css_file) {
   $css_minifier->add('/web/css/build/' . $css_file);


### PR DESCRIPTION
Just noticed the minifier of JS and CSS results in >300ms response-time on admin-page f.e.
this PR is halving the response-time by hashing content and caching the files in tmp-folder.

Is the tmp-folder cleared automatically by system or will I have to think of a method to clean up?