### PR TITLE
[Api docs] Added day ratelimit option to /add/domain endpoint

### DIFF
--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -533,6 +533,7 @@ paths:
                     - s
                     - m
                     - h
+                    - d
                   type: string
                 rl_value:
                   description: rate limit value


### PR DESCRIPTION
This fixes and is related to https://github.com/mailcow/mailcow-dockerized/issues/3906.