### PR TITLE
Quarantine notifications - exclude blacklisted sender

### DIFF
--- a/data/Dockerfiles/dovecot/quarantine_notify.py
+++ b/data/Dockerfiles/dovecot/quarantine_notify.py
@@ -97,7 +97,13 @@ def notify_rcpt(rcpt, msg_count, quarantine_acl):
       print('%s'  % (ex))
       time.sleep(3)
 
-records = query_mysql('SELECT IFNULL(user_acl.quarantine, 0) AS quarantine_acl, count(id) AS counter, rcpt FROM quarantine LEFT OUTER JOIN user_acl ON user_acl.username = rcpt WHERE notified = 0 AND rcpt in (SELECT username FROM mailbox) GROUP BY rcpt')
+records = query_mysql("""
+SELECT IFNULL(user_acl.quarantine, 0) AS quarantine_acl, count(id) AS counter, rcpt, sender FROM quarantine
+LEFT OUTER JOIN user_acl ON user_acl.username = rcpt
+WHERE notified = 0 AND rcpt in (SELECT username FROM mailbox)
+# dont send notifications for blacklisted senders
+AND (SELECT prefid FROM filterconf WHERE option = "blacklist_from" AND (object = rcpt OR object = SUBSTRING(rcpt, LOCATE("@", rcpt) + 1)) AND sender REGEXP(REPLACE(value, '*', '.+'))) IS NULL GROUP BY rcpt
+""")
 
 for record in records:
   attrs = ''


### PR DESCRIPTION
The final version, fixed syntax. I see my prev PR was reverted and I also hit the error with syntax problem. In this version, the syntax is fixed and it is working.

Signed-off-by: Kristián Feldsam <feldsam@gmail.com>