### PR TITLE
[web] fido2 add support for M1 macs with Touch ID

### DIFF
--- a/data/web/admin.php
+++ b/data/web/admin.php
@@ -156,7 +156,15 @@ if (!isset($_SESSION['gal']) && $license_cache = $redis->Get('LICENSE_STATUS_CAC
         </div>
         <div class="row">
           <div class="col-sm-offset-3 col-sm-9">
-            <button class="btn btn-sm btn-primary visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline" id="register-fido2"><?=$lang['fido2']['set_fido2'];?></button>
+	        <div class="btn-group">
+              <button class="btn btn-sm btn-xs-lg btn-primary" id="register-fido2"><?=$lang['fido2']['set_fido2'];?></button>
+              <button type="button" class="btn btn-sm btn-xs-lg btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu">
+                <li><a href="#" id="register-fido2-touchid" style="line-height:1.4;"><i class="bi bi-shield-fill-check"></i> <?=$lang['fido2']['set_fido2_touchid'];?></a></li>
+              </ul>
+	        </div>
           </div>
         </div>
         <br>

--- a/data/web/inc/footer.inc.php
+++ b/data/web/inc/footer.inc.php
@@ -176,12 +176,15 @@ $(document).ready(function() {
     });
   });
   // Set TFA/FIDO2
-  $("#register-fido2").click(function(){
+  $("#register-fido2, #register-fido2-touchid").click(function(){
+	let t = $(this);
+	  
     $("option:selected").prop("selected", false);
     if (!window.fetch || !navigator.credentials || !navigator.credentials.create) {
         window.alert('Browser not supported.');
         return;
     }
+    
     window.fetch("/api/v1/get/fido2-registration/<?= (isset($_SESSION['mailcow_cc_username'])) ? rawurlencode($_SESSION['mailcow_cc_username']) : null; ?>", {method:'GET',cache:'no-cache'}).then(function(response) {
       return response.json();
     }).then(function(json) {
@@ -189,6 +192,13 @@ $(document).ready(function() {
         throw new Error(json.msg);
       }
       recursiveBase64StrToArrayBuffer(json);
+      
+      // set attestation to node if we are registering apple touch id
+      if(t.attr('id') === 'register-fido2-touchid') {
+        json.publicKey.attestation = 'none';
+        json.publicKey.authenticatorSelection.authenticatorAttachment = "platform";
+      }
+      
       return json;
     }).then(function(createCredentialArgs) {
       console.log(createCredentialArgs);

--- a/data/web/lang/lang.cs.json
+++ b/data/web/lang/lang.cs.json
@@ -622,6 +622,7 @@
         "register_status": "Stav registrace",
         "rename": "Přejmenovat",
         "set_fido2": "Registrovat FIDO2 zařízení",
+        "set_fido2_touchid": "Registrovat Touch ID na Apple M1",
         "set_fn": "Nastavi uživatelsky přívětivý název",
         "start_fido2_validation": "Spustit FIDO2 ověření"
     },

--- a/data/web/lang/lang.de.json
+++ b/data/web/lang/lang.de.json
@@ -645,6 +645,7 @@
         "register_status": "Registrierungsstatus",
         "rename": "Umbenennen",
         "set_fido2": "Registriere FIDO2-Gerät",
+        "set_fido2_touchid": "Registriere Touch ID auf Apple M1",
         "set_fn": "Benutzerfreundlichen Namen konfigurieren",
         "start_fido2_validation": "Starte FIDO2-Validierung"
     },

--- a/data/web/lang/lang.en.json
+++ b/data/web/lang/lang.en.json
@@ -648,6 +648,7 @@
         "register_status": "Registration status",
         "rename": "Rename",
         "set_fido2": "Register FIDO2 device",
+        "set_fido2_touchid": "Register Touch ID on Apple M1",
         "set_fn": "Set friendly name",
         "start_fido2_validation": "Start FIDO2 validation"
     },

--- a/data/web/lang/lang.sk.json
+++ b/data/web/lang/lang.sk.json
@@ -646,6 +646,7 @@
         "register_status": "Stav registrácie",
         "rename": "Premenovať",
         "set_fido2": "Registrovať FIDO2 zariadenie",
+        "set_fido2_touchid": "Registrovať Touch ID na Apple M1",
         "set_fn": "Nastaviť zjednodušené meno",
         "start_fido2_validation": "Spustiť FIDO2 overenie"
     },


### PR DESCRIPTION
This adds support for Apple Macs (Macbooks and iMac) with an M1 processor and Touch-ID.

There is an unsolved [bug in WebKit](https://bugs.webkit.org/show_bug.cgi?id=224042) related to this.

I also changing `authenticatorSelection.authenticatorAttachment` to `platform`, because when the user selects Touch-ID in a dropdown, then it is obvious that he wants to use the platform and not the security key.