### PR TITLE
Allow CIDR notation for API_ALLOW_FROM

### DIFF
--- a/data/Dockerfiles/phpfpm/docker-entrypoint.sh
+++ b/data/Dockerfiles/phpfpm/docker-entrypoint.sh
@@ -116,8 +116,8 @@ if [[ "${MASTER}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
   if [[ ${API_ALLOW_FROM} != "invalid" ]] && [[ ! -z ${API_ALLOW_FROM} ]]; then
     IFS=',' read -r -a API_ALLOW_FROM_ARR <<< "${API_ALLOW_FROM}"
     declare -a VALIDATED_API_ALLOW_FROM_ARR
-    REGEX_IP6='^([0-9a-fA-F]{0,4}:){1,7}[0-9a-fA-F]{0,4}$'
-    REGEX_IP4='^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'
+    REGEX_IP6='^([0-9a-fA-F]{0,4}:){1,7}[0-9a-fA-F]{0,4}(/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))?$'
+    REGEX_IP4='^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/([0-9]|[1-2][0-9]|3[0-2]))?$'
     for IP in "${API_ALLOW_FROM_ARR[@]}"; do
       if [[ ${IP} =~ ${REGEX_IP6} ]] || [[ ${IP} =~ ${REGEX_IP4} ]]; then
         VALIDATED_API_ALLOW_FROM_ARR+=("${IP}")


### PR DESCRIPTION
The documentation mentions that currently the regex in `php-fpm/docker-entrypoint.sh` does not support CIDR notation for the `API_ALLOW_FROM` variable. As the CIDR notation is already supported via the webinterface I fixed the regex.

See also https://github.com/mailcow/mailcow-dockerized/pull/2855.