### PR TITLE
Unset Postfix smtpd_tls_session_cache_database, reduce disk writes

### DIFF
--- a/data/conf/postfix/main.cf
+++ b/data/conf/postfix/main.cf
@@ -7,7 +7,6 @@ smtpd_tls_cert_file = /etc/ssl/mail/cert.pem
 smtpd_tls_key_file = /etc/ssl/mail/key.pem
 tls_server_sni_maps = hash:/opt/postfix/conf/sni.map
 smtpd_tls_received_header = yes
-smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 smtpd_relay_restrictions = permit_mynetworks,
   permit_sasl_authenticated,


### PR DESCRIPTION
Postfix may update smtpd_tls_session_cache_database quite frequently even on not busy server, which leads to unnecessary (excessive) disk writes, which is an issue for SSD.
Postfix documentation suggests not to use this parameter anymore since there's another, better TLS session resumption method available.

>As of Postfix 2.11 the preferred mechanism for session resumption is RFC 5077 TLS session tickets, which don't require server-side storage. Consequently, for Postfix ≥ 2.11 this parameter should generally be left empty.

http://www.postfix.org/postconf.5.html#smtpd_tls_session_cache_database