### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/data/Dockerfiles/unbound/docker-entrypoint.sh
+++ b/data/Dockerfiles/unbound/docker-entrypoint.sh
@@ -6,7 +6,7 @@ chmod g+rw /dev/console
 echo "Receiving anchor key..."
 /usr/sbin/unbound-anchor -a /etc/unbound/trusted-key.key
 echo "Receiving root hints..."
-curl -#o /etc/unbound/root.hints https://www.internic.net/domain/named.cache
+curl -o /etc/unbound/root.hints https://www.internic.net/domain/named.cache
 /usr/sbin/unbound-control-setup
 
 # Run hooks


### PR DESCRIPTION
there is a typo this way unbound wont work properly because the root hints cant be downloaded