### PR TITLE
[Web] Fix: spf record validation failed with redirect

### DIFF
--- a/data/web/inc/spf.inc.php
+++ b/data/web/inc/spf.inc.php
@@ -24,7 +24,7 @@ function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false) {
 				$mod = explode('=', $mech);
 				if ($mod[0] == 'redirect') // handle a redirect
 				{
-					$hosts = get_spf_allowed_hosts($mod[1]);
+					$hosts = get_spf_allowed_hosts($mod[1],true);
 					return $hosts;
 				}
 			}
@@ -79,13 +79,13 @@ function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false) {
 	}
 	foreach ($hosts as &$host) {
 		if (filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
-      if ($expand_ipv6 === true) {
-        $hex = unpack("H*hex", inet_pton($host));
-        $host = substr(preg_replace("/([A-f0-9]{4})/", "$1:", $hex['hex']), 0, -1);
-      }
-      else {
-        $host = $host;
-      }
+			if ($expand_ipv6 === true) {
+				$hex = unpack("H*hex", inet_pton($host));
+				$host = substr(preg_replace("/([A-f0-9]{4})/", "$1:", $hex['hex']), 0, -1);
+			}
+			else {
+				$host = $host;
+			}
 		}
 	}
 	return $hosts;


### PR DESCRIPTION
When using a redirect in your SPF record, the web UI validation
failed when your record contained a ipv6 address. In
web/inc/ajax/dns_diagnostics.php the function get_spf_allowed_hosts
is called with the second parameter to be true to expand ipv6
addresses. But when called for redirects, the value was not set to
true, so it defaulted back to false. This caused an unexpanded ipv6
address to be added to the array and the in_array match for ipv6
never matched as it is always called with expand_ipv6.
While looking at the code i noted some messed up in the indention,
which is also "fixed" by this commit.