### PR TITLE
Watchdog: Allow sending notifications via Slack webhooks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -457,6 +457,7 @@ services:
         - OLEFY_THRESHOLD=5
         - MAILQ_THRESHOLD=20
         - MAILQ_CRIT=30
+          WATCHDOG_SLACK_URL=${WATCHDOG_SLACK_URL}
       networks:
         mailcow-network:
           aliases:

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -249,6 +249,11 @@ ALLOW_ADMIN_EMAIL_LOGIN=n
 #WATCHDOG_NOTIFY_EMAIL=a@example.com,b@example.com,c@example.com
 #WATCHDOG_NOTIFY_EMAIL=
 
+# Send watchdog notifications via a slack webhook.
+# The webhook URL can be generated using the guide here: https://api.slack.com/messaging/webhooks
+
+# WATCHDOG_SLACK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
+
 # Notify about banned IP (includes whois lookup)
 WATCHDOG_NOTIFY_BAN=y
 


### PR DESCRIPTION
With this commit we allow watchdog notifications to be sent to a Slack
channel via a Slack webhook (https://api.slack.com/messaging/webhooks).

Notifications are sent to all defined methods. That if both watchdog
e-mail and slack webhook is defined, notifications are sent to both. If
only one of them are defined, only one notification method will be used.

In order to do so, a bunch of if statements were moved to the
`mail_error` function.