### PR TITLE
fix new imapsync dependency

### DIFF
--- a/data/Dockerfiles/dovecot/Dockerfile
+++ b/data/Dockerfiles/dovecot/Dockerfile
@@ -33,6 +33,7 @@ RUN groupadd -g 5000 vmail \
   libdbi-perl \
   libdigest-hmac-perl \
   libdist-checkconflicts-perl \
+  libencode-imaputf7-perl \
   libfile-copy-recursive-perl \
   libfile-tail-perl \
   libhtml-parser-perl \


### PR DESCRIPTION
Following #3248, this fixes the error : 

```
Can't locate Encode/IMAPUTF7.pm in @INC (you may need to install the Encode::IMAPUTF7 module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.28.1 /usr/local/share/perl/5.28.1 /usr/lib/x86_64-linux-gnu/perl5/5.28 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.28 /usr/share/perl/5.28 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /usr/local/bin/imapsync line 887.
BEGIN failed--compilation aborted at /usr/local/bin/imapsync line 887.
```