### PR TITLE
Fix typos: BusybBox -> BusyBox

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -17,11 +17,11 @@ if [[ "$(uname -r)" =~ ^4\.4\. ]]; then
 fi
 
 if grep --help 2>&1 | grep -q -i "busybox"; then
-  echo "BusybBox grep detected, please install gnu grep, \"apk add --no-cache --upgrade grep\""
+  echo "BusyBox grep detected, please install gnu grep, \"apk add --no-cache --upgrade grep\""
   exit 1
 fi
 if cp --help 2>&1 | grep -q -i "busybox"; then
-  echo "BusybBox cp detected, please install coreutils, \"apk add --no-cache --upgrade coreutils\""
+  echo "BusyBox cp detected, please install coreutils, \"apk add --no-cache --upgrade coreutils\""
   exit 1
 fi
 

--- a/update.sh
+++ b/update.sh
@@ -180,9 +180,9 @@ if [ ${#DOTS} -lt 2 ]; then
   exit 1
 fi
 
-if grep --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusybBox grep detected, please install gnu grep, \"apk add --no-cache --upgrade grep\""; exit 1; fi
-if cp --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusybBox cp detected, please install coreutils, \"apk add --no-cache --upgrade coreutils\""; exit 1; fi
-if sed --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusybBox sed detected, please install gnu sed, \"apk add --no-cache --upgrade sed\""; exit 1; fi
+if grep --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusyBox grep detected, please install gnu grep, \"apk add --no-cache --upgrade grep\""; exit 1; fi
+if cp --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusyBox cp detected, please install coreutils, \"apk add --no-cache --upgrade coreutils\""; exit 1; fi
+if sed --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusyBox sed detected, please install gnu sed, \"apk add --no-cache --upgrade sed\""; exit 1; fi
 
 CONFIG_ARRAY=(
   "SKIP_LETS_ENCRYPT"


### PR DESCRIPTION
Corrects `BusybBox` to `BusyBox` in `generate_config.sh` and `update.sh`.