### PR TITLE
[Clamd] Rebase on Bullseye

### DIFF
--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 LABEL maintainer "André Peters <andre.peters@servercow.de>"
 


### PR DESCRIPTION
This PR is including the Rebase from the Clamd Image to Bullseye (Debian 11)

The Image Tag will be **mailcow/clamd:1.43**

(It has been tested already)