### PR TITLE
nextcloud.conf: add_header Strict-Transport-Security

### DIFF
--- a/data/assets/nextcloud/nextcloud.conf
+++ b/data/assets/nextcloud/nextcloud.conf
@@ -26,6 +26,7 @@ server {
   add_header X-Permitted-Cross-Domain-Policies "none" always;
   add_header X-Robots-Tag "none" always;
   add_header X-XSS-Protection "1; mode=block" always;
+  add_header Strict-Transport-Security "max-age=63072000" always;
 
   fastcgi_hide_header X-Powered-By;
 
@@ -112,6 +113,7 @@ server {
     add_header X-Permitted-Cross-Domain-Policies "none" always;
     add_header X-Robots-Tag "none" always;
     add_header X-XSS-Protection "1; mode=block" always;
+    add_header Strict-Transport-Security "max-age=63072000" always;
     access_log off;
   }
 


### PR DESCRIPTION
Hi,

i have seen that in nextcloud.conf hsts is missing. Maybe someone can add it.

https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1k&guideline=5.6