### PR TITLE
Remove X-XSS-Protection

### DIFF
--- a/data/conf/nginx/includes/site-defaults.conf
+++ b/data/conf/nginx/includes/site-defaults.conf
@@ -15,7 +15,6 @@
 
   add_header Strict-Transport-Security "max-age=15768000;";
   add_header X-Content-Type-Options nosniff;
-  add_header X-XSS-Protection "1; mode=block";
   add_header X-Robots-Tag none;
   add_header X-Download-Options noopen;
   add_header X-Frame-Options "SAMEORIGIN" always;


### PR DESCRIPTION
X-XSS-Protection has been removed in modern browsers:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
So this header doesn't do anything anymore and is useless.