### PR TITLE
[ClamAV] Update to 0.103.2

### DIFF
--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 LABEL maintainer "André Peters <andre.peters@servercow.de>"
 
-ARG CLAMAV=0.103.1
+ARG CLAMAV=0.103.2
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \


### PR DESCRIPTION
Security patch, see https://blog.clamav.net/2021/04/clamav-01032-security-patch-release.html