### PR TITLE
Filter für "ARC/DKIM-Keys"-Liste

### DIFF
--- a/data/web/admin.php
+++ b/data/web/admin.php
@@ -434,9 +434,9 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
       <div class="panel-heading"><?=$lang['admin']['dkim_keys'];?></div>
       <div class="panel-body">
         <div class="btn-group" data-toggle="button" style="margin-bottom: 20px;">
-          <a class="btn btn-sm btn-default active" href="#" data-toggle="collapse" data-target=".dkim_key_valid"><?=$lang['admin']['dkim_key_valid'];?></a>
-          <a class="btn btn-sm btn-default active" href="#" data-toggle="collapse" data-target=".dkim_key_unused"><?=$lang['admin']['dkim_key_unused'];?></a>
-          <a class="btn btn-sm btn-default active" href="#" data-toggle="collapse" data-target=".dkim_key_missing"><?=$lang['admin']['dkim_key_missing'];?></a>
+          <a class="btn btn-sm btn-default active" href="#" data-toggle="collapse" data-target="dkim_key_valid"><?=$lang['admin']['dkim_key_valid'];?></a>
+          <a class="btn btn-sm btn-default active" href="#" data-toggle="collapse" data-target="dkim_key_unused"><?=$lang['admin']['dkim_key_unused'];?></a>
+          <a class="btn btn-sm btn-default active" href="#" data-toggle="collapse" data-target="dkim_key_missing"><?=$lang['admin']['dkim_key_missing'];?></a>
         </div>
         <?php
         foreach(mailbox('get', 'domains') as $domain) {

--- a/data/web/admin.php
+++ b/data/web/admin.php
@@ -433,11 +433,10 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
     <div class="panel panel-default">
       <div class="panel-heading"><?=$lang['admin']['dkim_keys'];?></div>
       <div class="panel-body">
-        <div class="mass-actions-admin">
-          <div class="btn-group btn-group-sm">
-            <button type="button" id="toggle_multi_select_all" data-id="dkim" class="btn btn-default"><?=$lang['mailbox']['toggle_all'];?></button>
-            <button type="button" data-action="delete_selected" name="delete_selected" data-id="dkim" data-api-url="delete/dkim" class="btn btn-danger"><?=$lang['admin']['remove'];?></button>
-          </div>
+        <div class="btn-group" data-toggle="button" style="margin-bottom: 20px;">
+          <a class="btn btn-sm btn-default active" href="#" data-toggle="collapse" data-target=".dkim_key_valid"><?=$lang['admin']['dkim_key_valid'];?></a>
+          <a class="btn btn-sm btn-default active" href="#" data-toggle="collapse" data-target=".dkim_key_unused"><?=$lang['admin']['dkim_key_unused'];?></a>
+          <a class="btn btn-sm btn-default active" href="#" data-toggle="collapse" data-target=".dkim_key_missing"><?=$lang['admin']['dkim_key_missing'];?></a>
         </div>
         <?php
         foreach(mailbox('get', 'domains') as $domain) {
@@ -445,7 +444,7 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
               $dkim_domains[] = $domain;
               ($GLOBALS['SHOW_DKIM_PRIV_KEYS'] === true) ?: $dkim['privkey'] = base64_encode('Please set $SHOW_DKIM_PRIV_KEYS to true to show DKIM private keys.');
           ?>
-            <div class="row">
+            <div class="row collapse in dkim_key_valid">
               <div class="col-md-1"><input type="checkbox" data-id="dkim" name="multi_select" value="<?=$domain;?>" /></div>
               <div class="col-md-3">
                 <p><?=$lang['admin']['domain'];?>: <strong><?=htmlspecialchars($domain);?></strong>
@@ -464,7 +463,7 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
           }
           else {
           ?>
-          <div class="row">
+          <div class="row collapse in dkim_key_missing">
             <div class="col-md-1"><input class="dkim_missing" type="checkbox" data-id="dkim" name="multi_select" value="<?=$domain;?>" disabled /></div>
             <div class="col-md-3">
               <p><?=$lang['admin']['domain'];?>: <strong><?=htmlspecialchars($domain);?></strong><br /><span class="label label-danger"><?=$lang['admin']['dkim_key_missing'];?></span></p>
@@ -479,7 +478,7 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
               $dkim_domains[] = $alias_domain;
               ($GLOBALS['SHOW_DKIM_PRIV_KEYS'] === true) ?: $dkim['privkey'] = base64_encode('Please set $SHOW_DKIM_PRIV_KEYS to true to show DKIM private keys.');
             ?>
-              <div class="row">
+              <div class="row collapse in dkim_key_valid">
               <div class="col-md-1"><input type="checkbox" data-id="dkim" name="multi_select" value="<?=$alias_domain;?>" /></div>
                 <div class="col-md-2 col-md-offset-1">
                   <p><small>↳ Alias-Domain: <strong><?=htmlspecialchars($alias_domain);?></strong></small>
@@ -498,7 +497,7 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
             }
             else {
             ?>
-            <div class="row">
+            <div class="row collapse in dkim_key_missing">
               <div class="col-md-1"><input class="dkim_missing" type="checkbox" data-id="dkim" name="multi_select" value="<?=$alias_domain;?>" disabled /></div>
               <div class="col-md-2 col-md-offset-1">
                 <p><small>↳ Alias-Domain: <strong><?=htmlspecialchars($alias_domain);?></strong><br /></small><span class="label label-danger"><?=$lang['admin']['dkim_key_missing'];?></span></p>
@@ -515,7 +514,7 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
             $dkim_domains[] = $blind;
             ($GLOBALS['SHOW_DKIM_PRIV_KEYS'] === true) ?: $dkim['privkey'] = base64_encode('Please set $SHOW_DKIM_PRIV_KEYS to true to show DKIM private keys.');
           ?>
-            <div class="row">
+            <div class="row collapse in dkim_key_unused">
               <div class="col-md-1"><input type="checkbox" data-id="dkim" name="multi_select" value="<?=$blind;?>" /></div>
               <div class="col-md-3">
                 <p><?=$lang['admin']['domain'];?>: <strong><?=htmlspecialchars($blind);?></strong>
@@ -534,6 +533,12 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
           }
         }
         ?>
