### PR TITLE
[Watchdog] Update to Alpine 3.15

### DIFF
--- a/data/Dockerfiles/watchdog/Dockerfile
+++ b/data/Dockerfiles/watchdog/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.15
 LABEL maintainer "André Peters <andre.peters@servercow.de>"
 
 # Installation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -443,7 +443,7 @@ services:
         - /lib/modules:/lib/modules:ro
 
     watchdog-mailcow:
-      image: mailcow/watchdog:1.95
+      image: mailcow/watchdog:1.96
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       tmpfs:


### PR DESCRIPTION
This PR includes the Alpine Update 3.15 for the watchdog-mailcow container.

Fully tested (works flawlessly due to the fact that only the os got updated, not the script).

This PR will have the docker tag: **mailcow/watchdog:1.96**
