### PR TITLE
deliver CSS and JS as external request

### DIFF
--- a/data/conf/nginx/includes/site-defaults.conf
+++ b/data/conf/nginx/includes/site-defaults.conf
@@ -32,7 +32,7 @@
   gzip_buffers 16 8k;
   gzip_http_version 1.1;
   gzip_min_length 256;
-  gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
+  gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
 
   location ~ ^/(fonts|js|css|img)/ {
     expires max;
@@ -204,4 +204,8 @@
 
   location @awaitingupstream {
     rewrite ^(.*)$ /_status.502.html break;
+  }
+
+  location ~ ^/cache/(.*)$ {
+      try_files $uri $uri/ /resource.php?file=$1;
   }

--- a/data/web/inc/footer.inc.php
+++ b/data/web/inc/footer.inc.php
@@ -3,15 +3,16 @@ require_once $_SERVER['DOCUMENT_ROOT'] . '/modals/footer.php';
 logger();
 ?>
 <div style="margin-bottom: 100px;"></div>
-<script type='text/javascript'><?php
-    $JSPath = '/tmp/' . $js_minifier->getDataHash() . '.js';
-    if(file_exists($JSPath)) {
-        echo file_get_contents($JSPath);
-    } else {
-        echo $js_minifier->minify($JSPath);
-        cleanupJS($js_minifier->getDataHash());
-    }
-    ?></script>
+
+<?php
+$hash = $js_minifier->getDataHash();
+$JSPath = '/tmp/' . $hash . '.js';
+if(!file_exists($JSPath)) {
+  $js_minifier->minify($JSPath);
+  cleanupJS($hash);
+}
+?>
+<script src="/cache/<?=basename($JSPath)?>"></script>
 <script>
 <?php
 $lang_footer = json_encode($lang['footer']);

--- a/data/web/inc/header.inc.php
+++ b/data/web/inc/header.inc.php
@@ -29,16 +29,15 @@
     if ($_SERVER['REQUEST_URI'] == '/') {
       $css_minifier->add('/web/css/site/index.css');
     }
+
+  $hash = $css_minifier->getDataHash();
+  $CSSPath = '/tmp/' . $hash . '.css';
+  if(!file_exists($CSSPath)) {
+    $css_minifier->minify($CSSPath);
+    cleanupCSS($hash);
+  }
   ?>
-  <style><?php
-      $CSSPath = '/tmp/' . $css_minifier->getDataHash() . '.css';
-      if(file_exists($CSSPath)) {
-          echo file_get_contents($CSSPath);
-      } else {
-          echo $css_minifier->minify($CSSPath);
-          cleanupCSS($css_minifier->getDataHash());
-      }
-      ?></style>
+  <link rel="stylesheet" href="/cache/<?=basename($CSSPath)?>">
   <?php if (strtolower(trim($DEFAULT_THEME)) != "lumen"): ?>
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/<?= strtolower(trim($DEFAULT_THEME)); ?>/bootstrap.min.css">
   <?php endif; ?>

--- a/data/web/resource.php
+++ b/data/web/resource.php
@@ -1,0 +1,28 @@
+<?php
+
+$pathinfo = pathinfo($_GET['file']);
+$extension = strtolower($pathinfo['extension']);
+
+$filepath = '/tmp/' . $pathinfo['basename'];
+$content = '';
+
+if (file_exists($filepath)) {
+    $secondsToCache = 31536000;
+    $expires = gmdate('D, d M Y H:i:s', time() + $secondsToCache) . ' GMT';
+
+    if ($extension === 'js') {
+        header('Content-Type: application/javascript');
+    } elseif ($extension === 'css') {
+        header('Content-Type: text/css');
+    } else {
+        //currently just css and js should be supported!
+        exit();
+    }
+
+    header("Expires: $expires");
+    header('Pragma: cache');
+    header('Cache-Control: max-age=' . $secondsToCache);
+    $content = file_get_contents($filepath);
+}
+
+echo $content;


### PR DESCRIPTION
This PR should add more optimization for visitors of admin-panel and is an extension of #3062. :-)

- add correct gzip-type `application/javascript` to site.conf
- link resources, instead of printing it into html
  - add custom route to detect file:  `/cache/[path]` => `/resource.php?file=[path]`
  - reduce traffic (187KB => 24,6KB in admin-startpage)
  - respect cache of user/browser

I didn't want to specify a public cache-folder due to needed write permissions.