### PR TITLE
[SSL] fix bug with pruning old certificates

### DIFF
--- a/data/Dockerfiles/acme/acme.sh
+++ b/data/Dockerfiles/acme/acme.sh
@@ -328,6 +328,7 @@ while true; do
         log_f "Found orphaned certificate: ${EXISTING_CERT} - archiving it at ${ACME_BASE}/backups/${EXISTING_CERT}/"
         BACKUP_DIR=${ACME_BASE}/backups/${EXISTING_CERT}/${DATE}
         # archive rsa cert and any other files
+        mkdir -p ${ACME_BASE}/backups/${EXISTING_CERT}
         mv ${ACME_BASE}/${EXISTING_CERT} ${BACKUP_DIR}
         CERT_CHANGED=1
         CERT_AMOUNT_CHANGED=1


### PR DESCRIPTION
In some cases, pruning old certificates was not working as the base directory for backing it up did not exist yet.
The base path for a cert backup is created when renewing certificates - if this never happened for a specific certificate the pruning would fail.
Now it will also create the path while pruning.

Edit: probably related issue: https://github.com/mailcow/mailcow-dockerized/issues/3222