### PR TITLE
[WEB] Let admins log into Roundcube without password

### DIFF
--- a/data/web/inc/lib/RoundcubeAutoLogin.php
+++ b/data/web/inc/lib/RoundcubeAutoLogin.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Class to automatically login on a Roundcube installation
+ * @compatibility RoundCube 1.0.2+
+ */
+
+// original script by Philipp C. Heckel https://blog.heckel.io/2008/05/16/roundcube-login-via-php-script/
+// source: https://github.com/alexjeen/Roundcube-AutoLogin
+
+// a roundcube exception class
+class RoundCubeException extends Exception {}
+
+// main class
+class RoundcubeAutoLogin {
+    // roundcube link (with a trailing slash)
+    private $_rc_link = '';
+
+    private $cookieJar;
+
+    /**
+     * Creates a new RC object and temporary file for cookies
+     * @param $roundcube_link the roundcube link with a trailing slash
+     */
+    public function __construct($roundcube_link) {
+        $this->_rc_link = $roundcube_link;
+        $this->cookieJar = tempnam("/tmp", "cookie.txt");
+    }
+
+    /**
+     * Deletes temp file
+     */
+    public function __destruct() {
+        unlink($this->cookieJar);
+    }
+
+    /**
+     * Tries to log a RC user in using cURL. Does two requests. One to
+     * get a session token to perform the login, and one to do the actual
+     * login of the user
+     *
+     * @param $email the full e-mailaddress of the user
+     * @param $password the password of the user
+     *
+     * @returns The cookies you should set with setcookie
+     */
+    public function login($email, $password) {
+        try {
+            $token = $this->_get_token();
+
+            if($token === FALSE) {
+                throw new RoundCubeException('Unable to get token, is your RC link correct?');
+            }
+
+            // make the request to roundcube
+            $post_params = array(
+                '_token' => $token,
+                '_task' => 'login',
+                '_action' => 'login',
+                '_timezone' => '',
+                '_url' => '',
+                '_user' => $email,
+                '_pass' => $password
+            );
+
+            $ch = curl_init();
+            curl_setopt($ch, CURLOPT_URL, $this->_rc_link . '?_task=login');
+            curl_setopt($ch, CURLOPT_COOKIEFILE, realpath($this->cookieJar));
+            curl_setopt($ch, CURLOPT_COOKIEJAR, realpath($this->cookieJar));
+            curl_setopt($ch, CURLOPT_POST, TRUE);
+            curl_setopt($ch, CURLOPT_HEADER, TRUE);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($post_params));
+            $response = curl_exec($ch);
+            $response_info = curl_getinfo($ch);
+            curl_close($ch);
+
+            if($response_info['http_code'] == 302) {
+                // find all relevant cookies to set (php session + rc auth cookie)
+                preg_match_all('/Set-Cookie: (.*)\b/i', $response, $cookies);
+
+                $cookie_return = array();
+
+                foreach($cookies[1] as $cookie) {
+                    preg_match('|([A-z0-9\_]*)=([A-z0-9\_\-]*);|', $cookie, $cookie_match);
+                    if($cookie_match) {
+                        $cookie_return[$cookie_match[1]] = $cookie_match[2];
+                    }
+                }
+
+                return $cookie_return;
+            } else {
+                throw new RoundCubeException('Login failed, please check your credentials.');
+            }
+
+        } catch(RoundCubeException $e) {
+            echo 'RC error: ' . $e->getMessage();
+        } catch(Exception $e) {
+            echo 'General error: ' . $e->getMessage();
+        }
+    }
+
+    /**
+     * Redirect to RC
+     */
+    public function redirect() {
+        header('Location: ' . $this->_rc_link . '?task=mail');
+    }
+
+    /**
+     * Gets a token to use for the login
+     */
+    private function _get_token() {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $this->_rc_link);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+        curl_setopt($ch, CURLOPT_COOKIEJAR, realpath($this->cookieJar));
+        $response = curl_exec($ch);
+        curl_close($ch);
+
+        preg_match('|<input type="hidden" name="_token" value="([A-z0-9]*)">|', $response, $matches);
+
+        if($matches) {
+            return $matches[1];
+        } else {
+            return FALSE;
+        }
+    }
+}

