### PR TITLE
[Web] Allow underscore and hyphen in DKIM selector

### DIFF
--- a/data/web/inc/functions.dkim.inc.php
+++ b/data/web/inc/functions.dkim.inc.php
@@ -34,7 +34,7 @@ function dkim($_action, $_data = null, $privkey = false) {
           );
           continue;
         }
-        if (!ctype_alnum($dkim_selector)) {
+        if (!ctype_alnum(str_replace(['-', '_'], '', $dkim_selector))) {
           $_SESSION['return'][] = array(
             'type' => 'danger',
             'log' => array(__FUNCTION__, $_action, $_data, $privkey),


### PR DESCRIPTION
This change allows to have cleaner DNS zones as mail security related entries usually begin with _.
Also the default dkim selector was changed to _dkim.
I tested it and Google recognizes this selector without a single hitch.