### PR TITLE
Enable maildir_very_dirty_syncs by default

### DIFF
--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -27,7 +27,7 @@ mail_attachment_min_size = 128k
 # Significantly speeds up very large mailboxes, but is only safe to enable if
 # you do not manually modify the files in the `cur` directories in
 # mailcowdockerized_vmail-vol-1.
-# https://mailcow.github.io/mailcow-dockerized-docs/u_e-dovecot-perf/
+# https://docs.mailcow.email/manual-guides/Dovecot/u_e-dovecot-performance/
 maildir_very_dirty_syncs = yes
 
 # Dovecot 2.2

--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -28,7 +28,7 @@ mail_attachment_min_size = 128k
 # you do not manually modify the files in the `cur` directories in
 # mailcowdockerized_vmail-vol-1.
 # https://mailcow.github.io/mailcow-dockerized-docs/u_e-dovecot-perf/
-maildir_very_dirty_syncs=yes
+maildir_very_dirty_syncs = yes
 
 # Dovecot 2.2
 #ssl_protocols = !SSLv3

--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -25,9 +25,10 @@ mail_attachment_fs = crypt:set_prefix=mail_crypt_global:posix:
 mail_attachment_dir = /var/attachments
 mail_attachment_min_size = 128k
 # Significantly speeds up very large mailboxes, but is only safe to enable if
-# you do not manually modify the files in the `cur` directories in 
-# mailcowdockerized_vmail-vol-1. Disabled by default.
-#maildir_very_dirty_syncs=yes
+# you do not manually modify the files in the `cur` directories in
+# mailcowdockerized_vmail-vol-1.
+# https://mailcow.github.io/mailcow-dockerized-docs/u_e-dovecot-perf/
+maildir_very_dirty_syncs=yes
 
 # Dovecot 2.2
 #ssl_protocols = !SSLv3

--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -24,6 +24,10 @@ mail_plugins = </etc/dovecot/mail_plugins
 mail_attachment_fs = crypt:set_prefix=mail_crypt_global:posix:
 mail_attachment_dir = /var/attachments
 mail_attachment_min_size = 128k
+# Significantly speeds up very large mailboxes, but is only safe to enable if
+# you do not manually modify the files in the `cur` directories in 
+# mailcowdockerized_vmail-vol-1. Disabled by default.
+#maildir_very_dirty_syncs=yes
 
 # Dovecot 2.2
 #ssl_protocols = !SSLv3


### PR DESCRIPTION
`maildir_very_dirty_syncs` can significantly improve performance of very large mailboxes. 

From Roundcube's IMAP logs when loading one email from a mailbox containing 250k emails:
Before: 1.719s to fetch:
```
A0008 OK Fetch completed (0.860 + 0.000 + 0.859 secs).
```

After: 0.025s to fetch:
```
A0008 OK Fetch completed (0.013 + 0.000 + 0.012 secs).
```

What this option does is it avoids rescanning the entire `cur` directory whenever loading an email. With this option disabled, Dovecot takes it safe and scans the ENTIRE `cur` directory (essentially running an `ls`) to check if that particular email was touched (renamed, etc), by looking for all files whose names contain the correct ID. This is very slow if the directory is large, even on filesystems optimized for such use cases (eg. ext4 with dir_index enabled). 

With this option enabled, Dovecot will still notice changes if the file's mtime is changed, but otherwise it will not scan the directory and just assumes the index is up-to-date. This is essentially the same as what sdbox/mdbox do, and with this option you can get some of the performance increase that would come with sdbox/mdbox (see #1007) while still using maildir.

This is safe to use as long as you do not manually touch files under `cur` (as then Dovecot may not notice the changes). Delivering new emails using LMTP (which Mailcow does) is fine, and dropping new emails into the `new` directory is also fine, it's just modifying stuff under `cur` that's a bit risky. If you do manually modify files under `cur`, you can just delete the index files and let Dovecot rebuild them.

This option seems to be safe to enable with Mailcow, as nothing appears to directly modify files in the `cur` directory other than Dovecot (Docker is very useful to verify this - the volume is not mounted in any other Docker containers). Some other systems enable it default - For example, cPanel has it enabled by default. I did not want to enable it by default in Mailcow because we have no way of telling what weird things people are doing with their maildirs :)