### PR TITLE
fix alias_domain_alias_hint in de translation

### DIFF
--- a/data/web/lang/lang.de.json
+++ b/data/web/lang/lang.de.json
@@ -574,7 +574,7 @@
         "booking_0_short": "Immer verfügbar",
         "booking_lt0_short": "Weiches Limit",
         "booking_custom_short": "Hartes Limit",
-        "alias_domain_alias_hint": "Alias-Adressen werden <b>nicht</b> automatisch auch auf Domain-Alias Adressen angewendet. Eine Alias-Adresse <code>mein-alias@domain</code> bildet demnach <b>nicht</b> die Adresse <code>my-alias@alias-domain</code> ab.",
+        "alias_domain_alias_hint": "Alias-Adressen werden <b>nicht</b> automatisch auch auf Domain-Alias Adressen angewendet. Eine Alias-Adresse <code>mein-alias@domain</code> bildet demnach <b>nicht</b> die Adresse <code>mein-alias@alias-domain</code> ab.",
         "domain": "Domain",
         "spam_aliases": "Temp. Alias",
         "alias": "Alias",


### PR DESCRIPTION
Fixes a translation error in `alias_domain_alias_hint`. The two example addresses now have the same left part. 

The "current" translation lead to some confusion on my side until i understod that the first example got translated and the second not.