### PR TITLE
[Rspamd] Add open-relay-check@mailcow.email to monitoring_nolog.map

### DIFF
--- a/data/conf/rspamd/custom/monitoring_nolog.map
+++ b/data/conf/rspamd/custom/monitoring_nolog.map
@@ -4,3 +4,4 @@
 /watchdog@localhost/i
 /supertool@mxtoolbox\.com/i
 /test@mxtoolboxsmtpdiag\.com/i
+/open-relay-check@mailcow\.email/i


### PR DESCRIPTION
Adding open-relay-check@mailcow.email to monitoring_nolog.map, because i think that this is good option for all mailcow instances.