### PR TITLE
PR: Rspamd default behaviour for rejected mails

### DIFF
--- a/data/Dockerfiles/rspamd/docker-entrypoint.sh
+++ b/data/Dockerfiles/rspamd/docker-entrypoint.sh
@@ -79,6 +79,10 @@ EOF
   redis-cli -h redis-mailcow SLAVEOF NO ONE
 fi
 
+if [[ "${RSPAMD_DEFAULT}" == discard ]]; then
+echo "discard_on_reject = true;" >> /etc/rspamd/override.d/worker-proxy.inc
+fi
+
 chown -R _rspamd:_rspamd /var/lib/rspamd \
   /etc/rspamd/local.d \
   /etc/rspamd/override.d \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,7 @@ services:
         - IPV6_NETWORK=${IPV6_NETWORK:-fd4d:6169:6c63:6f77::/64}
         - REDIS_SLAVEOF_IP=${REDIS_SLAVEOF_IP:-}
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
+        - RSPAMD_DEFAULT=${RSPAMD_DEFAULT}
       volumes:
         - ./data/hooks/rspamd:/hooks
         - ./data/conf/rspamd/custom/:/etc/rspamd/custom

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -297,6 +297,9 @@ MAILDIR_SUB=Maildir
 # SOGo session timeout in minutes
 SOGO_EXPIRE_SESSION=480
 
+# default behaviour for SPAM-handling (reject/discard)
+RSPAMD_DEFAULT=reject
+
 EOF
 
 mkdir -p data/assets/ssl


### PR DESCRIPTION
With this option it would be possible to change the current default behavior of rspamd (reject) to silently drop(discard) rejected mails.
In some circumstances with quarantine-enabled environments the reject-mails confuse senders so that they think their mails won't get delivered.
Afaik the action stays "reject" and should not affect other things.