### PR TITLE
Allow activation of own S/MIME Certificates in iOS configuration profile

### DIFF
--- a/data/web/mobileconfig.php
+++ b/data/web/mobileconfig.php
@@ -95,8 +95,16 @@ echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
         <false/>
         <key>PreventMove</key>
         <false/>
-        <key>SMIMEEnabled</key>
-        <false/>
+        <key>SMIMESigningUserOverrideable</key>
+        <true/>
+		    <key>SMIMESigningCertificateUUIDUserOverrideable</key>
+        <true/>
+		    <key>SMIMEEncryptByDefaultUserOverrideable</key>
+        <true/>
+		    <key>SMIMEEncryptionCertificateUUIDUserOverrideable</key>
+        <true/>
+		    <key>SMIMEEnableEncryptionPerMessageSwitch</key>
+        <true/>
       </dict>
       <?php if($onlyEmailAccount === false): ?>
       <dict>

--- a/data/web/mobileconfig.php
+++ b/data/web/mobileconfig.php
@@ -97,13 +97,13 @@ echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
         <false/>
         <key>SMIMESigningUserOverrideable</key>
         <true/>
-		    <key>SMIMESigningCertificateUUIDUserOverrideable</key>
+        <key>SMIMESigningCertificateUUIDUserOverrideable</key>
         <true/>
-		    <key>SMIMEEncryptByDefaultUserOverrideable</key>
+        <key>SMIMEEncryptByDefaultUserOverrideable</key>
         <true/>
-		    <key>SMIMEEncryptionCertificateUUIDUserOverrideable</key>
+        <key>SMIMEEncryptionCertificateUUIDUserOverrideable</key>
         <true/>
-		    <key>SMIMEEnableEncryptionPerMessageSwitch</key>
+        <key>SMIMEEnableEncryptionPerMessageSwitch</key>
         <true/>
       </dict>
       <?php if($onlyEmailAccount === false): ?>


### PR DESCRIPTION
When installing the provided .mobileconfig configuration profile it is impossible to enable (separately managed and installed) S/MIME certificates on the device for this email account. 

This PR enables the user to enable S/MIME signing and encryption, by default it is disabled.  Tested in iOS 13.