### PR TITLE
fixed api

### DIFF
--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -54,7 +54,7 @@ if (isset($_SESSION['mailcow_cc_role']) || isset($_SESSION['pending_mailcow_cc_u
     $extra =      (isset($query[3])) ? $query[3] : null;
 
     // accept json in request body
-    if($_SERVER['HTTP_CONTENT_TYPE'] === 'application/json') {
+    if(strpos($_SERVER['HTTP_CONTENT_TYPE'], 'application/json') !== false) {
       $request = file_get_contents('php://input');
       $requestDecoded = json_decode($request, true);
 


### PR DESCRIPTION
I played a little bit with the API and I was unable to send some api-requests with the extra `charset=UTF-8`  as `Content-Type` as the api throws an error with
```json
{
    "type": "error",
    "msg": "Cannot find attributes in post data"
}
```

For example:
```bash
curl -H 'accept: application/json' -H 'x-api-key: MY-VERY-SECRET-API-KEY' -H 'content-type: application/json; charset=utf-8' -d '["mail-3@domain.tld"]' --compressed 'http://domain.tld/api/v1/delete/mailbox'
``` 

The Pull-Request changes the check from
```php
 if($_SERVER['HTTP_CONTENT_TYPE'] === 'application/json') {}
```

to

```php
if(strpos($_SERVER['HTTP_CONTENT_TYPE'], 'application/json') !== false) {}
```

to check if the `$_SERVER['HTTP_CONTENT_TYPE']` contains `application/json`.