### PR TITLE
[Rspamd] Remove score from SIEVE_HOST

### DIFF
--- a/data/conf/rspamd/local.d/multimap.conf
+++ b/data/conf/rspamd/local.d/multimap.conf
@@ -80,7 +80,6 @@ SIEVE_HOST {
   type = "ip";
   map = "${LOCAL_CONFDIR}/custom/dovecot_trusted.map";
   symbols_set = ["SIEVE_HOST"];
-  score = -15;
 }
 
 RSPAMD_HOST {


### PR DESCRIPTION
Commit e7a5c98704966865242d8f0c1348e3048b6261e5 remove upstream spam flag score so whitelisting of SIEVE_HOST unnecessary.