### PR TITLE
[Rspamd] Fix FREEMAIL_POLICY_FAILURE with SPF_SOFTFAIL

### DIFF
--- a/data/conf/rspamd/local.d/policies_group.conf
+++ b/data/conf/rspamd/local.d/policies_group.conf
@@ -1,6 +1,6 @@
 symbols = {
     "ARC_REJECT" {
-        score = 0.01;
+        score = 0.1;
     }
     "R_SPF_FAIL" {
         score = 8.0;
@@ -9,7 +9,7 @@ symbols = {
         score = 8.0;
     }
     "R_SPF_SOFTFAIL" {
-        score = 0.01;
+        score = 0.1;
     }
     "R_DKIM_REJECT" {
         score = 8.0;
@@ -21,6 +21,6 @@ symbols = {
         weight = 8.0;
     }
     "DMARC_POLICY_SOFTFAIL" {
-        weight = 0.01;
+        weight = 0.1;
     }
 }

--- a/data/conf/rspamd/local.d/policies_group.conf
+++ b/data/conf/rspamd/local.d/policies_group.conf
@@ -8,6 +8,9 @@ symbols = {
     "R_SPF_PERMFAIL" {
         score = 8.0;
     }
+    "R_SPF_SOFTFAIL" {
+        score = 0.01;
+    }
     "R_DKIM_REJECT" {
         score = 8.0;
     }
@@ -18,6 +21,6 @@ symbols = {
         weight = 8.0;
     }
     "DMARC_POLICY_SOFTFAIL" {
-        weight = 0.0;
+        weight = 0.01;
     }
 }


### PR DESCRIPTION
Add really low negative score to SOFTFAIL policy symbols to get FREEMAIL_POLICY_FAILURE triggered correctly