### PR TITLE
fixed backup failing

### DIFF
--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -117,7 +117,7 @@ function backup() {
       else
         echo "Using SQL image ${SQLIMAGE}, starting..."
         docker run --name mailcow-backup --rm \
-          --network $(docker network ls -qf name=${CMPS_PRJ}_) \
+          --network $(docker network ls -qf name=${CMPS_PRJ}_mailcow-network) \
           -v $(docker volume ls -qf name=${CMPS_PRJ}_mysql-vol-1):/var/lib/mysql/:ro \
           --entrypoint= \
           -v ${BACKUP_LOCATION}/mailcow-${DATE}:/backup \


### PR DESCRIPTION
I had the problem that my backup is failing, becaus I added a container (acme.sh) which is not using the mailcow-network. So docker created the default network. The docker network command now has returned two Networks. I added now that mailcow only searches for the own network.