+        <div class="mass-actions-admin">
+          <div class="btn-group btn-group-sm">
+            <button type="button" id="toggle_multi_select_all" data-id="dkim" class="btn btn-default"><span class="glyphicon glyphicon-check" aria-hidden="true"></span> <?=$lang['mailbox']['toggle_all'];?></button>
+            <button type="button" data-action="delete_selected" name="delete_selected" data-id="dkim" data-api-url="delete/dkim" class="btn btn-danger"><span class="glyphicon glyphicon-trash"></span> <?=$lang['admin']['remove'];?></button>
+          </div>
+        </div>
 
         <legend style="margin-top:40px"><?=$lang['admin']['dkim_add_key'];?></legend>
         <form class="form" data-id="dkim" role="form" method="post">


### PR DESCRIPTION
Hiermit werden Buttons hinzugefügt, um die Einträge der "ARC/DKIM-Keys"-Liste je nach Status ein- und ausblenden zu können. Zu Beginn sind alle Buttons gedrückt und es werden wie zuvor alle Einträge angezeigt.

![grafik](https://user-images.githubusercontent.com/5744732/95017520-0b386280-065a-11eb-8201-fbc176ba08f2.png)
![grafik](https://user-images.githubusercontent.com/5744732/95017530-1c816f00-065a-11eb-8c28-257ec55c4d5a.png)

Die Buttons "Alle" und "Entfernen" habe ich unter die Auflistung verschoben und um die zugehörigen Icons ergänzt.

![grafik](https://user-images.githubusercontent.com/5744732/95017506-f065ee00-0659-11eb-9686-36d46ee520ee.png)

Optimierungspotential:
- Ein- und Ausblendung haben keine Auswirkung darauf, welche Einträge mittels Checkbox selektiert sind. Je nach persönlichen Geschmack ist das ein Bug oder ein Feature. Da aber alle zu löschenden Keys im modalen Dialog nochmals aufgezählt werden, sollte das kein Problem darstellen.
- Ebenso wählt der "Alle"-Button auch ausgeblendete Einträge an un ab. Das ist unpraktisch, wenn man nach Keys ohne Zuordnung filtert und diese alle schnell löschen möchte. Ggf. sollte seine Auswirkung auf die aktuell sichtbaren Keys limitiert werden.
- Wie im folgenden Screenshot zu sehen geht die Zuordnung von Alias-Domains zu deren Hauptdomain verloren, falls diese durch den Filter ausgeblendet werden:
![grafik](https://user-images.githubusercontent.com/5744732/95017658-032cf280-065b-11eb-9c7c-9beff559ae5e.png)




