### PR TITLE
[Clamd] Update to 0.103.5 (DDOS Fix)

### DIFF
--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 LABEL maintainer "André Peters <andre.peters@servercow.de>"
 
-ARG CLAMAV=0.103.4
+ARG CLAMAV=0.103.5
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \
   zlib1g-dev \
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   dos2unix \
   netcat \
   && rm -rf /var/lib/apt/lists/* \
-  && wget -O - https://fossies.org/linux/misc/clamav-${CLAMAV}.tar.gz | tar xfvz - \
+  && wget -O - https://www.clamav.net/downloads/production/clamav-${CLAMAV}.tar.gz | tar xfvz - \
   && cd clamav-${CLAMAV} \
   && ./configure \
   --prefix=/usr \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
             - redis
 
     clamd-mailcow:
-      image: mailcow/clamd:1.42
+      image: mailcow/clamd:1.43
       restart: always
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254


### PR DESCRIPTION
This pull request is updating ClamAV to 0.103.5.

From the BSI (German Federal office for Information security) it is recommended to update to this version: https://www.bsi.bund.de/SharedDocs/Warnmeldungen/DE/TW/2022/01/warnmeldung_tw-t22-0012.html

I also changed the mirror url back to clamav´s one, because the selected mirror did not contain this release at this day (2022-01-15)

**This pull request need a new docker image tag (clamd-mailcow:1.43)**

How ever there is one thing curios which i don´t know for sure if it is a bug or not:
`clamd-mailcow_1      | Sat Jan 15 17:14:18 2022 -> ^Clamd was NOT notified: Can't connect to clamd through /run/clamav/clamd.sock: No such file or directory` <-- This is coming directly after the startup. I saw the issue: https://github.com/mailcow/mailcow-dockerized/issues/3088 and was wondering if this is the same error or not.

@andryyy or @MAGICCC  can someone check that with the current clamd version? If this error occurs on the older version 0.103.4.