### PR TITLE
Adding dependabot config (for Dockerfiles)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/data/Dockerfiles"
+    schedule:
+      interval: daily
+      time: "04:00"
+    target-branch: "staging"
+    pull-request-branch-name:
+      separator: "-"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Adding config for [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) keeping track of new versions.