### PR TITLE
Added xtables-addon to netfilter container to handle iptables rules with geoip

### DIFF
--- a/data/Dockerfiles/netfilter/Dockerfile
+++ b/data/Dockerfiles/netfilter/Dockerfile
@@ -13,6 +13,7 @@ RUN apk add --virtual .build-deps \
 && apk add -U python3 \
   iptables \
   ip6tables \
+  xtables-addons \
   tzdata \
   py3-pip \
   musl-dev \

--- a/data/Dockerfiles/netfilter/Dockerfile
+++ b/data/Dockerfiles/netfilter/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.15
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
 ENV XTABLES_LIBDIR /usr/lib/xtables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -420,7 +420,7 @@ services:
             - acme
 
     netfilter-mailcow:
-      image: mailcow/netfilter:1.45
+      image: mailcow/netfilter:1.46
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow


### PR DESCRIPTION
The Netfilter container runs into an error if the host system have active geoip rules in the Input, Forward or Mailcow chain:

`
Clearing all bans
Traceback (most recent call last):
  File "/server.py", line 526, in <module>
    clear()
  File "/server.py", line 299, in clear
    for rule in input_chain.rules:
  File "/usr/lib/python3.9/site-packages/iptc/ip4tc.py", line 1518, in _get_rules
    return [self.table.create_rule(e, self) for e in entries]
  File "/usr/lib/python3.9/site-packages/iptc/ip4tc.py", line 1518, in <listcomp>
    return [self.table.create_rule(e, self) for e in entries]
  File "/usr/lib/python3.9/site-packages/iptc/ip4tc.py", line 1834, in create_rule
    return Rule(entry, chain)
  File "/usr/lib/python3.9/site-packages/iptc/ip4tc.py", line 957, in __init__
    self.rule = entry
  File "/usr/lib/python3.9/site-packages/iptc/ip4tc.py", line 1363, in _set_rule
    m = Match(self, match=match)
  File "/usr/lib/python3.9/site-packages/iptc/ip4tc.py", line 552, in __init__
    raise XTablesError("can't find match %s" % (name))
iptc.errors.XTablesError: can't find match geoip
`

To fix this, we need to add the xtables-addons package to handle this rules.