### PR TITLE
Removed cd

### DIFF
--- a/helper-scripts/nextcloud.sh
+++ b/helper-scripts/nextcloud.sh
@@ -25,7 +25,6 @@ fi
 [[ ${NC_PURGE} == "y" ]] && [[ ${NC_INSTALL} == "y" ]] && { echo "Cannot use -p and -i at the same time"; }
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd ${SCRIPT_DIR}/../
 source mailcow.conf
 
 if [[ ${NC_PURGE} == "y" ]]; then


### PR DESCRIPTION
if you jump in directory and then back up to previous level, script is not able to find mailcow.conf file
```
vmi388707:/opt/mailcow-dockerized# ./install.sh -i
./install.sh: line 29: mailcow.conf: No such file or directory
Subdomain to run Nextcloud from [format: nextcloud.domain.tld]: 
```