### PR TITLE
rspamd: More comprehensive attachment handling

### DIFF
--- a/data/conf/rspamd/local.d/external_services.conf
+++ b/data/conf/rspamd/local.d/external_services.conf
@@ -4,4 +4,6 @@ oletools {
   # needs to be set explicitly for Rspamd < 1.9.5
   scan_mime_parts = true;
   # mime-part regex matching in content-type or filename
+  # block all macros
+  extended = true;
 }

--- a/data/conf/rspamd/local.d/mime_types.conf
+++ b/data/conf/rspamd/local.d/mime_types.conf
@@ -4,13 +4,22 @@ bad_extensions = {
   scr = 4,
   lnk = 4,
   exe = 1,
+  msi = 1,
+  msp = 1,
+  msu = 1,
   jar = 2,
   com = 4,
   bat = 4,
+  cmd = 4,
+  ps1 = 4,
   ace = 4,
   arj = 4,
   cab = 3,
-  doc = 10,
+  vbs = 4,
+  hta = 4,
+  shs = 4,
+  wsc = 4,
+  wsf = 4,
 };
 
 # Extensions that are particularly penalized for archives


### PR DESCRIPTION
- block all Office documents with macros
- don’t just block all doc files
- mark some more Windows executable extensions as bad

I have tested this with Word and Excel files, old formats (e.g. doc), new formats (e.g. docx) and macro-enabled new formats (e.g. docm). All files with macros are blocked and all files without macros are allowed to pass.

Fixes #3266