### PR TITLE
Rspamd: increase redis timeout

### DIFF
--- a/data/conf/rspamd/local.d/redis.conf
+++ b/data/conf/rspamd/local.d/redis.conf
@@ -1,1 +1,2 @@
 servers = "redis:6379";
+timeout = 10;


### PR DESCRIPTION
Rspamd's default Redis timeout for many operations is [one second](https://github.com/rspamd/rspamd/blob/db7221371cfde0b0cd7b9fef48c76dae51bf7f3c/lualib/lua_redis.lua#L283). If your server is under load, that can sometimes be too short, resulting in error messages like the following and DKIM signing, caching and rate limiting failing:
```
lua; arc.lua:580: cannot make request to load DKIM key for dkim.kuron.eu: timeout while connecting the server
lua; arc.lua:580: signing failure: cannot make request to load DKIM selector for domain example.com: timeout while connecting the server
lua; common.lua:223: got error checking cache: timeout while connecting the server
lua; dkim_signing.lua:88: signing failure: cannot make request to load DKIM selector for domain example.com: timeout while connecting the server
lua; ratelimit.lua:680: cannot update rate bucket 1000:admin@example.com: timeout while connecting the server
lua; ratelimit.lua:680: cannot update rate bucket 1000:admin@example.com:192.0.2.1: timeout while connecting the server
lua; ratelimit.lua:680: cannot update rate bucket 1000:admin@example.com:192.0.2.1:admin@example.org: timeout while connecting the server
task; rspamd_redis_timeout: connection to redis server redis timed out
```
This pull request increases the timeout to 10 seconds. At least on my server, that has completely eliminated the log messages above. There is no noticeable performance impact as most Redis requests finish in fractions of a second anyway.