### PR TITLE
Remove obsolete setting smtpd_use_tls.

### DIFF
--- a/data/conf/postfix/main.cf
+++ b/data/conf/postfix/main.cf
@@ -6,7 +6,6 @@ append_dot_mydomain = no
 smtpd_tls_cert_file = /etc/ssl/mail/cert.pem
 smtpd_tls_key_file = /etc/ssl/mail/key.pem
 tls_server_sni_maps = hash:/opt/postfix/conf/sni.map
-smtpd_use_tls = yes
 smtpd_tls_received_header = yes
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache


### PR DESCRIPTION
See http://www.postfix.org/postconf.5.html#smtpd_use_tls. It is
controlled by smtpd_tls_security_level, which is set to may.