### PR TITLE
Chrome Bug: Workaround for losing focus of token input element

### DIFF
--- a/data/web/inc/footer.inc.php
+++ b/data/web/inc/footer.inc.php
@@ -60,7 +60,13 @@ $(document).ready(function() {
   });
   $('#u2f_status_auth').html('<p><span class="glyphicon glyphicon-refresh glyphicon-spin"></span> ' + lang_tfa.init_u2f + '</p>');
   $('#ConfirmTFAModal').on('shown.bs.modal', function(){
-      $(this).find('input[name=token]').focus();
+      var tokenInput = $(this).find('input[name=token]')
+      tokenInput.focus()
+      $(document).on("keydown", function(e) {
+        if (!$(tokenInput).is(":focus"))
+          if (e.which != 9 && e.which != 13)
+          tokenInput.focus();
+      });
       // If U2F
       if(document.getElementById("u2f_auth_data") !== null) {
         $.ajax({


### PR DESCRIPTION
When time-based OTP is used as two-factor authentication, Chrome loses focus on the token input field in the modal. I have to select the input field manually, which requires an additional click.

![totp-chrome-focus](https://user-images.githubusercontent.com/1874487/86488442-44162200-bd61-11ea-956b-8787823b28fa.gif)

This has been annoying me for a while now, but I haven't been able to find a clean solution yet. I suppose this is a bug in Chrome, because I found several reports about a wrong handling of the focus.

In Firefox everything is fine, the focus is set to the token input element after opening the modal.

Printing `document.activeElement` in the devtools of Chrome and Firefox returns different elements:

**Chrome 83**
``` html
<div class="modal fade in" id="ConfirmTFAModal" tabindex="-1" role="dialog" aria-labelledby="ConfirmTFAModalLabel" style="display: block;">...</div>
```

**Firefox 78**
``` html
<input class="form-control" type="number" min="000000" max="999999" name="token" placeholder="123456" aria-describedby="tfa-addon">
```

When logging the `document.activeElement` in the file directly after the `.focus()` call in [`footer.inc.php:L63`](https://github.com/mailcow/mailcow-dockerized/blob/master/data/web/inc/footer.inc.php#L63) Chrome correctly returns the token input element.

It seems as if Chrome removes the focus from the input element on the first keystroke and sets it to the modal itself.

I tried a few things like playing with `autofocus` or setting the focus again after a few seconds - nothing helps.
I came up with this solution that resets the focus every time a key is pressed (ignoring <kbd>&#x21B9;</kbd> and  <kbd>↵</kbd>)- but I feel like it's a dirty hack.

Does anyone have a better idea?