### PR TITLE
Remove redundant password hash checks

### DIFF
--- a/data/web/inc/functions.admin.inc.php
+++ b/data/web/inc/functions.admin.inc.php
@@ -51,13 +51,7 @@ function admin($_action, $_data = null) {
       if (password_check($password, $password2) !== true) {
         return false;
       }
-      // support pre hashed passwords
-      if (preg_match('/^{(ARGON2I|ARGON2ID|BLF-CRYPT|CLEAR|CLEARTEXT|CRYPT|DES-CRYPT|LDAP-MD5|MD5|MD5-CRYPT|PBKDF2|PLAIN|PLAIN-MD4|PLAIN-MD5|PLAIN-TRUNC|PLAIN-TRUNC|SHA|SHA1|SHA256|SHA256-CRYPT|SHA512|SHA512-CRYPT|SMD5|SSHA|SSHA256|SSHA512)}/i', $password)) {
-        $password_hashed = $password_new;
-      }
-      else {
-        $password_hashed = hash_password($password_new);
-      }
+      $password_hashed = hash_password($password_new);
       $stmt = $pdo->prepare("INSERT INTO `admin` (`username`, `password`, `superadmin`, `active`)
         VALUES (:username, :password_hashed, '1', :active)");
       $stmt->execute(array(
@@ -131,13 +125,7 @@ function admin($_action, $_data = null) {
           if (password_check($password, $password2) !== true) {
             return false;
           }
-          // support pre hashed passwords
-          if (preg_match('/^{(ARGON2I|ARGON2ID|BLF-CRYPT|CLEAR|CLEARTEXT|CRYPT|DES-CRYPT|LDAP-MD5|MD5|MD5-CRYPT|PBKDF2|PLAIN|PLAIN-MD4|PLAIN-MD5|PLAIN-TRUNC|PLAIN-TRUNC|SHA|SHA1|SHA256|SHA256-CRYPT|SHA512|SHA512-CRYPT|SMD5|SSHA|SSHA256|SSHA512)}/i', $password)) {
-            $password_hashed = $password;
-          }
-          else {
-            $password_hashed = hash_password($password);
-          }
+          $password_hashed = hash_password($password);
           $stmt = $pdo->prepare("UPDATE `admin` SET `username` = :username_new, `active` = :active, `password` = :password_hashed WHERE `username` = :username");
           $stmt->execute(array(
             ':password_hashed' => $password_hashed,

--- a/data/web/inc/functions.domain_admin.inc.php
+++ b/data/web/inc/functions.domain_admin.inc.php
@@ -68,13 +68,7 @@ function domain_admin($_action, $_data = null) {
       if (password_check($password, $password2) !== true) {
         continue;
       }
-      // support pre hashed passwords
-      if (preg_match('/^{(ARGON2I|ARGON2ID|BLF-CRYPT|CLEAR|CLEARTEXT|CRYPT|DES-CRYPT|LDAP-MD5|MD5|MD5-CRYPT|PBKDF2|PLAIN|PLAIN-MD4|PLAIN-MD5|PLAIN-TRUNC|PLAIN-TRUNC|SHA|SHA1|SHA256|SHA256-CRYPT|SHA512|SHA512-CRYPT|SMD5|SSHA|SSHA256|SSHA512)}/i', $password)) {
-        $password_hashed = $password;
-      }
-      else {
-        $password_hashed = hash_password($password);
-      }
+      $password_hashed = hash_password($password);
       $valid_domains = 0;
       foreach ($domains as $domain) {
         if (!is_valid_domain_name($domain) || mailbox('get', 'domain_details', $domain) === false) {
@@ -205,13 +199,7 @@ function domain_admin($_action, $_data = null) {
             if (password_check($password, $password2) !== true) {
               return false;
             }
-            // support pre hashed passwords
-            if (preg_match('/^{(ARGON2I|ARGON2ID|BLF-CRYPT|CLEAR|CLEARTEXT|CRYPT|DES-CRYPT|LDAP-MD5|MD5|MD5-CRYPT|PBKDF2|PLAIN|PLAIN-MD4|PLAIN-MD5|PLAIN-TRUNC|PLAIN-TRUNC|SHA|SHA1|SHA256|SHA256-CRYPT|SHA512|SHA512-CRYPT|SMD5|SSHA|SSHA256|SSHA512)}/i', $password)) {
-              $password_hashed = $password;
-            }
-            else {
-              $password_hashed = hash_password($password);
-            }
+            $password_hashed = hash_password($password);
             $stmt = $pdo->prepare("UPDATE `admin` SET `username` = :username_new, `active` = :active, `password` = :password_hashed WHERE `username` = :username");
             $stmt->execute(array(
               ':password_hashed' => $password_hashed,

--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -979,13 +979,7 @@ function edit_user_account($_data) {
     if (password_check($password_new, $password_new2) !== true) {
       return false;
     }
-    // support pre hashed passwords
-    if (preg_match('/^{(ARGON2I|ARGON2ID|BLF-CRYPT|CLEAR|CLEARTEXT|CRYPT|DES-CRYPT|LDAP-MD5|MD5|MD5-CRYPT|PBKDF2|PLAIN|PLAIN-MD4|PLAIN-MD5|PLAIN-TRUNC|PLAIN-TRUNC|SHA|SHA1|SHA256|SHA256-CRYPT|SHA512|SHA512-CRYPT|SMD5|SSHA|SSHA256|SSHA512)}/i', $password)) {
-      $password_hashed = $password_new;
-    }
-    else {
-      $password_hashed = hash_password($password_new);
-    }
+    $password_hashed = hash_password($password_new);
     $stmt = $pdo->prepare("UPDATE `mailbox` SET `password` = :password_hashed,
       `attributes` = JSON_SET(`attributes`, '$.force_pw_update', '0'),
       `attributes` = JSON_SET(`attributes`, '$.passwd_update', NOW())

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -1049,13 +1049,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           if (password_check($password, $password2) !== true) {
             return false;
           }
-          // support pre hashed passwords
-          if (preg_match('/^{(ARGON2I|ARGON2ID|BLF-CRYPT|CLEAR|CLEARTEXT|CRYPT|DES-CRYPT|LDAP-MD5|MD5|MD5-CRYPT|PBKDF2|PLAIN|PLAIN-MD4|PLAIN-MD5|PLAIN-TRUNC|PLAIN-TRUNC|SHA|SHA1|SHA256|SHA256-CRYPT|SHA512|SHA512-CRYPT|SMD5|SSHA|SSHA256|SSHA512)}/i', $password)) {
-            $password_hashed = $password;
-          }
-          else {
-            $password_hashed = hash_password($password);
-          }
+          $password_hashed = hash_password($password);
           if ($MailboxData['count'] >= $DomainData['mailboxes']) {
             $_SESSION['return'][] = array(
               'type' => 'danger',
@@ -2583,13 +2577,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               if (password_check($password, $password2) !== true) {
                 continue;
               }
-              // support pre hashed passwords
-              if (preg_match('/^{(ARGON2I|ARGON2ID|BLF-CRYPT|CLEAR|CLEARTEXT|CRYPT|DES-CRYPT|LDAP-MD5|MD5|MD5-CRYPT|PBKDF2|PLAIN|PLAIN-MD4|PLAIN-MD5|PLAIN-TRUNC|PLAIN-TRUNC|SHA|SHA1|SHA256|SHA256-CRYPT|SHA512|SHA512-CRYPT|SMD5|SSHA|SSHA256|SSHA512)}/i', $password)) {
-                $password_hashed = $password;
-              }
-              else {
-                $password_hashed = hash_password($password);
-              }
+              $password_hashed = hash_password($password);
               $stmt = $pdo->prepare("UPDATE `mailbox` SET
                   `password` = :password_hashed,
                   `attributes` = JSON_SET(`attributes`, '$.passwd_update', NOW())


### PR DESCRIPTION
In a previous patch, the hash matching was moved into the hash_password() function. I thought I had cleaned up all the extra checks, but apparently not.