### PR TITLE
[Dovecot] Fix shared namespace typo

### DIFF
--- a/data/Dockerfiles/dovecot/docker-entrypoint.sh
+++ b/data/Dockerfiles/dovecot/docker-entrypoint.sh
@@ -195,7 +195,7 @@ namespace {
     type = shared
     separator = /
     prefix = Shared/%%u/
-    location = maildir:%%h${MAILDIR_SUB_SHARED}:INDEX=~${MAILDIR_SUB_SHARED}/Shared/%%u;CONTROL=~${MAILDIR_SUB_SHARED}/Shared/%%u
+    location = maildir:%%h${MAILDIR_SUB_SHARED}:INDEX=~${MAILDIR_SUB_SHARED}/Shared/%%u:CONTROL=~${MAILDIR_SUB_SHARED}/Shared/%%u
     subscriptions = no
     list = children
 }


### PR DESCRIPTION
I noticed the shared namespace was not listed by Dovecot over IMAP and found a typo in the namespace location parameter. Changing the semicolon to a colon fixes the issue.