### PR TITLE
Removed needs triage label from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: 🐞 Bug Report
 about: Report a reproducible bug for mailcow. (NOT to be used for support questions.)
-labels: bug, Needs triage
+labels: bug
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: 💡 Feature Request
 about: Suggest an idea for mailcow.
-labels: enhancement, Needs triage
+labels: enhancement
 ---
 
 <!--


### PR DESCRIPTION
I don't think we need `Needs triage` label as there're too few issues opened to be useful enough.