### PR TITLE
[Web] Fix admin ui title_name update

### DIFF
--- a/data/web/admin.php
+++ b/data/web/admin.php
@@ -1190,7 +1190,7 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
           <form class="form" data-id="uitexts" role="form" method="post">
             <div class="form-group">
               <label for="uitests_title_name"><?=$lang['admin']['title_name'];?>:</label>
-              <input type="text" class="form-control" id="uitests_title_name" placeholder="mailcow UI" value="<?=$ui_texts['title_name'];?>">
+              <input type="text" class="form-control" id="uitests_title_name" name="title_name" placeholder="mailcow UI" value="<?=$ui_texts['title_name'];?>">
             </div>
             <div class="form-group">
               <label for="uitests_main_name"><?=$lang['admin']['main_name'];?>:</label>


### PR DESCRIPTION
In #4105 there was a small error that renamed the input name to
input id, so we lost the name and the title name couldn't be
changed anymore. This should fix it.