### PR TITLE
Make restore not only find .tar.gz but also .gz for mysql backup

### DIFF
--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -220,9 +220,9 @@ elif [[ ${1} == "restore" ]]; then
     exit 1
   fi
 
-  echo "[ 0 ] all"
+  echo "[ 0 ] - all"
   # find all files in folder with *.gz extension, print their base names, remove backup_, remove .tar (if present), remove .gz
-  FILE_SELECTION[0]=$(find "${FOLDER_SELECTION[${input_sel}]}" -type f -name "*.gz" -printf "%f\n" | sed 's/backup_*//' | sed 's/\.[^.]*$//' | sed 's/\.[^.]*$//')
+  FILE_SELECTION[0]=$(find "${FOLDER_SELECTION[${input_sel}]}" -type f -name '*.gz' -printf '%f\n' | sed 's/backup_*//' | sed 's/\.[^.]*$//' | sed 's/\.[^.]*$//')
   for file in $(ls -f "${FOLDER_SELECTION[${input_sel}]}"); do
     if [[ ${file} =~ vmail ]]; then
       echo "[ ${i} ] - Mail directory (/var/vmail)"

--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -222,7 +222,7 @@ elif [[ ${1} == "restore" ]]; then
 
   echo "[ 0 ] all"
   # find all files in folder with .tar.gz extension, print their base names, remove backup_, remove .tar, remove .gz
-  FILE_SELECTION[0]=$(find "${FOLDER_SELECTION[${input_sel}]}" -type f -name "*.tar.gz" -printf "%f\n" | sed 's/backup_*//' | sed 's/\.[^.]*$//' | sed 's/\.[^.]*$//')
+  FILE_SELECTION[0]=$(find "${FOLDER_SELECTION[${input_sel}]}" -type f -name "*.gz" -printf "%f\n" | sed 's/backup_*//' | sed 's/\.[^.]*$//' | sed 's/\.[^.]*$//')
   for file in $(ls -f "${FOLDER_SELECTION[${input_sel}]}"); do
     if [[ ${file} =~ vmail ]]; then
       echo "[ ${i} ] - Mail directory (/var/vmail)"

--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -221,7 +221,7 @@ elif [[ ${1} == "restore" ]]; then
   fi
 
   echo "[ 0 ] all"
-  # find all files in folder with .tar.gz extension, print their base names, remove backup_, remove .tar, remove .gz
+  # find all files in folder with *.gz extension, print their base names, remove backup_, remove .tar (if present), remove .gz
   FILE_SELECTION[0]=$(find "${FOLDER_SELECTION[${input_sel}]}" -type f -name "*.gz" -printf "%f\n" | sed 's/backup_*//' | sed 's/\.[^.]*$//' | sed 's/\.[^.]*$//')
   for file in $(ls -f "${FOLDER_SELECTION[${input_sel}]}"); do
     if [[ ${file} =~ vmail ]]; then


### PR DESCRIPTION
This pull request provides a fix for my previous pr (#2922).

I noticed there is an issue with the mysql backup not getting restored, because the file extension is .gz and not .tar.gz as the others. While testing this i didnt noticed it, so here is the fix ... simple but powerful. 