### PR TITLE
Fix custom nginx sites with tls-sni

### DIFF
--- a/data/conf/nginx/templates/listen_plain.template
+++ b/data/conf/nginx/templates/listen_plain.template
@@ -1,0 +1,2 @@
+listen ${HTTP_PORT};
+listen [::]:${HTTP_PORT};

--- a/data/conf/nginx/templates/listen_ssl.template
+++ b/data/conf/nginx/templates/listen_ssl.template
@@ -1,0 +1,2 @@
+listen ${HTTPS_PORT} ssl http2;
+listen [::]:${HTTPS_PORT} ssl http2;

--- a/data/conf/nginx/templates/server_name.template
+++ b/data/conf/nginx/templates/server_name.template
@@ -1,0 +1,1 @@
+server_name ${MAILCOW_HOSTNAME} autodiscover.* autoconfig.*;

--- a/data/conf/nginx/templates/sites.template.sh
+++ b/data/conf/nginx/templates/sites.template.sh
@@ -18,9 +18,10 @@ for cert_dir in /etc/ssl/mail/*/ ; do
   fi
   # do not create vhost for default-certificate. the cert is already in the default server listen
   domains="$(cat ${cert_dir}domains | sed -e 's/^[[:space:]]*//')"
-  if [[ "${domains}" == "" ]] || [[ "${domains}" == "${MAILCOW_HOSTNAME}"* ]]; then
-    continue
-  fi
+  case "${domains}" in
+    "") continue;;
+    "${MAILCOW_HOSTNAME}"*) continue;;
+  esac
   echo -n '
 server {
   include /etc/nginx/conf.d/listen_plain.active;

--- a/data/conf/nginx/templates/sites.template.sh
+++ b/data/conf/nginx/templates/sites.template.sh
@@ -1,15 +1,13 @@
 echo '
 server {
   listen 127.0.0.1:65510;
-  listen '${HTTP_PORT}' default_server;
-  listen [::]:'${HTTP_PORT}' default_server;
-  listen '${HTTPS_PORT}' ssl http2 default_server;
-  listen [::]:'${HTTPS_PORT}' ssl http2 default_server;
+  include /etc/nginx/conf.d/listen_plain.active;
+  include /etc/nginx/conf.d/listen_ssl.active;
 
   ssl_certificate /etc/ssl/mail/cert.pem;
   ssl_certificate_key /etc/ssl/mail/key.pem;
 
-  server_name '${MAILCOW_HOSTNAME}' autodiscover.* autoconfig.*;
+  include /etc/nginx/conf.d/server_name.active;
 
   include /etc/nginx/conf.d/includes/site-defaults.conf;
 }
@@ -18,15 +16,15 @@ for cert_dir in /etc/ssl/mail/*/ ; do
   if [[ ! -f ${cert_dir}domains ]] || [[ ! -f ${cert_dir}cert.pem ]] || [[ ! -f ${cert_dir}key.pem ]]; then
     continue
   fi
-  # remove hostname to not cause nginx warnings (hostname is covered in default server listen)
-  domains="$(cat ${cert_dir}domains | sed -e "s/\(^\| \)\($(echo ${MAILCOW_HOSTNAME} | sed 's/\./\\./g')\)\( \|$\)/ /g" | sed -e 's/^[[:space:]]*//')"
-  if [[ "${domains}" == "" ]]; then
+  # do not create vhost for default-certificate. the cert is already in the default server listen
+  domains="$(cat ${cert_dir}domains | sed -e 's/^[[:space:]]*//')"
+  if [[ "${domains}" == "" ]] || [[ "${domains}" == "${MAILCOW_HOSTNAME}"* ]]; then
     continue
   fi
   echo -n '
 server {
-  listen '${HTTPS_PORT}' ssl http2;
-  listen [::]:'${HTTPS_PORT}' ssl http2;
+  include /etc/nginx/conf.d/listen_plain.active;
+  include /etc/nginx/conf.d/listen_ssl.active;
 
   ssl_certificate '${cert_dir}'cert.pem;
   ssl_certificate_key '${cert_dir}'key.pem;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,7 +275,10 @@ services:
       image: nginx:mainline-alpine
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
-      command: /bin/sh -c "envsubst < /etc/nginx/conf.d/templates/sogo.template > /etc/nginx/conf.d/sogo.active &&
+      command: /bin/sh -c "envsubst < /etc/nginx/conf.d/templates/listen_plain.template > /etc/nginx/conf.d/listen_plain.active &&
+        envsubst < /etc/nginx/conf.d/templates/listen_ssl.template > /etc/nginx/conf.d/listen_ssl.active &&
+        envsubst < /etc/nginx/conf.d/templates/server_name.template > /etc/nginx/conf.d/server_name.active &&
+        envsubst < /etc/nginx/conf.d/templates/sogo.template > /etc/nginx/conf.d/sogo.active &&
         envsubst < /etc/nginx/conf.d/templates/sogo_eas.template > /etc/nginx/conf.d/sogo_eas.active &&
         . /etc/nginx/conf.d/templates/sogo.auth_request.template.sh > /etc/nginx/conf.d/sogo_proxy_auth.active &&
         . /etc/nginx/conf.d/templates/sites.template.sh > /etc/nginx/conf.d/sites.active &&


### PR DESCRIPTION
I have restored some previous configurations:
- create the listen_plain, listen_ssl and server_name files again
- without the default_server directive now (first server will still be default, like before)
- stop creating a vhost with all domains in ADDITIONAL_SAN (already served in first vhost or custom configs)

This should prevent some issues with existing setups and custom configs: https://mailcow.github.io/mailcow-dockerized-docs/u_e-webmail-site/