### PR TITLE
[rspamd] add soft reject on task timeout

### DIFF
--- a/data/conf/rspamd/local.d/options.inc
+++ b/data/conf/rspamd/local.d/options.inc
@@ -7,3 +7,6 @@ dns {
   retransmits = 2;
 }
 disable_monitoring = true;
+# In case a task times out (like DNS lookup), soft reject the message
+# instead of silently accepting the message without further processing.
+soft_reject_on_timeout = true;


### PR DESCRIPTION
As we have seen issues in DNS processing actually stops rspamd from
processing a message, which leads to missing tag insertion for example,
we turn on soft reject on task timeout. Behavior is the same as with
greylisting for example, so the mail will be delayed/soft rejected, but
as DNS issues usually are most likely temporarily, it should get delivered
on the second try.