### PR TITLE
Web: Display app password name in last login list

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -258,7 +258,7 @@ function last_login($action, $username, $sasl_limit_days = 7) {
   switch ($action) {
     case 'get':
       if (filter_var($username, FILTER_VALIDATE_EMAIL) && hasMailboxObjectAccess($_SESSION['mailcow_cc_username'], $_SESSION['mailcow_cc_role'], $username)) {
-        $stmt = $pdo->prepare('SELECT `real_rip`, MAX(`datetime`) as `datetime`, `service`, `app_password` FROM `sasl_log`
+        $stmt = $pdo->prepare('SELECT `real_rip`, MAX(`datetime`) as `datetime`, `service`, `app_password`, MAX(`app_passwd`.`name`) as `app_password_name` FROM `sasl_log`
           LEFT OUTER JOIN `app_passwd` on `sasl_log`.`app_password` = `app_passwd`.`id`
           WHERE `username` = :username
             AND HOUR(TIMEDIFF(NOW(), `datetime`)) < :sasl_limit_days

--- a/data/web/js/site/user.js
+++ b/data/web/js/site/user.js
@@ -101,10 +101,11 @@ jQuery(function($){
             $.each(data.sasl, function (i, item) {
               var datetime = new Date(item.datetime.replace(/-/g, "/"));
               var local_datetime = datetime.toLocaleDateString(undefined, {year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", second: "2-digit"});
-              item.app_password ? app_password = ' <a href="/edit/app-passwd/' + item.app_password + '"><i class="bi bi-pen"></i> App</a>' : app_password = "", item.location ? ip_location = ' <span class="flag-icon flag-icon-' + item.location.toLowerCase() + '"></span>' : ip_location = "";
-              service = '<div class="label label-default">' + item.service.toUpperCase() + '</div>';
-              item.real_rip.startsWith("Web") ? real_rip = item.real_rip : real_rip = '<a href="https://bgp.he.net/ip/' + item.real_rip + '" target="_blank">' + item.real_rip + "</a>";
-              ip_data = real_rip + ip_location + app_password;
+              var service = '<div class="label label-default">' + item.service.toUpperCase() + '</div>';
+              var app_password = item.app_password ? ' <a href="/edit/app-passwd/' + item.app_password + '"><i class="bi bi-pen"></i> ' + escapeHtml(item.app_password_name || "App") + '</a>' : '';
+              var real_rip = item.real_rip.startsWith("Web") ? item.real_rip : '<a href="https://bgp.he.net/ip/' + item.real_rip + '" target="_blank">' + item.real_rip + "</a>";
+              var ip_location = item.location ? ' <span class="flag-icon flag-icon-' + item.location.toLowerCase() + '"></span>' : '';
+              var ip_data = real_rip + ip_location + app_password;
               $(".last-login").append('<li class="list-group-item">' + local_datetime + " " + service + " " + lang.from + " " + ip_data + "</li>");
             })
             $('.last-login').append('</ul>');


### PR DESCRIPTION
Small enhancement to last login list to show the app password name instead of `App`, e.g. turns:
```
30.10.2021, 14:57:15 DAV von Web/EAS/Internal (192.168.22.14)  App
30.10.2021, 14:53:02 EAS von Web/EAS/Internal (192.168.22.12)  App
30.10.2021, 13:34:57 IMAP von Web/EAS/Internal (192.168.22.14)  App
30.10.2021, 12:08:59 SSO von Web/EAS/Internal (192.168.22.14)
30.10.2021, 10:25:16 IMAP von 91.39.82.185   App
```
into
```
30.10.2021, 14:57:15 DAV von Web/EAS/Internal (192.168.22.14)  My Desktop
30.10.2021, 14:53:02 EAS von Web/EAS/Internal (192.168.22.12)  My Tablet
30.10.2021, 13:34:57 IMAP von Web/EAS/Internal (192.168.22.14)  My Desktop
30.10.2021, 12:08:59 SSO von Web/EAS/Internal (192.168.22.14)
30.10.2021, 10:25:16 IMAP von 91.39.82.185   My Mobile
```