### PR TITLE
[postfix] set hostname via docker-compose

### DIFF
--- a/data/Dockerfiles/postfix/postfix.sh
+++ b/data/Dockerfiles/postfix/postfix.sh
@@ -384,8 +384,6 @@ EOF
 sed -i '/User overrides/q' /opt/postfix/conf/main.cf
 echo >> /opt/postfix/conf/main.cf
 touch /opt/postfix/conf/extra.cf
-sed -i '/myhostname/d' /opt/postfix/conf/extra.cf
-echo -e "myhostname = ${MAILCOW_HOSTNAME}\n$(cat /opt/postfix/conf/extra.cf)" > /opt/postfix/conf/extra.cf
 
 cat /opt/postfix/conf/extra.cf >> /opt/postfix/conf/main.cf
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,6 +302,7 @@ services:
         - crypt-vol-1:/var/lib/zeyple:z
         - rspamd-vol-1:/var/lib/rspamd:z
         - mysql-socket-vol-1:/var/run/mysqld/:z
+      hostname: ${HOSTNAME}
       environment:
         - LOG_LINES=${LOG_LINES:-9999}
         - TZ=${TZ}


### PR DESCRIPTION
@andryyy hi, what you think about this change? I like to prevent setting myhostname in main.cf file, which is git tracked and make my git repo not clean and I have to do chekout before update. I don't use alltimes update.sh, especially when there are small changes in only web. Yes, I know I can do "assume-unchaged", but this is cleaner in my opinion.

I tested it using `docker-compose exec postfix-mailcow bash -c 'postconf|grep myhostname'` and I also try to ping "postfix" hostname from SOGo, so it doesnt breaks internal networking and name resolution.

Signed-off-by: Kristian Feldsam <feldsam@gmail.com>