### PR TITLE
Add urlhaus map with urls to rspamd

### DIFF
--- a/data/conf/rspamd/local.d/multimap.conf
+++ b/data/conf/rspamd/local.d/multimap.conf
@@ -156,3 +156,10 @@ BAZAR_ABUSE_CH {
   map = "https://bazaar.abuse.ch/export/txt/md5/recent/";
   score = 10.0;
 }
+
+URLHAUS_ABUSE_CH {
+  type = "url";
+  filter = "full";
+  map = "https://urlhaus.abuse.ch/downloads/text_online/";
+  score = 10.0;
+}


### PR DESCRIPTION
Add the list with recent online malware urls from URLhaus into rspamd to check against. In addition to the already included map with recent hashes from Malware Bazaar
https://urlhaus.abuse.ch/api/#retrieve