### PR TITLE
[Web] Implement all supported dovecot password schemas

### DIFF
--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -382,6 +382,7 @@ service auth {
     mode = 0600
     user = vmail
   }
+  vsz_limit = 2G
 }
 service managesieve-login {
   inet_listener sieve {

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -1055,7 +1055,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               return false;
             }
             // support pre hashed passwords
-            if (preg_match('/^({SSHA256}|{SSHA}|{SHA512-CRYPT}|{SSHA512}|{MD5-CRYPT}|{PLAIN-MD5})/i', $password)) {
+            if (preg_match('/^{(ARGON2I|ARGON2ID|BLF-CRYPT|CLEAR|CLEARTEXT|CRYPT|DES-CRYPT|LDAP-MD5|MD5|MD5-CRYPT|PBKDF2|PLAIN|PLAIN-MD4|PLAIN-MD5|PLAIN-TRUNC|PLAIN-TRUNC|SHA|SHA1|SHA256|SHA256-CRYPT|SHA512|SHA512-CRYPT|SMD5|SSHA|SSHA256|SSHA512)}/i', $password)) {
               $password_hashed = $password;
             }
             else {
@@ -2557,7 +2557,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                 continue;
               }
               // support pre hashed passwords
-              if (preg_match('/^({SSHA256}|{SSHA}|{SHA512-CRYPT}|{SSHA512}|{MD5-CRYPT}|{PLAIN-MD5})/i', $password)) {
+              if (preg_match('/^{(ARGON2I|ARGON2ID|BLF-CRYPT|CLEAR|CLEARTEXT|CRYPT|DES-CRYPT|LDAP-MD5|MD5|MD5-CRYPT|PBKDF2|PLAIN|PLAIN-MD4|PLAIN-MD5|PLAIN-TRUNC|PLAIN-TRUNC|SHA|SHA1|SHA256|SHA256-CRYPT|SHA512|SHA512-CRYPT|SMD5|SSHA|SSHA256|SSHA512)}/i', $password)) {
                 $password_hashed = $password;
               }
               else {


### PR DESCRIPTION
When migrating from other Dovecot based installations it can be very
convenient to just copy over existing hashed passwords.
However, mailcow currently only supports a limited number of password
schemes.

This commit implements all password schemes that do not require
challenge/response or OTP mechanisms.

A convenient way to generate the regex with all supported schemas is
`docker-compose exec dovecot-mailcow doveadm pw -l | awk -F' ' '{printf
"/^{("; for(i=1;i<=NF-1;i++){printf "%s%s", sep, $i; sep="|"}; printf
")}/i\n"}'`

Note that this will also include unsupported challenge/response and OTP
schemas.

Furthermore this increases the vsz_limit for the dovecot auth service to
2G for the use of ARGON2I and ARGON2ID schemas.

Signed-off-by: Felix Kaechele <felix@kaechele.ca>