### PR TITLE
Passwordless SOGo auth: support for calendar invitations and calender/contacts subscriptions

### DIFF
--- a/.github/workflows/close_old_issues_and_prs.yml
+++ b/.github/workflows/close_old_issues_and_prs.yml
@@ -25,8 +25,8 @@ jobs:
           stale-pr-message: >
             This pull request has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs.
-          exempt-issue-labels: "pinned,security,enhancement,investigating"
-          exempt-pr-labels: "pinned,security,enhancement,investigating"
+          exempt-issue-labels: "pinned,security,enhancement,investigating,neverstale"
+          exempt-pr-labels: "pinned,security,enhancement,investigating,neverstale"
           stale-issue-label: "stale"
           stale-pr-label: "stale"
           exempt-draft-pr: "true"

--- a/data/web/sogo-auth.php
+++ b/data/web/sogo-auth.php
@@ -89,6 +89,13 @@ elseif (isset($_SERVER['HTTP_X_ORIGINAL_URI']) && strcasecmp(substr($_SERVER['HT
     header("X-Auth: Basic ".base64_encode("$username:$password"));
     header("X-Auth-Type: Basic");
     exit;
+  } elseif(isset($_SESSION['mailcow_cc_username'])) {
+    $username = $_SESSION['mailcow_cc_username'];
+    $password = $_SESSION[$session_var_pass];
+    header("X-User: $username");
+    header("X-Auth: Basic ".base64_encode("$username:$password"));
+    header("X-Auth-Type: Basic");
+    exit;
   }
 }
 

--- a/data/web/sogo-auth.php
+++ b/data/web/sogo-auth.php
@@ -75,27 +75,26 @@ elseif (isset($_SERVER['HTTP_X_ORIGINAL_URI']) && strcasecmp(substr($_SERVER['HT
   session_start();
   // extract email address from "/SOGo/so/user@domain/xy"
   $url_parts = explode("/", $_SERVER['HTTP_X_ORIGINAL_URI']);
-  $email = $url_parts[3];
-  // check if this email is in session allowed list
-  if (
-      !empty($email) &&
-      filter_var($email, FILTER_VALIDATE_EMAIL) &&
-      is_array($_SESSION[$session_var_user_allowed]) &&
-      in_array($email, $_SESSION[$session_var_user_allowed])
-  ) {
-    $username = $email;
-    $password = $_SESSION[$session_var_pass];
-    header("X-User: $username");
-    header("X-Auth: Basic ".base64_encode("$username:$password"));
-    header("X-Auth-Type: Basic");
-    exit;
-  } elseif(isset($_SESSION['mailcow_cc_username'])) {
-    $username = $_SESSION['mailcow_cc_username'];
-    $password = $_SESSION[$session_var_pass];
-    header("X-User: $username");
-    header("X-Auth: Basic ".base64_encode("$username:$password"));
-    header("X-Auth-Type: Basic");
-    exit;
+  $email_list = array(
+      $url_parts[3],                                // Requested mailbox
+      ($_SESSION['mailcow_cc_username'] ?? ''),     // Current user
+      ($_SESSION["dual-login"]["username"] ?? ''),  // Dual login user
+  );
+  foreach($email_list as $email) {
+    // check if this email is in session allowed list
+    if (
+        !empty($email) &&
+        filter_var($email, FILTER_VALIDATE_EMAIL) &&
+        is_array($_SESSION[$session_var_user_allowed]) &&
+        in_array($email, $_SESSION[$session_var_user_allowed])
+    ) {
+      $username = $email;
+      $password = $_SESSION[$session_var_pass];
+      header("X-User: $username");
+      header("X-Auth: Basic ".base64_encode("$username:$password"));
+      header("X-Auth-Type: Basic");
+      exit;
+    }
   }
 }
 


### PR DESCRIPTION
Inviting someone to a calendar event triggers a request to `/SOGo/so/otheruser@example.com/freebusy.ifb/ajaxRead`. Attempting to subscribe to someone's calendar/contacts triggers a request to `/SOGo/so/otheruser@example.com/foldersSearch`. The email address in the URL is different from the logged-in user, which needs to be handled appropriately by sogo-auth.php.

Fixes #4333.

@keenmouse, could you please try this patch on your server and confirm that it fixes the issue for you too? @jkellerer, since you worked on the app passwords that use this authentication mechanism, could you please have a quick look at my patch? Also @mhofer117, who did the original work on passwordless SOGo authentication.

@DerLinkman, if you are okay with that, I would like to merge this straight to master instead of going through staging. It's a bugfix, and it's relatively simple, so I would like to get this to users as soon as possible.