### PR TITLE
Make mailcow.conf in backups accessible to other users

### DIFF
--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -81,6 +81,7 @@ function backup() {
   mkdir -p "${BACKUP_LOCATION}/mailcow-${DATE}"
   chmod 755 "${BACKUP_LOCATION}/mailcow-${DATE}"
   cp "${SCRIPT_DIR}/../mailcow.conf" "${BACKUP_LOCATION}/mailcow-${DATE}"
+  chmod 644 "${BACKUP_LOCATION}/mailcow-${DATE}/mailcow.conf"
   while (( "$#" )); do
     case "$1" in
     vmail|all)


### PR DESCRIPTION
To process the backups further on, like rsync them to another system, one should be able to do this w/o root/sudo, hence giving 644 for mailcow.conf as it has originally 600.

As the datafiles are already accessible by other users, I don't see a security issue here.