### PR TITLE
Respect Redis REPLICA

### DIFF
--- a/data/conf/rspamd/local.d/reputation.conf
+++ b/data/conf/rspamd/local.d/reputation.conf
@@ -2,9 +2,7 @@ rules {
   ip_reputation = {
     selector "ip" {
     }
-    backend "redis" {
-      servers = "redis";
-    }
+    backend "redis";
     symbol = "IP_REPUTATION";
   }
 }


### PR DESCRIPTION
For replicated REDIS setup, servers_read&_write should be used ( which is already setup in local.d/redis.conf )