### PR TITLE
OAuth improvements

### DIFF
--- a/data/web/index.php
+++ b/data/web/index.php
@@ -31,7 +31,7 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
         <div class="panel-heading"><span class="glyphicon glyphicon-user" aria-hidden="true"></span> <?= $lang['login']['login']; ?></div>
         <div class="panel-body">
           <div class="text-center mailcow-logo"><img src="<?=($main_logo = customize('get', 'main_logo')) ? $main_logo : '/img/cow_mailcow.svg';?>" alt="mailcow"></div>
-          <legend><?=$UI_TEXTS['main_name'];?></legend>
+          <legend><?= isset($_SESSION['oauth2_request']) ? $lang['oauth2']['authorize_app'] : $UI_TEXTS['main_name'];?></legend>
             <form method="post" autofill="off">
             <div class="form-group">
               <label class="sr-only" for="login_user"><?= $lang['login']['username']; ?></label>
@@ -49,6 +49,7 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
             </div>
             <div class="form-group">
               <button type="submit" class="btn btn-success" value="Login"><?= $lang['login']['login']; ?></button>
+              <?php if(!isset($_SESSION['oauth2_request'])): ?>
               <div class="btn-group pull-right">
                 <button type="button" <?=(isset($_SESSION['mailcow_locale']) && count($AVAILABLE_LANGUAGES) === 1) ? 'disabled="true"' : '' ?> class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   <span class="lang-sm lang-lbl" lang="<?= $_SESSION['mailcow_locale']; ?>"></span> <span class="caret"></span>
@@ -63,6 +64,7 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
                   ?>
                 </ul>
               </div>
+              <?php endif ?>
             </div>
             </form>
             <?php
@@ -72,6 +74,7 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
             <?php
             endif;
             ?>
+          <?php if(!isset($_SESSION['oauth2_request'])): ?>
           <legend><?=$UI_TEXTS['apps_name'];?></legend>
           <?php
           foreach ($MAILCOW_APPS as $app):
@@ -89,10 +92,12 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
               endforeach;
             }
           }
+          endif;
           ?>
         </div>
       </div>
     </div>
+    <?php if(!isset($_SESSION['oauth2_request'])): ?>
     <div class="col-md-offset-3 col-md-6">
       <div class="panel panel-default">
         <div class="panel-heading">
@@ -112,6 +117,7 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
         </div>
       </div>
     </div>
+    <?php endif ?>
   </div>
 </div><!-- /.container -->
 <?php

--- a/data/web/oauth/profile.php
+++ b/data/web/oauth/profile.php
@@ -17,6 +17,7 @@ if (!empty($mailbox)) {
       'identifier' => $token['user_id'],
       'email' => (!empty($mailbox['username']) ? $mailbox['username'] : ''),
       'full_name' => (!empty($mailbox['name']) ? $mailbox['name'] : 'mailcow administrative user'),
+      'displayName' => (!empty($mailbox['name']) ? $mailbox['name'] : 'mailcow administrative user'),
       'created' => (!empty($mailbox['created']) ? $mailbox['created'] : ''),
       'modified' => (!empty($mailbox['modified']) ? $mailbox['modified'] : ''),
       'active' => (!empty($mailbox['active']) ? $mailbox['active'] : ''),


### PR DESCRIPTION
- Add the `displayName` attribute to the profile. This is what NextCloud uses to populate its _full name_ field.
- Show a reduced login screen when authorizing OAuth: don't display the buttons for SOGo and other applications, don't show the help, and replace the "mailcow UI" title with "Authorize application". Otherwise the user may get confused and think they are actually going to get logged into the Mailcow UI.