### PR TITLE
Fix: Icons not displayed on oauth/authorize.php

### DIFF
--- a/data/web/css/build/013-bootstrap-icons.css
+++ b/data/web/css/build/013-bootstrap-icons.css
@@ -1,7 +1,7 @@
 @font-face {
   font-family: "bootstrap-icons";
-  src: url("../../fonts/bootstrap-icons.woff2?856008caa5eb66df68595e734e59580d") format("woff2"),
-url("../../fonts/bootstrap-icons.woff?856008caa5eb66df68595e734e59580d") format("woff");
+  src: url("/fonts/bootstrap-icons.woff2?856008caa5eb66df68595e734e59580d") format("woff2"),
+url("/fonts/bootstrap-icons.woff?856008caa5eb66df68595e734e59580d") format("woff");
 }
 
 [class^="bi-"]::before,


### PR DESCRIPTION
OAuth Authorization page did not show icons because of relative path.
As other fonts are included with an absolute path this should be fine here, too.

fixes #4151