### PR TITLE
[Web] Fix admin ui html label references

### DIFF
--- a/data/web/admin.php
+++ b/data/web/admin.php
@@ -179,7 +179,7 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
             <div class="col-sm-9">
               <div class="input-group">
                 <span class="input-group-addon">
-                  <i class="bi bi-suit-heart<?=(isset($_SESSION['gal']['valid']) && $_SESSION['gal']['valid'] === "true") ? '-fill text-danger' : '';?>""></i> 
+                  <i class="bi bi-suit-heart<?=(isset($_SESSION['gal']['valid']) && $_SESSION['gal']['valid'] === "true") ? '-fill text-danger' : '';?>"></i>
                 </span>
                 <input type="text" id="guid" class="form-control" value="<?=license('guid');?>" readonly>
               </div>
@@ -386,13 +386,13 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
             <div class="form-group">
               <label class="control-label col-sm-3" for="rspamd_ui_pass"><?=$lang['admin']['password'];?>:</label>
               <div class="col-sm-9">
-              <input type="password" class="form-control" name="rspamd_ui_pass" autocomplete="new-password" required>
+              <input type="password" class="form-control" id="rspamd_ui_pass" name="rspamd_ui_pass" autocomplete="new-password" required>
               </div>
             </div>
             <div class="form-group">
               <label class="control-label col-sm-3" for="rspamd_ui_pass2"><?=$lang['admin']['password_repeat'];?>:</label>
               <div class="col-sm-9">
-              <input type="password" class="form-control" name="rspamd_ui_pass2" autocomplete="new-password" required>
+              <input type="password" class="form-control" id="rspamd_ui_pass2" name="rspamd_ui_pass2" autocomplete="new-password" required>
               </div>
             </div>
             <div class="form-group">
@@ -436,16 +436,16 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
           <div class="col-md-6">
             <form class="form" data-id="rlyhost" role="form" method="post">
               <div class="form-group">
-                <label for="hostname"><?=$lang['admin']['host'];?></label>
-                <input class="form-control input-sm" name="hostname" placeholder='[0.0.0.0], [0.0.0.0]:25, host:25, host, [host]:25' required>
+                <label for="rlyhost_hostname"><?=$lang['admin']['host'];?></label>
+                <input class="form-control input-sm" id="rlyhost_hostname" name="hostname" placeholder='[0.0.0.0], [0.0.0.0]:25, host:25, host, [host]:25' required>
               </div>
               <div class="form-group">
-                <label for="username"><?=$lang['admin']['username'];?></label>
-                <input class="form-control input-sm" name="username">
+                <label for="rlyhost_username"><?=$lang['admin']['username'];?></label>
+                <input class="form-control input-sm" id="rlyhost_username" name="username">
               </div>
               <div class="form-group">
-                <label for="password"><?=$lang['admin']['password'];?></label>
-                <input class="form-control input-sm" name="password">
+                <label for="rlyhost_password"><?=$lang['admin']['password'];?></label>
+                <input class="form-control input-sm" id="rlyhost_password" name="password">
               </div>
               <button class="btn btn-default" data-action="add_item" data-id="rlyhost" data-api-url='add/relayhost' data-api-attr='{}' href="#"><i class="bi bi-plus-lg"></i> <?=$lang['admin']['add'];?></button>
             </form>
@@ -479,20 +479,20 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
           <div class="col-md-6">
             <form class="form" data-id="transport" role="form" method="post">
               <div class="form-group">
-                <label for="destination"><?=$lang['admin']['destination'];?></label>
-                <input class="form-control input-sm" name="destination" placeholder='<?=$lang['admin']['transport_dest_format'];?>' required>
+                <label for="transport_destination"><?=$lang['admin']['destination'];?></label>
+                <input class="form-control input-sm" id="transport_destination" name="destination" placeholder='<?=$lang['admin']['transport_dest_format'];?>' required>
               </div>
               <div class="form-group">
-                <label for="nexthop"><?=$lang['admin']['nexthop'];?></label>
-                <input class="form-control input-sm" name="nexthop" placeholder='host:25, host, [host]:25, [0.0.0.0]:25' required>
+                <label for="transport_nexthop"><?=$lang['admin']['nexthop'];?></label>
+                <input class="form-control input-sm" id="transport_nexthop" name="nexthop" placeholder='host:25, host, [host]:25, [0.0.0.0]:25' required>
               </div>
               <div class="form-group">
