### PR TITLE
[Nginx] custom redirect from location / ie webmail.domain to /SOGo/

### DIFF
--- a/data/conf/nginx/includes/site-defaults.conf
+++ b/data/conf/nginx/includes/site-defaults.conf
@@ -46,6 +46,7 @@
 
   location / {
     try_files $uri $uri/ @strip-ext;
+    include /etc/nginx/conf.d/redirects.*.custom;	
   }
 
   location /qhandler {


### PR DESCRIPTION
Added the new to add subdomain redirects for example if a domain is being moved from cPanel the end users where used to using webmail.DOMAIN. I did not use sites.*.custom as the redirect needs to go into location / to avoid any endless http loops. 

example redirect:
==> data/conf/nginx/redirects.webmail.custom 
if ( $host ~ ^webmail\.(?<domain>.+)$ ) {
        return 301 https://webmail.$domain/SOGo/;
 }