### PR TITLE
Bugfix: chmod +x would fail if needed

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -459,11 +459,12 @@ elif [[ $(curl -sL -w "%{http_code}" https://www.servercow.de/docker-compose/lat
   LATEST_COMPOSE=$(curl -#L https://www.servercow.de/docker-compose/latest.php)
   COMPOSE_VERSION=$(docker-compose version --short)
   if [[ "$LATEST_COMPOSE" != "$COMPOSE_VERSION" ]]; then
-    if [[ -w $(which docker-compose) ]]; then
-      curl -#L https://github.com/docker/compose/releases/download/${LATEST_COMPOSE}/docker-compose-$(uname -s)-$(uname -m) > $(which docker-compose)
-      chmod +x $(which docker-compose)
+    COMPOSE_PATH=$(which docker-compose) 
+    if [[ -w ${COMPOSE_PATH} ]]; then
+      curl -#L https://github.com/docker/compose/releases/download/${LATEST_COMPOSE}/docker-compose-$(uname -s)-$(uname -m) > $COMPOSE_PATH
+      chmod +x $COMPOSE_PATH
     else
-      echo -e "\e[33mWARNING: $(which docker-compose) is not writable, but new version $LATEST_COMPOSE is available (installed: $COMPOSE_VERSION)\e[0m"
+      echo -e "\e[33mWARNING: $COMPOSE_PATH is not writable, but new version $LATEST_COMPOSE is available (installed: $COMPOSE_VERSION)\e[0m"
     fi
   fi
 else


### PR DESCRIPTION
`which` only  works for executable files in `PATH`. So `chmod +x $(which docker-compose)` will only work if docker-compose is already executable.

Here a test.
```shell
copyrights@kestrel:~$ which mytest
/home/copyrights/bin/mytest
copyrights@kestrel:~$ chmod -x $(which mytest)
copyrights@kestrel:~$ chmod +x $(which mytest)
chmod: missing operand after '+x'
Try 'chmod --help' for more information.
copyrights@kestrel:~$ 

```