### PR TITLE
[Web] Fixed read write API permissions

### DIFF
--- a/data/web/inc/sessions.inc.php
+++ b/data/web/inc/sessions.inc.php
@@ -57,7 +57,7 @@ if (!empty($_SERVER['HTTP_X_API_KEY'])) {
       $_SESSION['mailcow_cc_username'] = 'API';
       $_SESSION['mailcow_cc_role'] = 'admin';
       $_SESSION['mailcow_cc_api'] = true;
-      if ($api_return['api_key'] == 'rw') {
+      if ($api_return['access'] == 'rw') {
         $_SESSION['mailcow_cc_api_access'] = 'rw';
       }
       else {


### PR DESCRIPTION
This fixes a issue where the read and write API key would not work.
Since the check if the API key is allowed to issue write calls, is using the wrong database table so the value ro and rw are never found and thus the else block just sets every api key to read only.