### PR TITLE
Removed typo when adding a row

### DIFF
--- a/data/web/js/site/admin.js
+++ b/data/web/js/site/admin.js
@@ -465,7 +465,7 @@ jQuery(function($){
     if (type == "app_link") {
     cols = '<td><input class="input-sm form-control" data-id="app_links" type="text" name="app" required></td>';
     cols += '<td><input class="input-sm form-control" data-id="app_links" type="text" name="href" required></td>';
-    cols += '<td><a href="#" role="button" class="btn btn-xs btn-default" type="button">">' + lang.remove_row + '</a></td>';
+    cols += '<td><a href="#" role="button" class="btn btn-xs btn-default" type="button">' + lang.remove_row + '</a></td>';
     } else if (type == "f2b_regex") {
     cols = '<td><input style="text-align:center" class="input-sm form-control" data-id="f2b_regex" type="text" value="+" disabled></td>';
     cols += '<td><input class="input-sm form-control regex-input" data-id="f2b_regex" type="text" name="regex" required></td>';


### PR DESCRIPTION
Hi there !

When adding row the name of the button is  `"> lang.remove_row` instead of just `lang.remove_row`

Can be showed in App links section of config in the dashboard

It's showing this
![image](https://user-images.githubusercontent.com/8531333/92412650-f6e17280-f14c-11ea-9777-decca4f82222.png)

Instead of
![image](https://user-images.githubusercontent.com/8531333/92412670-06f95200-f14d-11ea-8bbd-9371280c56b6.png)

Have a nice day !