### PR TITLE
Adding domain admins to domain table

### DIFF
--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -46,7 +46,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           $stmt = $pdo->prepare("SELECT `domain` FROM `mailbox` WHERE `username` = :username");
           $stmt->execute(array(':username' => $_SESSION['mailcow_cc_username']));
           $domain = $stmt->fetch(PDO::FETCH_ASSOC)['domain'];
-          $validity = strtotime("+".$_data["validity"]." hour"); 
+          $validity = strtotime("+".$_data["validity"]." hour");
           $letters = 'abcefghijklmnopqrstuvwxyz1234567890';
           $random_name = substr(str_shuffle($letters), 0, 24);
           $stmt = $pdo->prepare("INSERT INTO `spamalias` (`address`, `goto`, `validity`) VALUES
@@ -485,7 +485,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               'msg' => 'comment_too_long'
             );
             return false;
-          } 
+          }
           if (empty($addresses[0])) {
             $_SESSION['return'][] = array(
               'type' => 'danger',
@@ -841,7 +841,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             WHERE `domain` = :domain");
           $stmt->execute(array(':domain' => $domain));
           $DomainData = $stmt->fetch(PDO::FETCH_ASSOC);
-          $stmt = $pdo->prepare("SELECT 
+          $stmt = $pdo->prepare("SELECT
             COUNT(*) as count,
             COALESCE(ROUND(SUM(`quota`)/1048576), 0) as `quota`
               FROM `mailbox`
@@ -945,7 +945,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             );
             return false;
           }
-          $stmt = $pdo->prepare("INSERT INTO `mailbox` (`username`, `password`, `name`, `quota`, `local_part`, `domain`, `attributes`, `active`) 
+          $stmt = $pdo->prepare("INSERT INTO `mailbox` (`username`, `password`, `name`, `quota`, `local_part`, `domain`, `attributes`, `active`)
             VALUES (:username, :password_hashed, :name, :quota_b, :local_part, :domain, :mailbox_attrs, :active)");
           $stmt->execute(array(
             ':username' => $username,
@@ -1073,7 +1073,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             );
             return false;
           }
-          $stmt = $pdo->prepare("INSERT INTO `mailbox` (`username`, `password`, `name`, `quota`, `local_part`, `domain`, `active`, `multiple_bookings`, `kind`) 
+          $stmt = $pdo->prepare("INSERT INTO `mailbox` (`username`, `password`, `name`, `quota`, `local_part`, `domain`, `active`, `multiple_bookings`, `kind`)
             VALUES (:name, 'RESOURCE', :description, 0, :local_part, :domain, :active, :multiple_bookings, :kind)");
           $stmt->execute(array(
             ':name' => $name,
@@ -1249,7 +1249,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                 'msg' => 'access_denied'
               );
               continue;
-            } 
+            }
             $stmt = $pdo->prepare("UPDATE `mailbox`
               SET `attributes` = JSON_SET(`attributes`, '$.quarantine_notification', :quarantine_notification)
                 WHERE `username` = :username");
@@ -1360,7 +1360,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               continue;
             }
             $validity = round((int)time() + ($_data['validity'] * 3600));
-            $stmt = $pdo->prepare("UPDATE `spamalias` SET `validity` = :validity WHERE 
+            $stmt = $pdo->prepare("UPDATE `spamalias` SET `validity` = :validity WHERE
               `address` = :address");
             $stmt->execute(array(
               ':address' => $address,
@@ -1888,7 +1888,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                 );
                 continue;
               }
-              $stmt = $pdo->prepare("UPDATE `domain` SET 
+              $stmt = $pdo->prepare("UPDATE `domain` SET
               `description` = :description,
               `gal` = :gal
                 WHERE `domain` = :domain");
@@ -1928,7 +1928,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                 continue;
               }
               // todo: should be using api here
-              $stmt = $pdo->prepare("SELECT 
+              $stmt = $pdo->prepare("SELECT
                   COUNT(*) AS count,
                   MAX(COALESCE(ROUND(`quota`/1048576), 0)) AS `biggest_mailbox`,
                   COALESCE(ROUND(SUM(`quota`)/1048576), 0) AS `quota_all`
@@ -2009,7 +2009,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                 );
                 continue;
               }
-              $stmt = $pdo->prepare("UPDATE `domain` SET 
+              $stmt = $pdo->prepare("UPDATE `domain` SET
               `relay_all_recipients` = :relay_all_recipients,
               `backupmx` = :backupmx,
               `gal` = :gal,
@@ -2071,7 +2071,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               $domain     = $is_now['domain'];
               $quota_b    = $quota_m * 1048576;
               $password   = (!empty($_data['password'])) ? $_data['password'] : null;
-              $password2  = (!empty($_data['password2'])) ? $_data['password2'] : null; 
+              $password2  = (!empty($_data['password2'])) ? $_data['password2'] : null;
             }
             else {
               $_SESSION['return'][] = array(
@@ -2517,14 +2517,14 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           }
           $stmt = $pdo->prepare("SELECT `domain` FROM `domain`
             WHERE `domain` NOT IN (
-              SELECT REPLACE(`send_as`, '@', '') FROM `sender_acl` 
+              SELECT REPLACE(`send_as`, '@', '') FROM `sender_acl`
                 WHERE `logged_in_as` = :logged_in_as1
                   AND `external` = '0'
                   AND `send_as` LIKE '@%')
             UNION
             SELECT '*' FROM `domain`
               WHERE '*' NOT IN (
-                SELECT `send_as` FROM `sender_acl`  
+                SELECT `send_as` FROM `sender_acl`
                   WHERE `logged_in_as` = :logged_in_as2
                     AND `external` = '0'
               )");
@@ -2546,7 +2546,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           $stmt = $pdo->prepare("SELECT `address` FROM `alias`
             WHERE `goto` != :goto
               AND `address` NOT IN (
-                SELECT `send_as` FROM `sender_acl` 
+                SELECT `send_as` FROM `sender_acl`
                   WHERE `logged_in_as` = :logged_in_as
                     AND `external` = '0'
                     AND `send_as` NOT LIKE '@%')");
@@ -3074,11 +3074,11 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           if (!empty($row)) {
             $_data = $row['target_domain'];
           }
-          $stmt = $pdo->prepare("SELECT 
+          $stmt = $pdo->prepare("SELECT
               `domain`,
               `description`,
               `aliases`,
-              `mailboxes`, 
+              `mailboxes`,
               `defquota`,
               `maxquota`,
               `quota`,
@@ -3096,7 +3096,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             ':domain' => $_data
           ));
           $row = $stmt->fetch(PDO::FETCH_ASSOC);
-          if (empty($row)) { 
+          if (empty($row)) {
             return false;
           }
           $stmt = $pdo->prepare("SELECT COUNT(*) AS `count`,
@@ -3147,6 +3147,15 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           $AliasDataDomain = $stmt->fetch(PDO::FETCH_ASSOC);
           (isset($AliasDataDomain['alias_count'])) ? $domaindata['aliases_in_domain'] = $AliasDataDomain['alias_count'] : $domaindata['aliases_in_domain'] = "0";
           $domaindata['aliases_left'] = $row['aliases']	- $AliasDataDomain['alias_count'];
+          if ($_SESSION['mailcow_cc_role'] == "admin")
+          {
+              $stmt = $pdo->prepare("SELECT GROUP_CONCAT(`username` SEPARATOR ', ') AS domain_admins FROM `domain_admins` WHERE `domain` = :domain");
+              $stmt->execute(array(
+                ':domain' => $_data
+              ));
+              $domain_admins = $stmt->fetch(PDO::FETCH_ASSOC);
+              (isset($domain_admins['domain_admins'])) ? $domaindata['domain_admins'] = $domain_admins['domain_admins'] : $domaindata['domain_admins'] = "-";
+          }
           return $domaindata;
         break;
         case 'mailbox_details':
@@ -3726,7 +3735,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               curl_setopt($curl, CURLOPT_HTTPHEADER,array('Content-Type: text/xml'));
               curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
               curl_setopt($curl, CURLOPT_POST, 1);
-              curl_setopt($curl, CURLOPT_POSTFIELDS, '<delete><query>user:' . $username . '</query></delete>'); 
+              curl_setopt($curl, CURLOPT_POSTFIELDS, '<delete><query>user:' . $username . '</query></delete>');
               curl_setopt($curl, CURLOPT_TIMEOUT, 30);
               $response = curl_exec($curl);
               if ($response === false) {

--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -10,11 +10,11 @@ $(document).ready(function() {
       this._super();
       var self = this;
       var domains = [];
-      
+
       $.each(self.ft.rows.all, function(i, row){
         if((row.val().domain != null) && ($.inArray(row.val().domain, domains) === -1)) domains.push(row.val().domain);
       });
-      
+
       $form_grp = $('<div/>', {'class': 'form-group'})
         .append($('<label/>', {'class': 'sr-only', text: 'Domain'}))
         .prependTo(self.$form);
@@ -233,6 +233,7 @@ jQuery(function($){
         {"name":"max_quota_for_mbox","title":lang.mailbox_quota,"breakpoints":"xs sm","style":{"width":"125px"}},
         {"name":"rl","title":"RL","breakpoints":"xs sm md lg","style":{"maxWidth":"100px","width":"100px"}},
         {"name":"backupmx","filterable": false,"style":{"maxWidth":"120px","width":"120px"},"title":lang.backup_mx,"breakpoints":"xs sm md lg"},
+        {"name":"domain_admins","title":lang.domain_admins,"style":{"word-break":"break-all","min-width":"200px"},"breakpoints":"xs sm md lg","filterable":(role == "admin"),"visible":(role == "admin")},
         {"name":"active","filterable": false,"style":{"maxWidth":"80px","width":"80px"},"title":lang.active},
         {"name":"action","filterable": false,"sortable": false,"style":{"text-align":"right","maxWidth":"240px","width":"240px"},"type":"html","title":lang.action,"breakpoints":"xs sm md"}
       ],

--- a/data/web/lang/lang.ca.json
+++ b/data/web/lang/lang.ca.json
@@ -298,6 +298,7 @@
         "active": "Actiu",
         "action": "Acció",
         "backup_mx": "Backup MX",
+        "domain_admins": "Administradores de dominio",
         "domain_aliases": "Àlies de domini",
         "target_domain": "Domini destí",
         "target_address": "Direcció Goto",

--- a/data/web/lang/lang.cs.json
+++ b/data/web/lang/lang.cs.json
@@ -563,6 +563,7 @@
         "active": "Aktivní",
         "action": "Akce",
         "backup_mx": "Záložní MX",
+        "domain_admins": "Správci domén",
         "domain_aliases": "Doménové aliasy",
         "target_domain": "Cílová doména",
         "target_address": "Cílová adresa",

--- a/data/web/lang/lang.de.json
+++ b/data/web/lang/lang.de.json
@@ -569,6 +569,7 @@
         "active": "Aktiv",
         "action": "Aktion",
         "backup_mx": "Backup MX",
+        "domain_admins": "Domain-Administratoren",
         "domain_aliases": "Domain-Aliasse",
         "target_domain": "Ziel-Domain",
         "target_address": "Ziel-Adresse",

--- a/data/web/lang/lang.en.json
+++ b/data/web/lang/lang.en.json
@@ -568,6 +568,7 @@
         "active": "Active",
         "action": "Action",
         "backup_mx": "Backup MX",
+        "domain_admins": "Domain administrators",
         "domain_aliases": "Domain aliases",
         "target_domain": "Target domain",
         "target_address": "Goto address",

--- a/data/web/lang/lang.es.json
+++ b/data/web/lang/lang.es.json
@@ -262,6 +262,7 @@
         "active": "Activo",
         "action": "Acción",
         "backup_mx": "MX de respaldo",
+        "domain_admins": "Administradores por dominio",
         "domain_aliases": "Alias de dominio",
         "target_domain": "Dominio destino",
         "target_address": "Dirección destino",

--- a/data/web/lang/lang.fi.json
+++ b/data/web/lang/lang.fi.json
@@ -563,6 +563,7 @@
         "active": "Aktiivinen",
         "action": "Toiminnot",
         "backup_mx": "Varmuuskopiointi MX",
+        "domain_admins": "Verkkotunnuksien järjestelmänvalvojat",
         "domain_aliases": "Domain alueiden aliakset",
         "target_domain": "Kohde verkkotunnus alue",
         "target_address": "Siiretty osoitteseen",

--- a/data/web/lang/lang.fr.json
+++ b/data/web/lang/lang.fr.json
@@ -259,6 +259,7 @@
         "active": "Actif",
         "action": "Action",
         "backup_mx": "MX de secours",
+        "domain_admins": "Administrateurs de domaines",
         "domain_aliases": "Alias de domaine",
         "target_domain": "Domaine cible",
         "target_address": "Adresse cible",

--- a/data/web/lang/lang.it.json
+++ b/data/web/lang/lang.it.json
@@ -182,6 +182,7 @@
         "active": "Attiva",
         "action": "Azione",
         "backup_mx": "Backup MX",
+        "domain_admins": "Amministratori di dominio",
         "domain_aliases": "Alias di domini",
         "target_domain": "Target domain",
         "target_address": "Vai ad indirizzo",

--- a/data/web/lang/lang.lv.json
+++ b/data/web/lang/lang.lv.json
@@ -303,6 +303,7 @@
         "active": "Aktīvs",
         "action": "Rīcība",
         "backup_mx": "Rezerves kopija MX",
+        "domain_admins": "Domēna administratori",
         "domain_aliases": "Domēna aliases",
         "target_domain": "Mērķa domēns",
         "target_address": "Doties uz  adresi",

--- a/data/web/lang/lang.nl.json
+++ b/data/web/lang/lang.nl.json
@@ -565,6 +565,7 @@
         "active": "Actief",
         "action": "Handeling",
         "backup_mx": "Secundaire MX",
+        "domain_admins": "Domeinbeheerders",
         "domain_aliases": "Domeinaliassen",
         "target_domain": "Doeldomein",
         "target_address": "Doeladres",

--- a/data/web/lang/lang.pl.json
+++ b/data/web/lang/lang.pl.json
@@ -258,6 +258,7 @@
         "active": "Aktywny",
         "action": "Działanie",
         "backup_mx": "Backup MX",
+        "domain_admins": "Administratorzy domeny",
         "domain_aliases": "Aliasy domeny",
         "target_domain": "Domena docelowa",
         "target_address": "Adres Idź do",

--- a/data/web/lang/lang.pt.json
+++ b/data/web/lang/lang.pt.json
@@ -148,6 +148,7 @@
         "active": "Ativo",
         "action": "Ação",
         "backup_mx": "Backup MX",
+        "domain_admins": "Administradores de domínio",
         "domain_aliases": "Encaminhamento de Domínio",
         "target_domain": "Domínio Destino",
         "target_address": "Encaminhar para",

--- a/data/web/lang/lang.ru.json
+++ b/data/web/lang/lang.ru.json
@@ -259,6 +259,7 @@
         "active": "Активный",
         "action": "Действия",
         "backup_mx": "Резервное копирование MX",
+        "domain_admins": "Администраторы домена",
         "domain_aliases": "Псевдонимы доменов",
         "target_domain": "Целевой домен",
         "target_address": "Основной адрес",


### PR DESCRIPTION
Adds a listing of the assigned domain-admins to each domain in the domain listing. This way it will be possible to filter the domains by domain-admins.

The assigned domain admins are only visible for superadmins. Domain admins won't see the assigned domain-admins in the domain listing as we don't want to reveal other domain admins.