### PR TITLE
 Fix missing username in username_invalid message

### DIFF
--- a/data/web/inc/functions.admin.inc.php
+++ b/data/web/inc/functions.admin.inc.php
@@ -23,7 +23,7 @@ function admin($_action, $_data = null) {
         $_SESSION['return'][] = array(
           'type' => 'danger',
           'log' => array(__FUNCTION__, $_action, $_data_log),
-          'msg' => 'username_invalid'
+          'msg' => array('username_invalid', $username)
         );
         return false;
       }
@@ -261,7 +261,7 @@ function admin($_action, $_data = null) {
         ':admin' => $_data
       ));
       $row = $stmt->fetch(PDO::FETCH_ASSOC);
-      if (empty($row)) { 
+      if (empty($row)) {
         return false;
       }
       $admindata['username'] = $row['username'];

--- a/data/web/inc/functions.domain_admin.inc.php
+++ b/data/web/inc/functions.domain_admin.inc.php
@@ -35,7 +35,7 @@ function domain_admin($_action, $_data = null) {
         $_SESSION['return'][] = array(
           'type' => 'danger',
           'log' => array(__FUNCTION__, $_action, $_data_log),
-          'msg' => 'username_invalid'
+          'msg' => array('username_invalid', $username)
         );
         return false;
       }
@@ -44,12 +44,12 @@ function domain_admin($_action, $_data = null) {
         WHERE `username` = :username");
       $stmt->execute(array(':username' => $username));
       $num_results[] = count($stmt->fetchAll(PDO::FETCH_ASSOC));
-      
+
       $stmt = $pdo->prepare("SELECT `username` FROM `admin`
         WHERE `username` = :username");
       $stmt->execute(array(':username' => $username));
       $num_results[] = count($stmt->fetchAll(PDO::FETCH_ASSOC));
-      
+
       $stmt = $pdo->prepare("SELECT `username` FROM `domain_admins`
         WHERE `username` = :username");
       $stmt->execute(array(':username' => $username));
@@ -379,7 +379,7 @@ function domain_admin($_action, $_data = null) {
       }
       $stmt = $pdo->query("SELECT DISTINCT
         `username`
-          FROM `domain_admins` 
+          FROM `domain_admins`
             WHERE `username` IN (
               SELECT `username` FROM `admin`
                 WHERE `superadmin`!='1'
@@ -415,7 +415,7 @@ function domain_admin($_action, $_data = null) {
         ':domain_admin' => $_data
       ));
       $row = $stmt->fetch(PDO::FETCH_ASSOC);
-      if (empty($row)) { 
+      if (empty($row)) {
         return false;
       }
       $domainadmindata['username'] = $row['username'];


### PR DESCRIPTION
Fix missing username in username_invalid message when adding a new admin or domain-admin:
![Schnappschuss 2019-11-10 11 26 21](https://user-images.githubusercontent.com/5744732/68542701-ae7fe980-03af-11ea-9b89-1320b6d25a75.png)
