### PR TITLE
[WEB] fixed wrong value entry in Pushover.twig

### DIFF
--- a/data/web/templates/user/Pushover.twig
+++ b/data/web/templates/user/Pushover.twig
@@ -39,7 +39,7 @@
             <div class="col-sm-12">
               <div class="form-group">
                 <label for="text">{{ lang.user.pushover_sender_array|raw }}</label>
-                <input type="text" class="form-control" name="senders" value="{{ pushover_data.token }}" placeholder="sender1@example.com, sender2@example.com">
+                <input type="text" class="form-control" name="senders" value="{{ pushover_data.senders }}" placeholder="sender1@example.com, sender2@example.com">
               </div>
             </div>
             <div class="col-sm-12">


### PR DESCRIPTION
pushover_data.token was used twice in Pushover.twig (instead of pushover_data.senders)