### PR TITLE
Use tmpfs for watchdog's /tmp, reduce disk writes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -410,6 +410,8 @@ services:
       #command: /watchdog.sh
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
+      tmpfs:
+        - /tmp
       volumes:
         - rspamd-vol-1:/var/lib/rspamd:z
         - mysql-socket-vol-1:/var/run/mysqld/:z


### PR DESCRIPTION
Watchdog container writes data to /tmp quite frequently, which lead to unnecessary (excessive) disk writes, which is an issue for SSD.
Use tmpfs for /tmp inside the container to make it write to RAM.