### PR TITLE
Add pre and post update hook

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -6,9 +6,11 @@ if [ "$(id -u)" -ne "0" ]; then
   exit 1
 fi
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 # Run pre-update-hook
-if [ -f "$PWD/pre_update_hook.sh" ]; then
-  bash $PWD/pre_update_hook.sh
+if [ -f "${SCRIPT_DIR}/pre_update_hook.sh" ]; then
+  bash "${SCRIPT_DIR}/pre_update_hook.sh"
 fi
 
 if [[ "$(uname -r)" =~ ^4\.15\.0-60 ]]; then
@@ -651,8 +653,8 @@ echo -e "\e[32mCollecting garbage...\e[0m"
 docker_garbage
 
 # Run post-update-hook
-if [ -f "$PWD/post_update_hook.sh" ]; then
-  bash $PWD/post_update_hook.sh
+if [ -f "${SCRIPT_DIR}/post_update_hook.sh" ]; then
+  bash "${SCRIPT_DIR}/post_update_hook.sh"
 fi
 
 #echo "In case you encounter any problem, hard-reset to a state before updating mailcow:"

--- a/update.sh
+++ b/update.sh
@@ -6,6 +6,11 @@ if [ "$(id -u)" -ne "0" ]; then
   exit 1
 fi
 
+# Run pre-update-hook
+if [ -f "$PWD/pre_update_hook.sh" ]; then
+  bash $PWD/pre_update_hook.sh
+fi
+
 if [[ "$(uname -r)" =~ ^4\.15\.0-60 ]]; then
   echo "DO NOT RUN mailcow ON THIS UBUNTU KERNEL!";
   echo "Please update to 5.x or use another distribution."
@@ -644,6 +649,11 @@ fi
 
 echo -e "\e[32mCollecting garbage...\e[0m"
 docker_garbage
+
+# Run post-update-hook
+if [ -f "$PWD/post_update_hook.sh" ]; then
+  bash $PWD/post_update_hook.sh
+fi
 
 #echo "In case you encounter any problem, hard-reset to a state before updating mailcow:"
 #echo


### PR DESCRIPTION
This pr adds a pre and post update hook to mailcow which can be helpful if you run some kind of reverse proxy in front of your mailcow installation that has to be restarted due to several reasons.

It simply checks if the required files exists and runs them.

`pre_update_hook.sh`
`post_update_hook.sh`