### PR TITLE
Update dkim_signing.conf

### DIFF
--- a/data/conf/rspamd/local.d/dkim_signing.conf
+++ b/data/conf/rspamd/local.d/dkim_signing.conf
@@ -7,7 +7,7 @@ allow_hdrfrom_multiple = true;
 # If true, username does not need to contain matching domain
 allow_username_mismatch = true;
 # If false, messages from authenticated users are not selected for signing
-auth_only = true;
+sign_authenticated = true;
 # Default path to key, can include '$domain' and '$selector' variables
 path = "/data/dkim/keys/$domain.dkim";
 # Default selector to use


### PR DESCRIPTION
auth_only is deprecated, new settings which need to be used instead is sign_authenticated