### PR TITLE
[SOGo] Update SOGo to 5.5.0 + syslog Version Update (in Config)

### DIFF
--- a/data/Dockerfiles/sogo/syslog-ng-redis_slave.conf
+++ b/data/Dockerfiles/sogo/syslog-ng-redis_slave.conf
@@ -1,4 +1,4 @@
-@version: 3.19
+@version: 3.28
 @include "scl.conf"
 options {
   chain_hostnames(off);

--- a/data/Dockerfiles/sogo/syslog-ng.conf
+++ b/data/Dockerfiles/sogo/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.19
+@version: 3.28
 @include "scl.conf"
 options {
   chain_hostnames(off);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: mailcow/sogo:1.105
+      image: mailcow/sogo:1.106
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}


### PR DESCRIPTION
This PR is updating SOGo to the new 5.5.0 Release (https://github.com/inverse-inc/sogo/releases/tag/SOGo-5.5.0) <-- Available in master.

It also includes the nsyslog Update to 3.28 (since the new SOGo builds are using a newer version), which fix a warning message inside the sogo container that the nsyslog version is outdated and can be upgraded to 3.28

This new release will have the Docker Image Tag: **mailcow/sogo:1.106**