### PR TITLE
Remove left smtpd_last_auth statement

### DIFF
--- a/data/conf/postfix/master.cf
+++ b/data/conf/postfix/master.cf
@@ -72,7 +72,6 @@ submission inet n       -       n       -       -       smtpd
   -o smtpd_milters=
   -o non_smtpd_milters=
   -o syslog_name=postfix/bcc
-  -o smtpd_end_of_data_restrictions=$smtpd_last_auth
 
 # enforced smtp connector
 smtp_enforced_tls      unix  -       -       n       -       -       smtp


### PR DESCRIPTION
Removes smtpd_last_auth the which was missed in 05f6e28.