### PR TITLE
[redis] raise container net.core.somaxconn

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
         - "${REDIS_PORT:-127.0.0.1:7654}:6379"
       environment:
         - TZ=${TZ}
+      sysctls:
+        - net.core.somaxconn=4096
       networks:
         mailcow-network:
           ipv4_address: ${IPV4_NETWORK:-172.22.1}.249


### PR DESCRIPTION
On busy installations, default somaxconn is not sufficient. This raises it directly in the container because raising it in the host doesn't do it.

Signed-off-by: Kristian Feldsam <feldsam@gmail.com>