### PR TITLE
[web] when you adding domain or aliasdomain generate dkim key too

### DIFF
--- a/data/web/inc/functions.dkim.inc.php
+++ b/data/web/inc/functions.dkim.inc.php
@@ -5,14 +5,6 @@ function dkim($_action, $_data = null, $privkey = false) {
   global $lang;
   switch ($_action) {
     case 'add':
-      if ($_SESSION['mailcow_cc_role'] != "admin") {
-        $_SESSION['return'][] = array(
-          'type' => 'danger',
-          'log' => array(__FUNCTION__, $_action, $_data, ),
-          'msg' => 'access_denied'
-        );
-        return false;
-      }
       $key_length = intval($_data['key_size']);
       $dkim_selector = (isset($_data['dkim_selector'])) ? $_data['dkim_selector'] : 'dkim';
       $domains = array_map('trim', preg_split( "/( |,|;|\n)/", $_data['domains']));
@@ -39,6 +31,14 @@ function dkim($_action, $_data = null, $privkey = false) {
             'type' => 'danger',
             'log' => array(__FUNCTION__, $_action, $_data),
             'msg' => array('dkim_domain_or_sel_invalid', $domain)
+          );
+          continue;
+        }
+        if (!hasDomainAccess($_SESSION['mailcow_cc_username'], $_SESSION['mailcow_cc_role'], $domain)) {
+          $_SESSION['return'][] = array(
+            'type' => 'danger',
+            'log' => array(__FUNCTION__, $_action, $_data),
+            'msg' => array('access_denied', $domain)
           );
           continue;
         }

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -579,6 +579,9 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           if (!empty(intval($_data['rl_value']))) {
             ratelimit('edit', 'domain', array('rl_value' => $_data['rl_value'], 'rl_frame' => $_data['rl_frame'], 'object' => $domain));
           }
+          if (!empty($_data['key_size']) && !empty($_data['dkim_selector'])) {
+            dkim('add', array('key_size' => $_data['key_size'], 'dkim_selector' => $_data['dkim_selector'], 'domains' => $domain));
+          }
           if (!empty($restart_sogo)) {
             $restart_response = json_decode(docker('post', 'sogo-mailcow', 'restart'), true);
             if ($restart_response['type'] == "success") {
@@ -905,6 +908,9 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             }
             if (!empty(intval($_data['rl_value']))) {
               ratelimit('edit', 'domain', array('rl_value' => $_data['rl_value'], 'rl_frame' => $_data['rl_frame'], 'object' => $alias_domain));
+            }
+            if (!empty($_data['key_size']) && !empty($_data['dkim_selector'])) {
+              dkim('add', array('key_size' => $_data['key_size'], 'dkim_selector' => $_data['dkim_selector'], 'domains' => $alias_domain));
             }
             $_SESSION['return'][] = array(
               'type' => 'success',

--- a/data/web/modals/mailbox.php
+++ b/data/web/modals/mailbox.php
@@ -166,6 +166,22 @@ if (!isset($_SESSION['mailcow_cc_role'])) {
           </div>
           <hr>
           <div class="form-group">
+            <label class="control-label col-sm-2" for="dkim_selector"><?=$lang['admin']['dkim_domains_selector'];?></label>
+            <div class="col-sm-10">
+              <input class="form-control" id="dkim_selector" name="dkim_selector" value="dkim">
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="control-label col-sm-2" for="key_size"><?=$lang['admin']['dkim_key_length'];?></label>
+            <div class="col-sm-10">
+              <select data-style="btn btn-default btn-sm" class="form-control" id="key_size" name="key_size">
+                <option data-subtext="bits">1024</option>
+                <option data-subtext="bits">2048</option>
+              </select>
+            </div>
+          </div>
+          <hr>
+          <div class="form-group">
             <label class="control-label col-sm-2"><?=$lang['add']['backup_mx_options'];?></label>
             <div class="col-sm-10">
               <div class="checkbox">
@@ -381,6 +397,23 @@ if (!isset($_SESSION['mailcow_cc_role'])) {
             </select>
             </div>
           </div>
+          <hr>
+          <div class="form-group">
+            <label class="control-label col-sm-2" for="dkim_selector"><?=$lang['admin']['dkim_domains_selector'];?></label>
+            <div class="col-sm-10">
+              <input class="form-control" id="dkim_selector" name="dkim_selector" value="dkim">
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="control-label col-sm-2" for="key_size"><?=$lang['admin']['dkim_key_length'];?></label>
+            <div class="col-sm-10">
+              <select data-style="btn btn-default btn-sm" class="form-control" id="key_size" name="key_size">
+                <option data-subtext="bits">1024</option>
+                <option data-subtext="bits">2048</option>
+              </select>
+            </div>
+          </div>
+          <hr>
           <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
               <button class="btn btn-xs-lg visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline btn-success" data-action="add_item" data-id="add_alias_domain" data-api-url='add/alias-domain' data-api-attr='{}' href="#"><?=$lang['admin']['add'];?></button>


### PR DESCRIPTION
Actual problems:
- two-step work - adding domain and then going to the admin section and generate DKIM key.
- domain admin can add an alias domain too, but it is unable to generate a DKIM key. So customer service needs to be contacted and the DKIM key has to be generated by support.

Both issues were solved in this PR by adding two DKIM related fields to "add" modals and updated permissions checks in `dkim.functions` to allow domain admins to generate DKIM keys.

Other proposals:
- configurable default values of DKIM selector and key size
note: if user-configured default DKIM selector is an empty value, it effectively disable this feature