### PR TITLE
[ClamAV] Update to 0.103.4

### DIFF
--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -2,8 +2,7 @@ FROM debian:buster-slim
 
 LABEL maintainer "André Peters <andre.peters@servercow.de>"
 
-ARG CLAMAV=0.103.3
-
+ARG CLAMAV=0.103.4
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \
   zlib1g-dev \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
             - redis
 
     clamd-mailcow:
-      image: mailcow/clamd:1.41
+      image: mailcow/clamd:1.42
       restart: always
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254


### PR DESCRIPTION
ClamAV 0.103.4 is a critical patch release, see https://blog.clamav.net/2021/11/clamav-01034-and-01041-patch-releases.html for more information.