### PR TITLE
[WEB] Set domain to filtered one by default when creating new mailbox

### DIFF
--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -125,6 +125,18 @@ $(document).ready(function() {
       }
     });
   });
+  // Add Mailbox Modal
+  var addMailboxModalShown = false;
+  $('#addMailboxModal').on('show.bs.modal', function(e) {
+    if (addMailboxModalShown) {
+      return;
+    }
+    addMailboxModalShown = true;
+    var $domainSelect = $("#mailbox_table select");
+    if ($domainSelect[0].selectedIndex > 0) { // not "All Domains"
+      $("#addSelectDomain").val($domainSelect.val()).change().selectpicker("render");
+    }
+  });
   // Log modal
   $('#dnsInfoModal').on('show.bs.modal', function(e) {
     var domain = $(e.relatedTarget).data('domain');


### PR DESCRIPTION
This is a little convenience feature for admins: if one selects a domain in the dropdown to filter mailboxes, it is reasonable to assume that if they want to add a new mailbox, they want to add it to the selected domain.

![mm](https://user-images.githubusercontent.com/5840038/101116745-fd657600-35e5-11eb-80c6-818ad1aa7470.gif)
