### PR TITLE
[Config (Clamd)] Update SSL Path to new style (dynamic)

### DIFF
--- a/data/Dockerfiles/acme/obtain-certificate.sh
+++ b/data/Dockerfiles/acme/obtain-certificate.sh
@@ -80,7 +80,7 @@ fi
 printf "[SAN]\nsubjectAltName=" > /tmp/_SAN
 printf "DNS:%s," "${CERT_DOMAINS[@]}" >> /tmp/_SAN
 sed -i '$s/,$//' /tmp/_SAN
-openssl req -new -sha256 -key ${KEY} -subj "/" -reqexts SAN -config <(cat /etc/ssl/openssl.cnf /tmp/_SAN) > ${CSR}
+openssl req -new -sha256 -key ${KEY} -subj "/" -reqexts SAN -config <(cat "$(openssl version -d | sed 's/.*"\(.*\)"/\1/g')/openssl.cnf" /tmp/_SAN) > ${CSR}
 
 # acme-tiny writes info to stderr and ceritifcate to stdout
 # The redirects will do the following:


### PR DESCRIPTION
Thanks to @mkuron this fix will change the ssl path to be dynamic (not hardcoded) to ensure that acme is still working with Alpine 3.15 or higher.

This PR is included in the Docker tag: mailcow/acme:1.81 (including the Alpine 3.15 update)