### PR TITLE
Slack Integration with Watchdog ✉️

### DIFF
--- a/data/Dockerfiles/watchdog/watchdog.sh
+++ b/data/Dockerfiles/watchdog/watchdog.sh
@@ -137,7 +137,7 @@ function mail_error() {
 
     # Send Slack Message
     if [ ! -z "$WATCHDOG_SLACK_URL" ]; then
-      content="\"text\": \"${SUBJECT}\",\"blocks\": [{\"type\": \"section\",\"text\":{\"type\": \"mrkdwn\",\"text\":\"*${SUBJECT}*\"}},{\"type\": \"section\",\"text\":{\"type\": \"mrkdwn\",\"text\":\"${BODY}\"}}]"
+      content="\"text\": \"${SUBJECT}\",\"blocks\": [{\"type\": \"section\",\"text\":{\"type\": \"mrkdwn\",\"text\":\"*${SUBJECT}*\"}},{\"type\": \"section\",\"text\":{\"type\": \"mrkdwn\",\"text\":\"${BODY}\n\n${WATCHDOG_SLACK_PING}\"}}]"
       curl -X POST --data-urlencode "payload={$content}" $WATCHDOG_SLACK_URL
       log_msg "Sent Slack notification"
     fi

--- a/data/Dockerfiles/watchdog/watchdog.sh
+++ b/data/Dockerfiles/watchdog/watchdog.sh
@@ -134,6 +134,13 @@ function mail_error() {
       --ipv4
       #--server="${RCPT_MX}"
     log_msg "Sent notification email to ${rcpt}"
+
+    # Send Slack Message
+    if [ ! -z "$WATCHDOG_SLACK_URL" ]; then
+      content="\"text\": \"${SUBJECT}\",\"blocks\": [{\"type\": \"section\",\"text\":{\"type\": \"mrkdwn\",\"text\":\"*${SUBJECT}*\"}},{\"type\": \"section\",\"text\":{\"type\": \"mrkdwn\",\"text\":\"${BODY}\"}}]"
+      curl -X POST --data-urlencode "payload={$content}" $WATCHDOG_SLACK_URL
+      log_msg "Sent Slack notification"
+    fi
   done
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -496,8 +496,8 @@ services:
         - OLEFY_THRESHOLD=${OLEFY_THRESHOLD:-5}
         - MAILQ_THRESHOLD=${MAILQ_THRESHOLD:-20}
         - MAILQ_CRIT=${MAILQ_CRIT:-30}
-        - WATCHDOG_SLACK_URL=${WATCHDOG_SLACK_URL}
-        - WATCHDOG_SLACK_PING=${WATCHDOG_SLACK_PING}
+        - WATCHDOG_SLACK_URL=${WATCHDOG_SLACK_URL:-}
+        - WATCHDOG_SLACK_PING=${WATCHDOG_SLACK_PING:-}
       networks:
         mailcow-network:
           aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -496,6 +496,7 @@ services:
         - OLEFY_THRESHOLD=${OLEFY_THRESHOLD:-5}
         - MAILQ_THRESHOLD=${MAILQ_THRESHOLD:-20}
         - MAILQ_CRIT=${MAILQ_CRIT:-30}
+        - WATCHDOG_SLACK_URL=${WATCHDOG_SLACK_URL}
       networks:
         mailcow-network:
           aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -497,6 +497,7 @@ services:
         - MAILQ_THRESHOLD=${MAILQ_THRESHOLD:-20}
         - MAILQ_CRIT=${MAILQ_CRIT:-30}
         - WATCHDOG_SLACK_URL=${WATCHDOG_SLACK_URL}
+        - WATCHDOG_SLACK_PING=${WATCHDOG_SLACK_PING}
       networks:
         mailcow-network:
           aliases:

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -273,6 +273,10 @@ USE_WATCHDOG=y
 #WATCHDOG_NOTIFY_EMAIL=a@example.com,b@example.com,c@example.com
 #WATCHDOG_NOTIFY_EMAIL=
 
+# Send watchdog notifications via a slack webhook.
+# The webhook URL can be generated using the guide here: https://api.slack.com/messaging/webhooks
+# WATCHDOG_SLACK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
+
 # Notify about banned IP (includes whois lookup)
 WATCHDOG_NOTIFY_BAN=n
 

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -277,6 +277,9 @@ USE_WATCHDOG=y
 # The webhook URL can be generated using the guide here: https://api.slack.com/messaging/webhooks
 # WATCHDOG_SLACK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 
+# Add a "notification ping" in Slack for a user or group. Examples: @username, @channel, @here
+# WATCHDOG_SLACK_PING=@here
+
 # Notify about banned IP (includes whois lookup)
 WATCHDOG_NOTIFY_BAN=n
 

--- a/update.sh
+++ b/update.sh
@@ -250,6 +250,8 @@ CONFIG_ARRAY=(
   "SKIP_SOGO"
   "USE_WATCHDOG"
   "WATCHDOG_NOTIFY_EMAIL"
+  "WATCHDOG_SLACK_URL"
+  "WATCHDOG_SLACK_PING"
   "WATCHDOG_NOTIFY_BAN"
   "WATCHDOG_EXTERNAL_CHECKS"
   "WATCHDOG_SUBJECT"
@@ -305,6 +307,16 @@ for option in ${CONFIG_ARRAY[@]}; do
     if ! grep -q ${option} mailcow.conf; then
       echo "Adding new option \"${option}\" to mailcow.conf"
       echo "WATCHDOG_NOTIFY_EMAIL=" >> mailcow.conf
+    fi
+  elif [[ ${option} == "WATCHDOG_SLACK_URL" ]]; then
+    if ! grep -q ${option} mailcow.conf; then
+      echo "Adding new option \"${option}\" to mailcow.conf"
+      echo "WATCHDOG_SLACK_URL=" >> mailcow.conf
+    fi
+  elif [[ ${option} == "WATCHDOG_SLACK_PING" ]]; then
+    if ! grep -q ${option} mailcow.conf; then
+      echo "Adding new option \"${option}\" to mailcow.conf"
+      echo "WATCHDOG_SLACK_PING=" >> mailcow.conf
     fi
   elif [[ ${option} == "LOG_LINES" ]]; then
     if ! grep -q ${option} mailcow.conf; then


### PR DESCRIPTION
# Slack Integration with Watchdog ✉️

A simple refresher of https://github.com/mailcow/mailcow-dockerized/pull/3672 to enable Slack webhooks to post Watchdog alerts directly into Slack for ease of monitoring.

Credits to @jacobbaungard

Fixes #3672

## Usage

To use this feature, all you need to do is create a Slack webhook ([docs](https://api.slack.com/messaging/webhooks)) and add the following line to your `mailcow.config` file:

```ini
WATCHDOG_SLACK_URL=<SLACK_URL>
```

You may also take advantage of the `WATCHDOG_SLACK_PING` variable to ping a user or group directly in Slack: `@username`, `@here`, `@channel`.

```ini
WATCHDOG_SLACK_PING=<@username>
```

### Examples

Docker Logs:

```console
# docker-compose logs --tail=200 -f watchdog-mailcow
watchdog-mailcow_1   | Waiting for containers to settle...
watchdog-mailcow_1   | Uptime: 1284  Threads: 12  Questions: 3198  Slow queries: 0  Opens: 59  Open tables: 50  Queries per second avg: 2.490
watchdog-mailcow_1   | Resolved MX for <redacted>
watchdog-mailcow_1   | Sun Jul 25 05:33:12 UTC 2021 Sent notification email to <redacted>
watchdog-mailcow_1   | okSun Jul 25 05:33:13 UTC 2021 Sent Slack notification
```

Slack Screenshot:

![image](https://user-images.githubusercontent.com/23362539/126888863-05aa07f5-8d06-45b2-b530-4d8bb590c1de.png)

With `WATCHDOG_SLACK_PING` set to `@here`:

![image](https://user-images.githubusercontent.com/23362539/126910062-644c2f23-6189-4e90-b9a0-d582c1147044.png)

