### PR TITLE
[Compose] better security

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -474,7 +474,12 @@ services:
         - TZ=${TZ}
       image: robbertkl/ipv6nat
       restart: always
-      privileged: true
+      cap-drop:
+        - ALL
+      cap-add:
+        - NET_RAW
+        - NET_ADMIN
+        - SYS_MODULE
       network_mode: "host"
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -474,9 +474,9 @@ services:
         - TZ=${TZ}
       image: robbertkl/ipv6nat
       restart: always
-      cap-drop:
+      cap_drop:
         - ALL
-      cap-add:
+      cap_add:
         - NET_RAW
         - NET_ADMIN
         - SYS_MODULE


### PR DESCRIPTION
Die README vom Projekt sagt es ganz unten, ist 1:1 umgesetzt. 

https://github.com/robbertkl/docker-ipv6nat#docker-container

So hat der Container nicht mehr root auf den Host sondern nur die 3 entsprechenden Berechtigungen. 