### PR TITLE
[rspamd] Restore add header forced action

### DIFF
--- a/data/conf/rspamd/local.d/force_actions.conf
+++ b/data/conf/rspamd/local.d/force_actions.conf
@@ -1,6 +1,6 @@
 rules {
   WHITELIST_FORWARDING_HOST_NO_REJECT {
-    action = "rewrite subject";
+    action = "add header";
     expression = "WHITELISTED_FWD_HOST";
     require_action = ["reject"];
   }


### PR DESCRIPTION
Revert 0474de88b175ef1cb638ef5525376033057be564. I have confirmed that the issue does not occur anymore since c3a4c6d311058103287a4ad95ab2cca0bc51585a.