### PR TITLE
pulling docker images by built-in functionality

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -61,15 +61,7 @@ check_online_status() {
 prefetch_images() {
   [[ -z ${BRANCH} ]] && { echo -e "\e[33m\nUnknown branch...\e[0m"; exit 1; }
   git fetch origin #${BRANCH}
-  while read image; do
-    RET_C=0
-    until docker pull ${image}; do
-      RET_C=$((RET_C + 1))
-      echo -e "\e[33m\nError pulling $image, retrying...\e[0m"
-      [ ${RET_C} -gt 3 ] && { echo -e "\e[31m\nToo many failed retries, exiting\e[0m"; exit 1; }
-      sleep 1
-    done
-  done < <(git show origin/${BRANCH}:docker-compose.yml | grep "image:" | awk '{ gsub("image:","", $3); print $2 }')
+  docker-compose pull
 }
 
 docker_garbage() {


### PR DESCRIPTION
Since I run into unexpected problems with the `update.sh` script when changing one image name within the `docker-compose.yml` (invalid reference format – Error pulling image:, retrying...) where I was pretty sure, the reference format was correct, I inspected the `update.sh` and refactored it to the usage of builtin `docker-compose pull`.

Perhaps that is an improvement from which everyone can benefit.