### PR TITLE
Reduce Rspamd DNSBL false positives

### DIFF
--- a/data/conf/rspamd/local.d/composites.conf
+++ b/data/conf/rspamd/local.d/composites.conf
@@ -34,6 +34,6 @@ FORGED_W_BAD_POLICY {
   expression = "( ~g+:policies | ~R_SPF_NA) & ( ~FROM_NEQ_ENVFROM & ~FORGED_SENDER )"
   score = 3.0;
 }
-RBL_SORBS_EXCLUDE_FWD_HOST {
-  expression = "-WHITELISTED_FWD_HOST & ^RBL_SORBS_RECENT"
+RBL_EXCLUDE_FWD_HOST {
+  expression = "-WHITELISTED_FWD_HOST & ^g:rbl"
 }

--- a/data/conf/rspamd/local.d/composites.conf
+++ b/data/conf/rspamd/local.d/composites.conf
@@ -34,3 +34,6 @@ FORGED_W_BAD_POLICY {
   expression = "( ~g+:policies | ~R_SPF_NA) & ( ~FROM_NEQ_ENVFROM & ~FORGED_SENDER )"
   score = 3.0;
 }
+RBL_SORBS_EXCLUDE_FWD_HOST {
+  expression = "-WHITELISTED_FWD_HOST & ^RBL_SORBS_RECENT"
+}

--- a/data/conf/rspamd/local.d/rbl_group.conf
+++ b/data/conf/rspamd/local.d/rbl_group.conf
@@ -45,4 +45,8 @@ symbols = {
     score = 2.0;  
     description = "List of networks hijacked from their original owners, some of which have already used for spamming.";  
   }
+  "RECEIVED_SPAMHAUS_XBL" {
+    weight = 0.0;
+    description = "Received address is listed in ZEN XBL";
+  }
 }


### PR DESCRIPTION
- Ignore SORBS for forwarding hosts. Recently, one of gmx.net's servers was listed on SORBS. I have that whitelisted as a forwarding host with spam filtering enabled, so I got lots of false positives there. When you trust a server enought to list it as a forwarding host, you don't need to check SORBS (since that might tag all messages coming from there as spam).

- Disable Spamhaus XBL for `Received:` headers. XBL lists "compromised" IP addresses, but that can include addresses that ISPs assign to their customers. Even though these should actually be on PBL, there are cases where an address is on the "wrong" list. This can cause emails to get flagged as spam that simply got sent from an end-user ISP address (unless of course the sender's email server anonymizes its `Received:` headers).