-                <label for="username"><?=$lang['admin']['username'];?></label>
-                <input class="form-control input-sm" name="username">
+                <label for="transport_username"><?=$lang['admin']['username'];?></label>
+                <input class="form-control input-sm" id="transport_username" name="username">
               </div>
               <div class="form-group">
-                <label for="password"><?=$lang['admin']['password'];?></label>
-                <input class="form-control input-sm" name="password">
+                <label for="transport_password"><?=$lang['admin']['password'];?></label>
+                <input class="form-control input-sm" id="transport_password" name="password">
               </div>
               <!-- <div class="form-group">
                 <label>
@@ -627,13 +627,13 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
         <legend style="margin-top:40px"><?=$lang['admin']['dkim_add_key'];?></legend>
         <form class="form" data-id="dkim" role="form" method="post">
           <div class="form-group">
-            <label for="domain"><?=$lang['admin']['domain_s'];?></label>
+            <label for="dkim_add_domains"><?=$lang['admin']['domain_s'];?></label>
             <input class="form-control input-sm" id="dkim_add_domains" name="domains" placeholder="example.org, example.com" required>
             <small><i class="bi bi-arrow-return-right"></i> <a href="#" id="dkim_missing_keys"><?=$lang['admin']['dkim_domains_wo_keys'];?></a></small>
           </div>
           <div class="form-group">
-            <label for="domain"><?=$lang['admin']['dkim_domains_selector'];?></label>
-            <input class="form-control input-sm" name="dkim_selector" value="dkim" required>
+            <label for="dkim_selector"><?=$lang['admin']['dkim_domains_selector'];?></label>
+            <input class="form-control input-sm" id="dkim_selector" name="dkim_selector" value="dkim" required>
           </div>
           <div class="form-group">
             <select data-width="200px" data-style="btn btn-default btn-sm" class="form-control" id="key_size" name="key_size" title="<?=$lang['admin']['dkim_key_length'];?>" required>
@@ -650,12 +650,12 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
         <div id="import_dkim" class="collapse">
         <form class="form" data-id="dkim_import" role="form" method="post">
           <div class="form-group">
-            <label for="domain"><?=$lang['admin']['domain'];?>:</label>
-            <input class="form-control input-sm" name="domain" placeholder="example.org" required>
+            <label for="dkim_import_domain"><?=$lang['admin']['domain'];?>:</label>
+            <input class="form-control input-sm" id="dkim_import_domain" name="domain" placeholder="example.org" required>
           </div>
           <div class="form-group">
