### PR TITLE
[olefy] Update container to alpine 12 to fix build

### DIFF
--- a/data/Dockerfiles/olefy/Dockerfile
+++ b/data/Dockerfiles/olefy/Dockerfile
@@ -1,11 +1,11 @@
-FROM alpine:3.11
+FROM alpine:3.13
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
 WORKDIR /app
 
 #RUN addgroup -S olefy && adduser -S olefy -G olefy \
-RUN apk add --virtual .build-deps gcc python3-dev musl-dev libffi-dev openssl-dev \
-  && apk add --update --no-cache python3 openssl tzdata libmagic \
+RUN apk add --virtual .build-deps gcc musl-dev python3-dev libffi-dev openssl-dev cargo \
+  && apk add --update --no-cache python3 py3-pip openssl tzdata libmagic \
   && pip3 install --upgrade pip \
   && pip3 install --upgrade asyncio python-magic \
   && pip3 install --upgrade https://github.com/HeinleinSupport/oletools/archive/master.zip \


### PR DESCRIPTION
This MR updates the olefy container to use alpine 3:12. This update is necessary since the cryptography pip module now needs rust to compile and the necessary rust version is not available in 3:11. 