### PR TITLE
[PHP-FPM] Increase PHP memory limit for "cli" to 512M

### DIFF
--- a/data/conf/phpfpm/php-conf.d/other.ini
+++ b/data/conf/phpfpm/php-conf.d/other.ini
@@ -1,2 +1,3 @@
 max_execution_time = 3600
 max_input_time = 3600
+memory_limit = 512M


### PR DESCRIPTION
The CLI of Nextcloud (occ) complains about the memory limit which is by default 256 MB.
So please consider changing the php cli memory limit to 512 MB like for the PHP FPM web-worker pool.