### PR TITLE
Generalize FIDO2 description for biometric auth on Apple devices

### DIFF
--- a/data/web/lang/lang.de.json
+++ b/data/web/lang/lang.de.json
@@ -646,7 +646,7 @@
         "register_status": "Registrierungsstatus",
         "rename": "Umbenennen",
         "set_fido2": "Registriere FIDO2-Gerät",
-        "set_fido2_touchid": "Registriere Touch ID auf Apple M1",
+        "set_fido2_touchid": "Registriere Touch ID oder Face ID auf Apple-Geräten",
         "set_fn": "Benutzerfreundlichen Namen konfigurieren",
         "start_fido2_validation": "Starte FIDO2-Validierung"
     },

--- a/data/web/lang/lang.en.json
+++ b/data/web/lang/lang.en.json
@@ -648,7 +648,7 @@
         "register_status": "Registration status",
         "rename": "Rename",
         "set_fido2": "Register FIDO2 device",
-        "set_fido2_touchid": "Register Touch ID on Apple M1",
+        "set_fido2_touchid": "Register Touch ID or Face ID on Apple devices",
         "set_fn": "Set friendly name",
         "start_fido2_validation": "Start FIDO2 validation"
     },


### PR DESCRIPTION
This is just a cosmetic change to avoid confusion. The recent FIDO2-related additions by @feldsam work with all kinds of biometric authentication on Apple devices, not just Touch ID on newer M1 devices.

I successfully tested with Touch ID on an Intel MacBook Pro, on iPad as well as Face ID on iPhone.