### PR TITLE
Removed --database-table-prefix switch

### DIFF
--- a/helper-scripts/nextcloud.sh
+++ b/helper-scripts/nextcloud.sh
@@ -110,7 +110,6 @@ elif [[ ${NC_INSTALL} == "y" ]]; then
     --database-name ${DBNAME} \
     --database-user ${DBUSER} \
     --database-pass ${DBPASS} \
-    --database-table-prefix nc_ \
     --admin-user admin \
     --admin-pass ${ADMIN_NC_PASS} \
       --data-dir /web/nextcloud/data


### PR DESCRIPTION
Looks like in NC 2.0 this option is no more supported. During installation I got this error:

The "--database-table-prefix" option does not exist.