### PR TITLE
[Solr] Remove breached class from log4j-core.jar

### DIFF
--- a/data/Dockerfiles/solr/Dockerfile
+++ b/data/Dockerfiles/solr/Dockerfile
@@ -16,10 +16,15 @@ RUN dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
   tzdata \
   curl \
   bash \
+  zip \
   && apt-get autoclean \
   && rm -rf /var/lib/apt/lists/* \
   && chmod +x /solr.sh \
   && sync \
   && bash /solr.sh --bootstrap
+  
+RUN zip -q -d /opt/solr/server/lib/ext/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+
+RUN apt remove zip -y  
 
 CMD ["/solr.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -523,7 +523,7 @@ services:
             - dockerapi
 
     solr-mailcow:
-      image: mailcow/solr:1.8
+      image: mailcow/solr:1.8.1
       restart: always
       volumes:
         - solr-vol-1:/opt/solr/server/solr/dovecot-fts/data:Z


### PR DESCRIPTION
**This pull request need a new image build and tag of the solr-mailcow image 1.8 --> 1.8.1**

This is the hard fix for the log4j fix. To be 100% sure that this issue is fixed in this solr version.

**Use with caution, it´s not comfirmed that this won´t break anything of the mailcow by now, it is tested and worked (at least now)**