### PR TITLE
[ClamAV] Update to latest LTS release

### DIFF
--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 LABEL maintainer "André Peters <andre.peters@servercow.de>"
 
-ARG CLAMAV=0.103.2
+ARG CLAMAV=0.103.3
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \


### PR DESCRIPTION
- ClamAV 0.103 is the first Long Term Support (LTS) feature release.
- LTS feature releases will be supported for at least three years from the initial publication date of that LTS feature version. In other words, support for the LTS release "X.Y" starts when version "X.Y.0" is published and ends three years after.
- Each LTS feature release will be supported with critical patch versions and access to download signatures for the duration of the three-year support period.
- A new LTS feature release will be identified approximately every two years.
- Users must stay up-to-date with the latest patch versions for continued support. As of Aug. 28, that means version 0.103.3.
- Source: https://blog.clamav.net/2021/09/changes-to-clamav-end-of-life-policy.html