### PR TITLE
Fix custom http redirects with TLS-SNI

### DIFF
--- a/data/conf/nginx/templates/sites.template.sh
+++ b/data/conf/nginx/templates/sites.template.sh
@@ -24,7 +24,6 @@ for cert_dir in /etc/ssl/mail/*/ ; do
   esac
   echo -n '
 server {
-  include /etc/nginx/conf.d/listen_plain.active;
   include /etc/nginx/conf.d/listen_ssl.active;
 
   ssl_certificate '${cert_dir}'cert.pem;


### PR DESCRIPTION
Disable http listener for SNI ssl hosts in nginx. This allows the use of the following config again:
https://mailcow.github.io/mailcow-dockerized-docs/u_e-80_to_443/

However that documentation page should still be updated: https://github.com/mailcow/mailcow-dockerized-docs/pull/175