--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -426,6 +426,9 @@ jQuery(function($){
               if (ALLOW_ADMIN_EMAIL_LOGIN) {
                 item.action += '<a href="/sogo-auth.php?login=' + encodeURIComponent(item.username) + '" class="login_as btn btn-xs btn-primary" target="_blank"><span class="glyphicon glyphicon-envelope"></span> SOGo</a>';
               }
+              if (ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE) {
+                item.action += '<a href="/rc-auth.php?login=' + encodeURIComponent(item.username) + '" class="login_as btn btn-xs btn-primary" target="_blank"><span class="glyphicon glyphicon-envelope"></span> Roundcube</a>';
+              }
               item.action += '</div>';
             }
             else {

--- a/data/web/mailbox.php
+++ b/data/web/mailbox.php
@@ -618,10 +618,15 @@ echo "var role = '". $role . "';\n";
 echo "var is_dual = " . $is_dual . ";\n";
 echo "var pagination_size = '". $PAGINATION_SIZE . "';\n";
 $ALLOW_ADMIN_EMAIL_LOGIN = (preg_match(
-	"/^([yY][eE][sS]|[yY])+$/",
+	"/^(yes|y)+$/i",
     $_ENV["ALLOW_ADMIN_EMAIL_LOGIN"]
 )) ? "true" : "false";
 echo "var ALLOW_ADMIN_EMAIL_LOGIN = " . $ALLOW_ADMIN_EMAIL_LOGIN . ";\n";
+$ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE = (preg_match(
+  "/^(yes|y)+$/i",
+  $_ENV["ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE"]
+)) ? "true" : "false";
+echo "var ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE = " . $ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE . ";\n";
 ?>
 </script>
 <?php

--- a/data/web/rc-auth.php
+++ b/data/web/rc-auth.php
@@ -1,0 +1,64 @@
+<?php
+
+$ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE = (preg_match(
+  "/^(yes|y)+$/i",
+  $_ENV["ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE"]
+));
+
+// prevent if feature is disabled
+if (!$ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE) {
+  header('HTTP/1.0 403 Forbidden');
+  echo "this feature is disabled";
+  exit;
+}
+
+require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
+$AuthUsers = array("admin", "domainadmin");
+if (!isset($_SESSION['mailcow_cc_role']) || !in_array($_SESSION['mailcow_cc_role'], $AuthUsers) || $_SESSION['acl']['login_as'] != "1") {
+    header('HTTP/1.0 403 Forbidden');
+    exit();
+}
+
+$login = html_entity_decode(rawurldecode($_GET["login"]));
+if (!hasMailboxObjectAccess($_SESSION['mailcow_cc_username'], $_SESSION['mailcow_cc_role'], $login)){
+    header('HTTP/1.0 403 Forbidden');
+    exit();
+}
+
+// find roundcube installation
+
+if (empty($MAILCOW_APPS)){
+    header('HTTP/1.0 501 Not Implemented');
+    echo "Roundcube is not installed";
+    exit();
+}
+
+$rc_path = null;
+foreach ($MAILCOW_APPS as $app) {
+    $filename = $_SERVER['DOCUMENT_ROOT'] . $app['link'] . 'README.md';
+    if (is_file($filename) && file_get_contents($filename, false, null, 0, 9) == 'Roundcube'){
+        $rc_path = $app['link'];
+        break;
+    }
+}
+
+if (!$rc_path){
+    header('HTTP/1.0 501 Not Implemented');
+    echo "Roundcube is not installed";
+    exit();
+}
+
+require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/lib/RoundcubeAutoLogin.php';
+
+$url = "https://$mailcow_hostname:" . $_SERVER['SERVER_PORT'] . $rc_path;
+$rc = new RoundcubeAutoLogin($url);
+
+list($master_user, $master_passwd) = explode(':', trim(file_get_contents('/etc/sogo/sieve.creds')));
+
+$cookies = $rc->login($login . '*' . $master_user, $master_passwd);
+
+foreach ($cookies as $cookie_name => $cookie_value) {
+    setcookie($cookie_name, $cookie_value, 0, '/', '');
+}
+
+$rc->redirect();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,6 +151,7 @@ services:
         - SKIP_CLAMD=${SKIP_CLAMD:-n}
         - SKIP_SOGO=${SKIP_SOGO:-n}
         - ALLOW_ADMIN_EMAIL_LOGIN=${ALLOW_ADMIN_EMAIL_LOGIN:-n}
+        - ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE=${ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE:-n}
         - MASTER=${MASTER:-y}
       restart: always
       networks:

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -240,6 +240,11 @@ SOLR_HEAP=1024
 
 ALLOW_ADMIN_EMAIL_LOGIN=n
 
+# Allow admins to log into Roundcube as email user (without any password)
+# Roundcube with plugin dovecot_impersonate must be installed first
+
+ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE=\$ALLOW_ADMIN_EMAIL_LOGIN
+
 # Enable watchdog (watchdog-mailcow) to restart unhealthy containers
 
 USE_WATCHDOG=y

--- a/update.sh
+++ b/update.sh
@@ -212,6 +212,7 @@ CONFIG_ARRAY=(
   "SKIP_SOLR"
   "ENABLE_SSL_SNI"
   "ALLOW_ADMIN_EMAIL_LOGIN"
+  "ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE"
   "SKIP_HTTP_VERIFICATION"
   "SOGO_EXPIRE_SESSION"
   "REDIS_PORT"
@@ -374,6 +375,13 @@ for option in ${CONFIG_ARRAY[@]}; do
     if ! grep -q ${option} mailcow.conf; then
       echo "Adding new option \"${option}\" to mailcow.conf"
       echo "REDIS_PORT=127.0.0.1:7654" >> mailcow.conf
+  fi
+  elif [[ ${option} == "ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE" ]]; then
+    if ! grep -q ${option} mailcow.conf; then
+      echo "Adding new option \"${option}\" to mailcow.conf"
+      echo '# Allow admins to log into Roundcube as email user (without any password)' >> mailcow.conf
+      echo '# Roundcube with plugin dovecot_impersonate must be installed first' >> mailcow.conf
+      echo 'ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE=$ALLOW_ADMIN_EMAIL_LOGIN' >> mailcow.conf
   fi
   elif [[ ${option} == "DOVECOT_MASTER_USER" ]]; then
     if ! grep -q ${option} mailcow.conf; then


### PR DESCRIPTION
**What does it do?**

This PR implements a similar feature as the password-less SOGo admin login: admins and domain admins can login to Roundcube by clicking a button on the admin interface, without having to enter any password.

![rc](https://user-images.githubusercontent.com/5840038/98595729-a5816b00-22d6-11eb-99e1-80fd21ef344c.png)


**Prerequisites**

Admins need to install Roundcube and the plugin [dovecot_impersonate](https://github.com/corbosman/dovecot_impersonate/).

**How does it work?**

PHP reads the `/etc/sogo/sieve.creds` file which contains the password for dovecot's master user. Then it logs in with the master password by sending curl HTTP requests to Roundcube, basically mimicking a browser. Finally it sets the retrieved roundcube authentication cookies for the user and redirects him/her to Roundcube.

Note: if a user is in the *Force password update at next login* state, even admins can't access emails by this method.

---

I'm not sure if you want to include this as Roundcube is not installed by default. Nonetheless too many things need to be modified if you want this feature, so I think it is easier to include the code than writing a manual patch in the docs.