### PR TITLE
Add server_tokens off to the default site settings

### DIFF
--- a/data/conf/nginx/includes/site-defaults.conf
+++ b/data/conf/nginx/includes/site-defaults.conf
@@ -3,6 +3,8 @@
   charset utf-8;
   override_charset on;
 
+  server_tokens off;
+
   ssl_protocols TLSv1.2 TLSv1.3;
   ssl_prefer_server_ciphers on;
   ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;

--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -1,4 +1,3 @@
-server_tokens off;
 proxy_cache_path /tmp levels=1:2 keys_zone=sogo:10m inactive=24h  max_size=1g;
 server_names_hash_bucket_size 64;
 


### PR DESCRIPTION
Hello,

I think it makes sense to hide the NGINX version in the default settings for sites. For example, if someone configures a redirect from `webmail.example.com` to `mail.example.com/SOGo/` as a new site, they probably won't think of setting `server_tokens off`. So the version can be leaked easily.