### PR TITLE
[Dovecot] fix error redirection at doveconf

### DIFF
--- a/data/Dockerfiles/dovecot/docker-entrypoint.sh
+++ b/data/Dockerfiles/dovecot/docker-entrypoint.sh
@@ -343,7 +343,7 @@ while [[ ${VERSIONS_OK} != 'OK' ]]; do
     sleep 3
   fi
 done
-PUBKEY_MCRYPT=$(doveconf -P | grep -i mail_crypt_global_public_key 2> /dev/null| cut -d '<' -f2)
+PUBKEY_MCRYPT=$(doveconf -P 2> /dev/null | grep -i mail_crypt_global_public_key | cut -d '<' -f2)
 if [ -f ${PUBKEY_MCRYPT} ]; then
   GUID=$(cat <(echo ${MAILCOW_HOSTNAME}) /mail_crypt/ecpubkey.pem | sha256sum | cut -d ' ' -f1 | tr -cd "[a-fA-F0-9.:/] ")
   if [ ${#GUID} -eq 64 ]; then


### PR DESCRIPTION
I find the error redirect from doveconf while dovecot instance is not launched is helpless in current https://github.com/mailcow/mailcow-dockerized/blob/731f5cb354e5015dd3c916749c966d7e60d3ff74/data/Dockerfiles/dovecot/docker-entrypoint.sh , though which seems a typo.
