### PR TITLE
Disable SMTPUTF8 in Postfix due Dovecot-LMTP isn't support it

### DIFF
--- a/data/conf/postfix/main.cf
+++ b/data/conf/postfix/main.cf
@@ -188,7 +188,7 @@ transport_maps = pcre:/opt/postfix/conf/custom_transport.pcre,
 smtp_sasl_auth_soft_bounce = no
 postscreen_discard_ehlo_keywords = silent-discard, dsn
 compatibility_level = 2
-smtputf8_enable = yes
+smtputf8_enable = no
 # Define protocols for SMTPS and submission service
 submission_smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
 smtps_smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1


### PR DESCRIPTION
SMTPUTF8 to work correctly must be done end-to-end. Leaving it enabled now when LMTP can't receive such email gives more issues then profit.