### PR TITLE
netfilter - Python 3.8 - SyntaxWarning for 'is not'

### DIFF
--- a/data/Dockerfiles/netfilter/server.py
+++ b/data/Dockerfiles/netfilter/server.py
@@ -496,7 +496,7 @@ if __name__ == '__main__':
   watch_thread.daemon = True
   watch_thread.start()
 
-  if os.getenv('SNAT_TO_SOURCE') and os.getenv('SNAT_TO_SOURCE') is not 'n':
+  if os.getenv('SNAT_TO_SOURCE') and os.getenv('SNAT_TO_SOURCE') != 'n':
     try:
       snat_ip = os.getenv('SNAT_TO_SOURCE')
       snat_ipo = ipaddress.ip_address(snat_ip)


### PR DESCRIPTION
With the update to Alpine 3.11, Python 3.8 is used, so there is a SyntaxWarning in the netfilter script. I could not test it, but I would say "is not" is not correct, because `os.getenv('SNAT_TO_SOURCE') is not 'n'` is a string comparison and "!=" must be used. 
https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/

```
2020-05-12T18:02:18.029988+02:00 - docker/mailcowdockerized_netfilter-mailcow_1/441d4f8f2c67 - err ## /server.py:510: SyntaxWarning: "is not" with a literal. Did you mean "!="?
2020-05-12T18:02:18.030029+02:00 - docker/mailcowdockerized_netfilter-mailcow_1/441d4f8f2c67 - err ## if os.getenv('SNAT6_TO_SOURCE') and os.getenv('SNAT6_TO_SOURCE') is not 'n':
```