### PR TITLE
It is unnecessary to run update.sh as root

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
 # Check permissions
-if [ "$(id -u)" -ne "0" ]; then
-  echo "You need to be root"
-  exit 1
+if groups | grep -vq docker; then
+  if [ "$(id -u)" -ne "0" ]; then
+    echo "You need to be root or in the docker group."
+    exit 1
+  fi
 fi
 
 if [[ "$(uname -r)" =~ ^4\.15\.0-60 ]]; then


### PR DESCRIPTION
If the current user is in the `docker` group it is unnecessary to run this
script with the `root` user.

Having `/opt/mailcow-dockeriwed` in `root:root` and executing everything
including `git pull` as `root` should be considered a bad practice for
security reasons.