### PR TITLE
[Update] Add variable for watchdog verbose output to mailcow config

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -306,6 +306,7 @@ CONFIG_ARRAY=(
   "MAILCOW_PASS_SCHEME"
   "ADDITIONAL_SERVER_NAMES"
   "ACME_CONTACT"
+  "WATCHDOG_VERBOSE"
 )
 
 sed -i --follow-symlinks '$a\' mailcow.conf


### PR DESCRIPTION
Currently the new variable is not added to the mailcow.conf when updating a mailcow instance.