### PR TITLE
Change want_spam to list of symbols_enabled

### DIFF
--- a/data/web/inc/presets/rspamd/preset_2.yml
+++ b/data/web/inc/presets/rspamd/preset_2.yml
@@ -2,4 +2,9 @@ headline: lang.rsettings_preset_2
 content: |
   priority = 10;
   rcpt = "/postmaster@.*/";
-  want_spam = yes;
+  apply {
+    symbols_enabled = ["DKIM_SIGNED", "RATELIMITED", "RATELIMIT_UPDATE", "RATELIMIT_CHECK", "DYN_RL_CHECK", "HISTORY_SAVE", "MILTER_HEADERS", "ARC_SIGNED"];
+  actions {
+      greylist = null;
+    }
+  }

--- a/data/web/inc/presets/rspamd/preset_2.yml
+++ b/data/web/inc/presets/rspamd/preset_2.yml
@@ -3,7 +3,7 @@ content: |
   priority = 10;
   rcpt = "/postmaster@.*/";
   apply {
-    symbols_enabled = ["DKIM_SIGNED", "RATELIMITED", "RATELIMIT_UPDATE", "RATELIMIT_CHECK", "DYN_RL_CHECK", "HISTORY_SAVE", "MILTER_HEADERS", "ARC_SIGNED"];
+    symbols_enabled = ["DKIM_SIGNED", "HISTORY_SAVE", "MILTER_HEADERS", "ARC_SIGNED"];
   actions {
       greylist = null;
     }


### PR DESCRIPTION
`want_spam` disable all mail processing by RspamD, so DKIM signing is not applied for any mail where rcpt is `/postmaster@*/`, including external one.
So `greylist = null` and list of `symbols_enabled` used for outgoing mail doing same job as `want_spam`, but not broke DKIM & ARC.