### PR TITLE
Apply hash matching to domain admin passwords

### DIFF
--- a/data/web/inc/functions.domain_admin.inc.php
+++ b/data/web/inc/functions.domain_admin.inc.php
@@ -235,7 +235,12 @@ function domain_admin($_action, $_data = null) {
               );
               continue;
             }
-            $password_hashed = hash_password($password);
+            if (preg_match('/^{(ARGON2I|ARGON2ID|BLF-CRYPT|CLEAR|CLEARTEXT|CRYPT|DES-CRYPT|LDAP-MD5|MD5|MD5-CRYPT|PBKDF2|PLAIN|PLAIN-MD4|PLAIN-MD5|PLAIN-TRUNC|PLAIN-TRUNC|SHA|SHA1|SHA256|SHA256-CRYPT|SHA512|SHA512-CRYPT|SMD5|SSHA|SSHA256|SSHA512)}/i', $password)) {
+              $password_hashed = $password;
+            }
+            else {
+              $password_hashed = hash_password($password);
+            }
             $stmt = $pdo->prepare("UPDATE `admin` SET `username` = :username_new, `active` = :active, `password` = :password_hashed WHERE `username` = :username");
             $stmt->execute(array(
               ':password_hashed' => $password_hashed,


### PR DESCRIPTION
Email addresses can be imported into mailcow with existing hashed passwords. This commit aims to provide the same functionality for importing domain administrators. Would it make more sense to move hash checking into the hash_password() function to prevent redundant code?