### PR TITLE
[docs] /api/v1/edit/mailbox Changed type of items parameter to list

### DIFF
--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -3035,7 +3035,8 @@ paths:
                     - domain3.tld
                     - "*"
                   sogo_access: "1"
-                items: info@domain.tld
+                items:
+                  - info@domain.tld
               properties:
                 attr:
                   properties:


### PR DESCRIPTION
As the Swagger UI displays the items object in the request body as a String instead of a list, requests made with this method would lead into empty responses. 