### PR TITLE
[dockerapi] Update the dockerapi

### DIFF
--- a/data/Dockerfiles/dockerapi/Dockerfile
+++ b/data/Dockerfiles/dockerapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.15
 
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -515,6 +515,7 @@ services:
       environment:
         - DBROOT=${DBROOT}
         - TZ=${TZ}
+        - COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-mailcow-dockerized}
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock:ro
       networks:


### PR DESCRIPTION
Currently dockerapi-mailcow has access to all containers on a host, so I modified the script to only allow access to the containers of the mailcow project. A further step would be to restrict the api call to the IP range of the mailcow project (currently not implemented).

To have a better overview about which methods are applicable to which conatiner I introduced the method _check_applicability. 

or almost all api calls a container_id must be passed, the id must be determined in a separate step. Now you can use the container_name (name in the docker-compose.yml file) instead of the container_id. 

Exampe (source: https://github.com/mailcow/mailcow-dockerized/blob/694e3d652fb5eeb2ea030e21ca0b23ad0e7382a5/data/Dockerfiles/acme/reload-configurations.sh)
```
OLD:
NGINX=($(curl --silent --insecure https://dockerapi/containers/json | jq -r ".[] | {name: .Config.Labels[\"com.docker.compose.service\"], project: .Config.Labels[\"com.docker.compose.project\"], id: .Id}" | jq -rc "select( .name | tostring | contains(\"nginx-mailcow\")) | select( .project | tostring | contains(\"${COMPOSE_PROJECT_NAME,,}\")) | .id" | tr "\n" " "))
NGINX_RELOAD_RET=$(curl -X POST --insecure https://dockerapi/containers/${NGINX}/exec -d '{"cmd":"reload", "task":"nginx"}' --silent -H 'Content-type: application/json' | jq -r .type)

NEW:
NGINX_RELOAD_RET=$(curl -X POST --insecure https://dockerapi/containers/nginx-mailcow/exec -d '{"cmd":"reload", "task":"nginx"}' --silent -H 'Content-type: application/json' | jq -r .type)

```

I tested the changes as far as it was possible, nevertheless further testing should be done. 

off topic:
It would be nice to reconsider the use of the container ofelia-mailcow, because it also has direct access to the /var/run/docker.sock (admin access to docker and the entire host) and the update policy of the conatiner is not the fastest.

