### PR TITLE
Run garbage collection with -f without asking questions

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -106,7 +106,8 @@ docker_garbage() {
         echo "OK, skipped."
       fi
     else
-      echo "Skipped image removal because of force mode."
+      echo "Running image removal without extra confirmation due to force mode."
+      docker rmi ${IMGS_TO_DELETE[*]}
     fi
   fi
   echo -e "\e[32mFurther cleanup...\e[0m"


### PR DESCRIPTION
This PR addresses one of the problems described here: https://github.com/mailcow/mailcow-dockerized/issues/3904
In the update.sh script "Ensure that --gc respects the -f flag". With this change `./update.sh --gc -f` will run the garbage collection without asking for confirmation.
