### PR TITLE
Added mailflowmonitoring.com to no log Rspamd

### DIFF
--- a/data/conf/rspamd/lua/rspamd.local.lua
+++ b/data/conf/rspamd/lua/rspamd.local.lua
@@ -203,7 +203,7 @@ rspamd_config:register_symbol({
   type = 'postfilter',
   callback = function(task)
     local from = task:get_header('From')
-    if from and (string.find(from, 'monitoring-system@everycloudtech.us', 1, true) or from == 'watchdog@localhost') then
+    if from and (string.find(from, 'monitoring-system@everycloudtech.us', 1, true) or string.find(from, 'monitor@tools.mailflowmonitoring.com', 1, true) or from == 'watchdog@localhost') then
       task:set_flag('no_log')
       task:set_flag('no_stat')
     end


### PR DESCRIPTION
Hi, just a mirror pull request to add free mail flow monitor from mailflowmonitoring.com to no logging like EveryCloud currently is.

Adding this might be helpfully for anyone that might uses that free mail flow monitor instead of EveryCloud one.

I don't mind if this pull get rejected as I can just add it to rspamd.local.lua on my own server instead .