-            <label for="domain"><?=$lang['admin']['dkim_domains_selector'];?>:</label>
-            <input class="form-control input-sm" name="dkim_selector" value="dkim" required>
+            <label for="dkim_import_selector"><?=$lang['admin']['dkim_domains_selector'];?>:</label>
+            <input class="form-control input-sm" id="dkim_import_selector" name="dkim_selector" value="dkim" required>
           </div>
           <div class="form-group">
             <label for="private_key_file"><?=$lang['admin']['private_key'];?>: (RSA PKCS#8)</label>
@@ -743,8 +743,8 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
         <p class="help-block"><?=$lang['admin']['forwarding_hosts_add_hint'];?></p>
         <form class="form" data-id="fwdhost" role="form" method="post">
           <div class="form-group">
-            <label for="hostname"><?=$lang['admin']['host'];?></label>
-            <input class="form-control" name="hostname" placeholder="example.org" required>
+            <label for="fwdhost_hostname"><?=$lang['admin']['host'];?></label>
+            <input class="form-control" id="fwdhost_hostname" name="hostname" placeholder="example.org" required>
           </div>
           <div class="form-group">
             <select data-width="200px" class="form-control" id="filter_spam" name="filter_spam" title="<?=$lang['user']['spamfilter'];?>" required>
@@ -767,40 +767,40 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
       ?>
         <form class="form" data-id="f2b" role="form" method="post">
           <div class="form-group">
-            <label for="ban_time"><?=$lang['admin']['f2b_ban_time'];?>:</label>
-            <input type="number" class="form-control" name="ban_time" value="<?=$f2b_data['ban_time'];?>" required>
+            <label for="f2b_ban_time"><?=$lang['admin']['f2b_ban_time'];?>:</label>
+            <input type="number" class="form-control" id="f2b_ban_time" name="ban_time" value="<?=$f2b_data['ban_time'];?>" required>
           </div>
           <div class="form-group">
-            <label for="max_attempts"><?=$lang['admin']['f2b_max_attempts'];?>:</label>
-            <input type="number" class="form-control" name="max_attempts" value="<?=$f2b_data['max_attempts'];?>" required>
+            <label for="f2b_max_attempts"><?=$lang['admin']['f2b_max_attempts'];?>:</label>
+            <input type="number" class="form-control" id="f2b_max_attempts" name="max_attempts" value="<?=$f2b_data['max_attempts'];?>" required>
           </div>
           <div class="form-group">
-            <label for="retry_window"><?=$lang['admin']['f2b_retry_window'];?>:</label>
-            <input type="number" class="form-control" name="retry_window" value="<?=$f2b_data['retry_window'];?>" required>
+            <label for="f2b_retry_window"><?=$lang['admin']['f2b_retry_window'];?>:</label>
+            <input type="number" class="form-control" id="f2b_retry_window" name="retry_window" value="<?=$f2b_data['retry_window'];?>" required>
           </div>
           <div class="form-group">
-            <label for="netban_ipv4"><?=$lang['admin']['f2b_netban_ipv4'];?>:</label>
+            <label for="f2b_netban_ipv4"><?=$lang['admin']['f2b_netban_ipv4'];?>:</label>
             <div class="input-group">
               <span class="input-group-addon">/</span>
-              <input type="number" class="form-control" name="netban_ipv4" value="<?=$f2b_data['netban_ipv4'];?>" required>
+              <input type="number" class="form-control" id="f2b_netban_ipv4" name="netban_ipv4" value="<?=$f2b_data['netban_ipv4'];?>" required>
             </div>
           </div>
           <div class="form-group">
-            <label for="netban_ipv6"><?=$lang['admin']['f2b_netban_ipv6'];?>:</label>
+            <label for="f2b_netban_ipv6"><?=$lang['admin']['f2b_netban_ipv6'];?>:</label>
             <div class="input-group">
               <span class="input-group-addon">/</span>
-              <input type="number" class="form-control" name="netban_ipv6" value="<?=$f2b_data['netban_ipv6'];?>" required>
+              <input type="number" class="form-control" id="f2b_netban_ipv6" name="netban_ipv6" value="<?=$f2b_data['netban_ipv6'];?>" required>
             </div>
           </div>
           <hr>
           <p class="help-block"><?=$lang['admin']['f2b_list_info'];?></p>
           <div class="form-group">
-            <label for="whitelist"><?=$lang['admin']['f2b_whitelist'];?>:</label>
-            <textarea class="form-control" name="whitelist" rows="5"><?=$f2b_data['whitelist'];?></textarea>
+            <label for="f2b_whitelist"><?=$lang['admin']['f2b_whitelist'];?>:</label>
+            <textarea class="form-control" id="f2b_whitelist" name="whitelist" rows="5"><?=$f2b_data['whitelist'];?></textarea>
           </div>
           <div class="form-group">
-            <label for="blacklist"><?=$lang['admin']['f2b_blacklist'];?>:</label>
-            <textarea class="form-control" name="blacklist" rows="5"><?=$f2b_data['blacklist'];?></textarea>
+            <label for="f2b_blacklist"><?=$lang['admin']['f2b_blacklist'];?>:</label>
+            <textarea class="form-control" id="f2b_blacklist" name="blacklist" rows="5"><?=$f2b_data['blacklist'];?></textarea>
           </div>
           <div class="btn-group">
             <button class="btn btn-sm btn-success" data-action="edit_selected" data-item="self" data-id="f2b" data-api-url='edit/fail2ban' data-api-attr='{}' href="#"><i class="bi bi-check-lg"></i> <?=$lang['admin']['save'];?></button>
@@ -894,60 +894,60 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
         ?>
         <form class="form-horizontal" data-id="quarantine" role="form" method="post">
           <div class="form-group">
-            <label class="col-sm-4 control-label" for="retention_size"><?=$lang['admin']['quarantine_retention_size'];?></label>
+            <label class="col-sm-4 control-label" for="quarantine_retention_size"><?=$lang['admin']['quarantine_retention_size'];?></label>
             <div class="col-sm-8">
-              <input type="number" class="form-control" name="retention_size" value="<?=$q_data['retention_size'];?>" placeholder="0" required>
+              <input type="number" class="form-control" id="quarantine_retention_size" name="retention_size" value="<?=$q_data['retention_size'];?>" placeholder="0" required>
             </div>
           </div>
           <div class="form-group">
-            <label class="col-sm-4 control-label" for="max_size"><?=$lang['admin']['quarantine_max_size'];?></label>
+            <label class="col-sm-4 control-label" for="quarantine_max_size"><?=$lang['admin']['quarantine_max_size'];?></label>
             <div class="col-sm-8">
-              <input type="number" class="form-control" name="max_size" value="<?=$q_data['max_size'];?>" placeholder="0" required>
+              <input type="number" class="form-control" id="quarantine_max_size" name="max_size" value="<?=$q_data['max_size'];?>" placeholder="0" required>
             </div>
           </div>
           <div class="form-group">
-            <label class="col-sm-4 control-label" for="max_score"><?=$lang['admin']['quarantine_max_score'];?></label>
+            <label class="col-sm-4 control-label" for="quarantine_max_score"><?=$lang['admin']['quarantine_max_score'];?></label>
             <div class="col-sm-8">
-              <input type="number" class="form-control" name="max_score" value="<?=$q_data['max_score'];?>" placeholder="9999.0">
+              <input type="number" class="form-control" id="quarantine_max_score" name="max_score" value="<?=$q_data['max_score'];?>" placeholder="9999.0">
             </div>
           </div>
           <div class="form-group">
-            <label class="col-sm-4 control-label" for="max_age"><?=$lang['admin']['quarantine_max_age'];?></label>
+            <label class="col-sm-4 control-label" for="quarantine_max_age"><?=$lang['admin']['quarantine_max_age'];?></label>
             <div class="col-sm-8">
-              <input type="number" class="form-control" name="max_age" value="<?=$q_data['max_age'];?>" min="1" required>
-            </div>
-          </div>
-          <hr>
-          <div class="form-group">
-            <label class="col-sm-4 control-label" for="sender"><i class="bi bi-box-arrow-right"></i> <?=$lang['admin']['quarantine_redirect'];?></label>
-            <div class="col-sm-8">
-              <input type="email" class="form-control" name="redirect" value="<?=htmlspecialchars($q_data['redirect']);?>" placeholder="">
-            </div>
-          </div>
-          <div class="form-group">
-            <label class="col-sm-4 control-label" for="sender"><i class="bi bi-files"></i> <?=$lang['admin']['quarantine_bcc'];?></label>
-            <div class="col-sm-8">
-              <input type="email" class="form-control" name="bcc" value="<?=htmlspecialchars($q_data['bcc']);?>" placeholder="">
+              <input type="number" class="form-control" id="quarantine_max_age" name="max_age" value="<?=$q_data['max_age'];?>" min="1" required>
             </div>
           </div>
           <hr>
           <div class="form-group">
-            <label class="col-sm-4 control-label" for="sender"><?=$lang['admin']['quarantine_notification_sender'];?>:</label>
+            <label class="col-sm-4 control-label" for="quarantine_redirect"><i class="bi bi-box-arrow-right"></i> <?=$lang['admin']['quarantine_redirect'];?></label>
             <div class="col-sm-8">
-              <input type="email" class="form-control" name="sender" value="<?=htmlspecialchars($q_data['sender']);?>" placeholder="quarantine@localhost">
+              <input type="email" class="form-control" id="quarantine_redirect" name="redirect" value="<?=htmlspecialchars($q_data['redirect']);?>" placeholder="">
             </div>
           </div>
           <div class="form-group">
-            <label class="col-sm-4 control-label" for="subject"><?=$lang['admin']['quarantine_notification_subject'];?>:</label>
+            <label class="col-sm-4 control-label" for="quarantine_bcc"><i class="bi bi-files"></i> <?=$lang['admin']['quarantine_bcc'];?></label>
             <div class="col-sm-8">
-              <input type="text" class="form-control" name="subject" value="<?=htmlspecialchars($q_data['subject']);?>" placeholder="Spam Quarantine Notification">
+              <input type="email" class="form-control" id="quarantine_bcc" name="bcc" value="<?=htmlspecialchars($q_data['bcc']);?>" placeholder="">
             </div>
           </div>
           <hr>
           <div class="form-group">
-            <label class="col-sm-4 control-label" for="release_format"><?=$lang['admin']['quarantine_release_format'];?>:</label>
+            <label class="col-sm-4 control-label" for="quarantine_sender"><?=$lang['admin']['quarantine_notification_sender'];?>:</label>
             <div class="col-sm-8">
-              <select data-width="100%" name="release_format" class="selectpicker" title="<?=$lang['tfa']['select'];?>">
+              <input type="email" class="form-control" id="quarantine_sender" name="sender" value="<?=htmlspecialchars($q_data['sender']);?>" placeholder="quarantine@localhost">
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="col-sm-4 control-label" for="quarantine_subject"><?=$lang['admin']['quarantine_notification_subject'];?>:</label>
+            <div class="col-sm-8">
+              <input type="text" class="form-control" id="quarantine_subject" name="subject" value="<?=htmlspecialchars($q_data['subject']);?>" placeholder="Spam Quarantine Notification">
+            </div>
+          </div>
+          <hr>
+          <div class="form-group">
+            <label class="col-sm-4 control-label" for="quarantine_release_format"><?=$lang['admin']['quarantine_release_format'];?>:</label>
+            <div class="col-sm-8">
+              <select data-width="100%" id="quarantine_release_format" name="release_format" class="selectpicker" title="<?=$lang['tfa']['select'];?>">
                 <option <?=($q_data['release_format'] == 'raw') ? 'selected' : null;?> value="raw"><?=$lang['admin']['quarantine_release_format_raw'];?></option>
                 <option <?=($q_data['release_format'] == 'attachment') ? 'selected' : null;?> value="attachment"><?=$lang['admin']['quarantine_release_format_att'];?></option>
               </select>
@@ -990,14 +990,14 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
         <div class="row">
           <div class="col-sm-6">
             <div class="form-group">
-              <label for="sender"><?=$lang['admin']['quarantine_notification_sender'];?>:</label>
-              <input type="email" class="form-control" name="sender" value="<?=htmlspecialchars($qw_data['sender']);?>" placeholder="quota-warning@localhost">
+              <label for="quota_notification_sender"><?=$lang['admin']['quarantine_notification_sender'];?>:</label>
+              <input type="email" class="form-control" id="quota_notification_sender" name="sender" value="<?=htmlspecialchars($qw_data['sender']);?>" placeholder="quota-warning@localhost">
             </div>
           </div>
           <div class="col-sm-6">
             <div class="form-group">
-              <label for="subject"><?=$lang['admin']['quarantine_notification_subject'];?>:</label>
-              <input type="text" class="form-control" name="subject" value="<?=htmlspecialchars($qw_data['subject']);?>" placeholder="Quota warning">
+              <label for="quota_notification_subject"><?=$lang['admin']['quarantine_notification_subject'];?>:</label>
+              <input type="text" class="form-control" id="quota_notification_subject" name="subject" value="<?=htmlspecialchars($qw_data['subject']);?>" placeholder="Quota warning">
             </div>
           </div>
         </div>
@@ -1089,12 +1089,12 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
                   <form class="form" data-id="rsettings" role="form" method="post">
                     <input type="hidden" name="active" value="0">
                     <div class="form-group">
-                      <label for="desc"><?=$lang['admin']['rsetting_desc'];?>:</label>
-                      <input type="text" class="form-control" name="desc" value="<?=htmlspecialchars($rsetting_details['desc']);?>">
+                      <label for="rsettings_desc"><?=$lang['admin']['rsetting_desc'];?>:</label>
+                      <input type="text" class="form-control" id="rsettings_desc" name="desc" value="<?=htmlspecialchars($rsetting_details['desc']);?>">
                     </div>
                     <div class="form-group">
-                      <label for="content"><?=$lang['admin']['rsetting_content'];?>:</label>
-                      <textarea class="form-control" name="content" rows="10"><?=htmlspecialchars($rsetting_details['content']);?></textarea>
+                      <label for="rsettings_content"><?=$lang['admin']['rsetting_content'];?>:</label>
+                      <textarea class="form-control" id="rsettings_content" name="content" rows="10"><?=htmlspecialchars($rsetting_details['content']);?></textarea>
                     </div>
                     <div class="form-group">
                       <label>
@@ -1191,16 +1191,16 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
         <?php $ui_texts = customize('get', 'ui_texts'); ?>
           <form class="form" data-id="uitexts" role="form" method="post">
             <div class="form-group">
-              <label for="title_name"><?=$lang['admin']['title_name'];?>:</label>
-              <input type="text" class="form-control" name="title_name" placeholder="mailcow UI" value="<?=$ui_texts['title_name'];?>">
+              <label for="uitests_title_name"><?=$lang['admin']['title_name'];?>:</label>
+              <input type="text" class="form-control" id="uitests_title_name" placeholder="mailcow UI" value="<?=$ui_texts['title_name'];?>">
             </div>
             <div class="form-group">
-              <label for="main_name"><?=$lang['admin']['main_name'];?>:</label>
-              <input type="text" class="form-control" name="main_name" placeholder="mailcow UI" value="<?=$ui_texts['main_name'];?>">
+              <label for="uitests_main_name"><?=$lang['admin']['main_name'];?>:</label>
+              <input type="text" class="form-control" id="uitests_main_name" name="main_name" placeholder="mailcow UI" value="<?=$ui_texts['main_name'];?>">
             </div>
             <div class="form-group">
-              <label for="apps_name"><?=$lang['admin']['apps_name'];?>:</label>
-              <input type="text" class="form-control" name="apps_name" placeholder="mailcow Apps" value="<?=$ui_texts['apps_name'];?>">
+              <label for="uitests_apps_name"><?=$lang['admin']['apps_name'];?>:</label>
+              <input type="text" class="form-control" id="uitests_apps_name" name="apps_name" placeholder="mailcow Apps" value="<?=$ui_texts['apps_name'];?>">
             </div>
             <div class="form-group">
               <label for="help_text"><?=$lang['admin']['help_text'];?>:</label>
@@ -1210,7 +1210,7 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
             <div class="form-group">
               <p class="help-block"><?=$lang['admin']['ui_header_announcement_help'];?></p>
               <label for="ui_announcement_type"><?=$lang['admin']['ui_header_announcement'];?>:</label>
-              <p><select multiple data-width="100%" name="ui_announcement_type" class="selectpicker show-tick" data-max-options="1" title="<?=$lang['admin']['ui_header_announcement_select'];?>">
+              <p><select multiple data-width="100%" id="ui_announcement_type" name="ui_announcement_type" class="selectpicker show-tick" data-max-options="1" title="<?=$lang['admin']['ui_header_announcement_select'];?>">
                 <option <?=($ui_texts['ui_announcement_type'] == 'info') ? 'selected' : null;?> value="info"><?=$lang['admin']['ui_header_announcement_type_info'];?></option>
                 <option <?=($ui_texts['ui_announcement_type'] == 'warning') ? 'selected' : null;?> value="warning"><?=$lang['admin']['ui_header_announcement_type_warning'];?></option>
                 <option <?=($ui_texts['ui_announcement_type'] == 'danger') ? 'selected' : null;?> value="danger"><?=$lang['admin']['ui_header_announcement_type_danger'];?></option>
@@ -1283,15 +1283,15 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
       <div class="panel-body">
         <form class="form-horizontal" autocapitalize="none" data-id="admin" autocorrect="off" role="form" method="post">
           <div class="form-group">
-            <label class="control-label col-sm-2" for="mass_from"><?=$lang['admin']['from'];?>:</label>
+            <label class="control-label col-sm-2" for="admin_mass_from"><?=$lang['admin']['from'];?>:</label>
             <div class="col-sm-10">
-              <input type="email" class="form-control" name="mass_from" value="noreply@<?=getenv('MAILCOW_HOSTNAME');;?>" required>
+              <input type="email" class="form-control" id="admin_mass_from" name="mass_from" value="noreply@<?=getenv('MAILCOW_HOSTNAME');;?>" required>
             </div>
           </div>
           <div class="form-group">
-            <label class="control-label col-sm-2" for="mass_subject"><?=$lang['admin']['subject'];?>:</label>
+            <label class="control-label col-sm-2" for="admin_mass_subject"><?=$lang['admin']['subject'];?>:</label>
             <div class="col-sm-10">
-              <input type="text" class="form-control" name="mass_subject" required>
+              <input type="text" class="form-control" id="admin_mass_subject" name="mass_subject" required>
             </div>
           </div>
           <?php


### PR DESCRIPTION
Many of the labels referenced inputs that did not have the IDs they were supposed to have.
As some of those inputs on the page have the same name but in different forms, the ID could
not always be the same as the name.
For these cases, to avoid conflicts, the forms data-id is used as a prefix for the id attribute.

Also a rogue " was removed.

--- 

I'm new to the project, and in the 'contributing guidelines' I didn't find anything about PRs or code contributions.
So this is a first little PR as an introduction to your project and your processes.