### PR TITLE
Aliases in SoGO will be sorted this way

### DIFF
--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -3,7 +3,7 @@ function init_db_schema() {
   try {
     global $pdo;
 
-    $db_version = "16022020_1804";
+    $db_version = "05032020_0715";
 
     $stmt = $pdo->query("SHOW TABLES LIKE 'versions'");
     $num_results = count($stmt->fetchAll(PDO::FETCH_ASSOC));

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -16,7 +16,7 @@ function init_db_schema() {
 
     $views = array(
     "grouped_mail_aliases" => "CREATE VIEW grouped_mail_aliases (username, aliases) AS
-      SELECT goto, IFNULL(GROUP_CONCAT(address SEPARATOR ' '), '') AS address FROM alias
+      SELECT goto, IFNULL(GROUP_CONCAT(address ORDER BY address SEPARATOR ' '), '') AS address FROM alias
       WHERE address!=goto
       AND active = '1'
       AND sogo_visible = '1'


### PR DESCRIPTION
The sender drop down list when writing a new email in SoGO will be sorted with this patch. Currently they are in a pretty random order. I had to manually drop and recreate the view, not sure how to trigger this in Mailcow.