### PR TITLE
[dovecot] Update TLS cipher-suites

### DIFF
--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -30,8 +30,9 @@ mail_attachment_min_size = 128k
 # Dovecot 2.3
 ssl_min_protocol = TLSv1.2
 
-ssl_prefer_server_ciphers = yes
-ssl_cipher_list = ALL:!ADH:!LOW:!SSLv2:!SSLv3:!EXP:!aNULL:!eNULL:!3DES:!MD5:!PSK:!DSS:!RC4:!SEED:!IDEA:+HIGH:+MEDIUM
+# Source: Heise c't 2/2022 page 142; https://wiki.mozilla.org/Security/Server_Side_TLS; https://ssl-config.mozilla.org
+ssl_prefer_server_ciphers = no
+ssl_cipher_list = ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
 
 # Default in Dovecot 2.3
 ssl_options = no_compression no_ticket


### PR DESCRIPTION
This PR adapts the TLS cipher suites to the recommendations of Heise and Mozilla. 
This RP has its origin here: https://github.com/mailcow/mailcow-dockerized/issues/3127

Source:
https://wiki.mozilla.org/Security/Server_Side_TLS
https://ssl-config.mozilla.org/#server=dovecot&version=2.3.9&config=intermediate&openssl=1.1.1d&guideline=5.6
https://www.heise.de/select/ct/2022/2/2011113555115048413

