### PR TITLE
Update arc.conf

### DIFF
--- a/data/conf/rspamd/local.d/arc.conf
+++ b/data/conf/rspamd/local.d/arc.conf
@@ -7,7 +7,7 @@ allow_hdrfrom_multiple = false;
 # If true, username does not need to contain matching domain
 allow_username_mismatch = false;
 # If false, messages from authenticated users are not selected for signing
-auth_only = false;
+sign_authenticated = false;
 # Default path to key, can include '$domain' and '$selector' variables
 path = "/data/dkim/keys/$domain.dkim";
 # Default selector to use


### PR DESCRIPTION
auth_only is deprecated, new settings which need to be used instead is sign_authenticated