### PR TITLE
[ofelia] - ofelia-mailcow does not have the correct time zone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -560,6 +560,7 @@ services:
       image: mcuadros/ofelia:latest
       restart: always
       command: daemon --docker
+      environment:
         - TZ=${TZ}
       depends_on:
         - sogo-mailcow


### PR DESCRIPTION
ofelia-mailcow does not have the correct time zone.
Test: docker exec -it mailcowdockerized_ofelia-mailcow_1 date