### PR TITLE
[Web] Added vnd.dovecot.execute/filter/pipe sieve validator support

### DIFF
--- a/data/web/inc/lib/sieve/extensions/vnd.dovecot.execute.xml
+++ b/data/web/inc/lib/sieve/extensions/vnd.dovecot.execute.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' standalone='yes'?>
+
+<extension name="vnd.dovecot.execute">
+
+	<test name="execute">
+		<parameter type="tag" name="pipe" regex="pipe" occurrence="optional"/>
+		<parameter type="string" name="program-name"/>
+		<parameter type="stringlist" name="arguments" occurrence="optional"/>
+	</test>
+
+	<command name="execute">
+		<parameter type="tag" name="pipe" regex="pipe" occurrence="optional"/>
+		<parameter type="string" name="program-name"/>
+		<parameter type="stringlist" name="arguments" occurrence="optional"/>
+	</command>
+	
+</extension>

--- a/data/web/inc/lib/sieve/extensions/vnd.dovecot.filter.xml
+++ b/data/web/inc/lib/sieve/extensions/vnd.dovecot.filter.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' standalone='yes'?>
+
+<extension name="vnd.dovecot.filter">
+
+	<test name="filter">
+		<parameter type="string" name="program-name"/>
+		<parameter type="stringlist" name="arguments" occurrence="optional"/>
+	</test>
+
+	<command name="filter">
+		<parameter type="string" name="program-name"/>
+		<parameter type="stringlist" name="arguments" occurrence="optional"/>
+	</command>
+
+</extension>

--- a/data/web/inc/lib/sieve/extensions/vnd.dovecot.pipe.xml
+++ b/data/web/inc/lib/sieve/extensions/vnd.dovecot.pipe.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' standalone='yes'?>
+
+<extension name="vnd.dovecot.pipe">
+
+	<command name="pipe">
+		<parameter type="tag" name="try" regex="try" occurrence="optional"/>
+		<parameter type="string" name="program-name"/>
+		<parameter type="stringlist" name="arguments" occurrence="optional"/>
+	</command>
+	
+</extension>


### PR DESCRIPTION
This fixes the problem mentioned here #2026 and enables editing the global sieve filter in GUI.
I use these extensions as well, namely to process payment notification emails from bank and for notifications via curl to localhost outside of docker container as well.
It is mostly correct according to RFC (https://github.com/dovecot/pigeonhole/blob/master/doc/rfc/spec-bosch-sieve-extprograms.txt), good enough for most use cases I tried.