**TODO**
What I still don't like is the "ssl_dh" (Diffie Hellman) parameter, [Mailcow uses a 5 year old 2048 bit parameter.](https://github.com/mailcow/mailcow-dockerized/blob/10b1be7f6b5e1f8cbe477b35b5601755db0717e2/data/assets/ssl-example/dhparams.pem#L1) 
[According to the Openssl wiki "Your Diffie-Hellman group parameters should match the key size used in the server's certificate"](https://wiki.openssl.org/index.php/Diffie-Hellman_parameters), so I think the DH parameter should be 4096 bit ([acme-mailcow generate 4096 bit certs](https://github.com/mailcow/mailcow-dockerized/blob/e2b4b6f6bcb9b8f6d6a4d9b401896ad1c83de288/data/Dockerfiles/acme/acme.sh#L152)).
Maybe each Mailcow installation should have its own dh-parameter (but I'm not sure), which is generated e.g. every year (because the generation takes a long time) with the call of update.sh.

I used "openssl dhparam 4096 > data/assets/ssl/dhparams.pem" to create a new dh-parameter (Processing time approx. 12 minutes). (source: https://doc.dovecot.org/configuration_manual/dovecot_ssl_configuration/)




---
before the adjustments:
cmd: testssl.sh mx2.example.de:993

```
...
 Testing robust (perfect) forward secrecy, (P)FS -- omitting Null Authentication/Encryption, 3DES, RC4 

 PFS is offered (OK)          TLS_AES_256_GCM_SHA384 TLS_CHACHA20_POLY1305_SHA256 ECDHE-RSA-AES256-GCM-SHA384 ECDHE-RSA-AES256-SHA384 ECDHE-RSA-AES256-SHA DHE-RSA-AES256-GCM-SHA384 ECDHE-RSA-CHACHA20-POLY1305
                              DHE-RSA-CHACHA20-POLY1305 DHE-RSA-AES256-CCM8 DHE-RSA-AES256-CCM DHE-RSA-AES256-SHA256 ECDHE-RSA-CAMELLIA256-SHA384 DHE-RSA-CAMELLIA256-SHA256 DHE-RSA-ARIA256-GCM-SHA384 ECDHE-ARIA256-GCM-SHA384
                              TLS_AES_128_GCM_SHA256 ECDHE-RSA-AES128-GCM-SHA256 ECDHE-RSA-AES128-SHA256 ECDHE-RSA-AES128-SHA DHE-RSA-AES128-GCM-SHA256 DHE-RSA-AES128-CCM8 DHE-RSA-AES128-CCM DHE-RSA-AES128-SHA256
                              ECDHE-RSA-CAMELLIA128-SHA256 DHE-RSA-CAMELLIA128-SHA256 DHE-RSA-ARIA128-GCM-SHA256 ECDHE-ARIA128-GCM-SHA256 
 Elliptic curves offered:     prime256v1 secp384r1 secp521r1 X25519 X448 
 DH group offered:            Unknown DH group (2048 bits)

 Testing server preferences 

 Has server cipher order?     yes (OK) -- TLS 1.3 and below
 Negotiated protocol          TLSv1.3
 Negotiated cipher            TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 Cipher order
    TLSv1.2:   ECDHE-RSA-AES256-GCM-SHA384 DHE-RSA-AES256-GCM-SHA384 ECDHE-RSA-CHACHA20-POLY1305 DHE-RSA-CHACHA20-POLY1305 DHE-RSA-AES256-CCM8 DHE-RSA-AES256-CCM ECDHE-ARIA256-GCM-SHA384 DHE-RSA-ARIA256-GCM-SHA384
               ECDHE-RSA-AES128-GCM-SHA256 DHE-RSA-AES128-GCM-SHA256 DHE-RSA-AES128-CCM8 DHE-RSA-AES128-CCM ECDHE-ARIA128-GCM-SHA256 DHE-RSA-ARIA128-GCM-SHA256 ECDHE-RSA-AES256-SHA384 DHE-RSA-AES256-SHA256
               ECDHE-RSA-CAMELLIA256-SHA384 DHE-RSA-CAMELLIA256-SHA256 ECDHE-RSA-AES128-SHA256 DHE-RSA-AES128-SHA256 ECDHE-RSA-CAMELLIA128-SHA256 DHE-RSA-CAMELLIA128-SHA256 ECDHE-RSA-AES256-SHA ECDHE-RSA-AES128-SHA
               AES256-GCM-SHA384 AES256-CCM8 AES256-CCM ARIA256-GCM-SHA384 AES128-GCM-SHA256 AES128-CCM8 AES128-CCM ARIA128-GCM-SHA256 AES256-SHA256 CAMELLIA256-SHA256 AES128-SHA256 CAMELLIA128-SHA256 
    TLSv1.3:   TLS_AES_256_GCM_SHA384 TLS_CHACHA20_POLY1305_SHA256 TLS_AES_128_GCM_SHA256 
...
```

after the adjustments:
cmd: testssl.sh mx2.example.de:993

```
...
 Testing robust (perfect) forward secrecy, (P)FS -- omitting Null Authentication/Encryption, 3DES, RC4 

 PFS is offered (OK)          TLS_AES_256_GCM_SHA384 TLS_CHACHA20_POLY1305_SHA256 ECDHE-RSA-AES256-GCM-SHA384 DHE-RSA-AES256-GCM-SHA384 ECDHE-RSA-CHACHA20-POLY1305 TLS_AES_128_GCM_SHA256 ECDHE-RSA-AES128-GCM-SHA256
                              DHE-RSA-AES128-GCM-SHA256 
 Elliptic curves offered:     prime256v1 secp384r1 secp521r1 X25519 X448 
 DH group offered:            Unknown DH group (2048 bits)

 Testing server preferences 

 Has server cipher order?     no (NOT ok)
 Negotiated protocol          TLSv1.3
 Negotiated cipher            TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519) (limited sense as client will pick)
 Negotiated cipher per proto  (limited sense as client will pick)
     ECDHE-RSA-AES256-GCM-SHA384:   TLSv1.2
     TLS_AES_256_GCM_SHA384:        TLSv1.3
 No further cipher order check has been done as order is determined by the client
...
```
"Has server cipher order?     no (NOT ok)" -> ["The cipher suites are all strong and so we allow the client to choose, as they will know best if they have support for hardware-accelerated AES"](https://wiki.mozilla.org/Security/Server_Side_TLS)  -> therefore OK

after the dh-parameter adjustments:
```
...
 Testing robust (perfect) forward secrecy, (P)FS -- omitting Null Authentication/Encryption, 3DES, RC4 

 PFS is offered (OK)          TLS_AES_256_GCM_SHA384 TLS_CHACHA20_POLY1305_SHA256 ECDHE-RSA-AES256-GCM-SHA384 DHE-RSA-AES256-GCM-SHA384 ECDHE-RSA-CHACHA20-POLY1305 TLS_AES_128_GCM_SHA256 ECDHE-RSA-AES128-GCM-SHA256
                              DHE-RSA-AES128-GCM-SHA256 
 Elliptic curves offered:     prime256v1 secp384r1 secp521r1 X25519 X448 
 DH group offered:            Unknown DH group (4096 bits)

 Testing server preferences 

 Has server cipher order?     no (NOT ok)
 Negotiated protocol          TLSv1.3
 Negotiated cipher            TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519) (limited sense as client will pick)
 Negotiated cipher per proto  (limited sense as client will pick)
     ECDHE-RSA-AES256-GCM-SHA384:   TLSv1.2
     TLS_AES_256_GCM_SHA384:        TLSv1.3
 No further cipher order check has been done as order is determined by the client
...
```
Now "Unknown DH group (4096 bits)"

