### PR TITLE
[Config] Add Wikipedia link for TZ values

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -170,6 +170,8 @@ SOLR_PORT=127.0.0.1:18983
 REDIS_PORT=127.0.0.1:7654
 
 # Your timezone
+# See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of timezones
+# Use the row named 'TZ database name' + pay attention for 'Notes' row
 
 TZ=${MAILCOW_TZ}
 


### PR DESCRIPTION
Add a Wikipedia link for TZ values because users tend to insert any random value for the TZ variable and thus have errors