### PR TITLE
[Rspamd] Fix SOGo Contacts Dynmap

### DIFF
--- a/data/conf/rspamd/dynmaps/settings.php
+++ b/data/conf/rspamd/dynmaps/settings.php
@@ -52,6 +52,7 @@ function parse_email($email) {
 }
 
 function normalize_email($email) {
+  $email = strtolower(str_replace('/', '\/', $email));
   $gm = "@gmail.com";
   if (substr_compare($email, $gm, -strlen($gm)) == 0) {
     $email = explode('@', $email);
@@ -65,7 +66,6 @@ function normalize_email($email) {
     $email[1] = str_replace('@', '', $gm);
     $email = implode('@', $email);
   }
-  $email = strtolower(str_replace('/', '\/', $email));
   return $email;
 }
 

--- a/data/conf/rspamd/dynmaps/settings.php
+++ b/data/conf/rspamd/dynmaps/settings.php
@@ -51,6 +51,24 @@ function parse_email($email) {
   return array('local' => substr($email, 0, $a), 'domain' => substr($email, $a));
 }
 
+function normalize_email($email) {
+  $gm = "@gmail.com";
+  if (substr_compare($email, $gm, -strlen($gm)) == 0) {
+    $email = explode('@', $email);
+    $email[0] = str_replace('.', '', $email[0]);
+    $email = implode('@', $email);
+  } 
+  $gm_alt = "@googlemail.com";
+  if (substr_compare($email, $gm_alt, -strlen($gm_alt)) == 0) {
+    $email = explode('@', $email);
+    $email[0] = str_replace('.', '', $email[0]);
+    $email[1] = str_replace('@', '', $gm);
+    $email = implode('@', $email);
+  }
+  $email = strtolower(str_replace('/', '\/', $email));
+  return $email;
+}
+
 function wl_by_sogo() {
   global $pdo;
   $rcpt = array();
@@ -65,7 +83,7 @@ function wl_by_sogo() {
       }
       // Explicit from, no mime_from, no regex - envelope must match
       // mailcow white and blacklists also cover mime_from
-      $rcpt[$row['user']][] = str_replace('/', '\/', $contact);
+      $rcpt[$row['user']][] = normalize_email($contact);
     }
   }
   return $rcpt;

--- a/data/conf/rspamd/dynmaps/settings.php
+++ b/data/conf/rspamd/dynmaps/settings.php
@@ -66,6 +66,12 @@ function normalize_email($email) {
     $email[1] = str_replace('@', '', $gm);
     $email = implode('@', $email);
   }
+  if (str_contains($email, "+")) {
+    $email = explode('@', $email);
+    $user = explode('+', $email[0]);
+    $email[0] = $user[0];
+    $email = implode('@', $email);
+  }
   return $email;
 }
 


### PR DESCRIPTION
Added new normalize_email function which applies to contacts inside wl_by_sogo setting.php dynmap to align with Rspamd:
1. Lowercase emails
2. Remove tag's
3. Remove dots from gmail.com and change googlemail.com to gmail.com with removed dots as per https://github.com/rspamd/rspamd/blob/master/lualib/lua_util.lua#L271-L274