### PR TITLE
Added data/web/rc* to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ data/assets/ssl/*
 *.iml
 data/web/.well-known/acme-challenge
 data/web/nextcloud*/
+data/web/rc*/
 data/conf/rspamd/local.d/*
 data/conf/rspamd/override.d/*
 !data/conf/nginx/dynmaps.conf


### PR DESCRIPTION
When users add Roundcube (explained here: https://mailcow.github.io/mailcow-dockerized-docs/third_party-roundcube/), they have a lot of files in 'git status' showing as 'not tracked'.