### PR TITLE
[Rspamd] Increase map watch interval

### DIFF
--- a/data/conf/rspamd/local.d/options.inc
+++ b/data/conf/rspamd/local.d/options.inc
@@ -1,7 +1,7 @@
 dns {
   enable_dnssec = true;
 }
-map_watch_interval = 30s;
+map_watch_interval = 1min;
 dns {
   timeout = 4s;
   retransmits = 2;


### PR DESCRIPTION
May fixes https://github.com/mailcow/mailcow-dockerized/issues/3929

We can also set it to 45s because since the actual check interval is jittered, it'll get executed every 1x to 2x of the set value (45s to 90s).
https://rspamd.com/doc/configuration/options.html#global-options