### PR TITLE
Fixed DKIM regex to allow arguments after the public key

### DIFF
--- a/data/web/inc/ajax/dns_diagnostics.php
+++ b/data/web/inc/ajax/dns_diagnostics.php
@@ -376,8 +376,8 @@ foreach ($records as $record) {
     elseif ($current['type'] == 'TXT' &&
       stripos($current['txt'], 'v=dkim') === 0 &&
       stripos($record[2], 'v=dkim') === 0) {
-        preg_match('/v=DKIM1;.*k=rsa;.*p=(.*)/i', $current[$data_field[$current['type']]], $dkim_matches_current);
-        preg_match('/v=DKIM1;.*k=rsa;.*p=(.*)/i', $record[2], $dkim_matches_good);
+        preg_match('/v=DKIM1;.*k=rsa;.*p=([^;]*).*/i', $current[$data_field[$current['type']]], $dkim_matches_current);
+        preg_match('/v=DKIM1;.*k=rsa;.*p=([^;]*).*/i', $record[2], $dkim_matches_good);
         if ($dkim_matches_current[1] == $dkim_matches_good[1]) {
           $state = state_good;
         }


### PR DESCRIPTION
Hi there,

yesterday I figured out that on some domain hosters the order of DKIM arguments is not like as assumed by mailcow. I tried for hours to add/edit my DKIM record for my domain but mailcow still showed a red X when validating the DNS records. I tested many other tools and websites but the DKIM record was always valid and correct. So it had to be a problem in mailcow.

I have a domain at OVH.com. The DKIM there looks as follows:
`v=DKIM1;k=rsa;s=email;p=MIIBIj......OwIDAQAB;t=s`

I found out that the `t=s` argument is at the end when adding a DKIM record at OVH.
But in mailcow the `t=s` is not allowed to be at the end. I found this line of code in [/data/web/inc/ajax/dns_diagnostics.php](https://github.com/mailcow/mailcow-dockerized/blob/master/data/web/inc/ajax/dns_diagnostics.php): 

`preg_match('/v=DKIM1;.*k=rsa;.*p=(.*)/i', .....);`

So the first regex matching group should be the DKIM key, but if in my case the `t=s` argument is at the end it will not be the case. So i just changed the regex from 

`preg_match('/v=DKIM1;.*k=rsa;.*p=(.*)/i', .....);`

to

`preg_match('/v=DKIM1;.*k=rsa;.*p=([^;]*).*/i', .....);`.

It now is possible to add other DKIM parameters like in my example `t=s` at the end of the DKIM record and be validated correctly. I tested it on my mailcow server and it worked just fine. I tested it with `t=s` at the end and after `k=rsa` like mailcow intended.

Maybe this little fix can help someone, at least for me it did 😄 