### PR TITLE
[WebAuthn] fido2 passwordless auth - fix

### DIFF
--- a/.github/workflows/close_old_issues_and_prs.yml
+++ b/.github/workflows/close_old_issues_and_prs.yml
@@ -25,8 +25,8 @@ jobs:
           stale-pr-message: >
             This pull request has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs.
-          exempt-issue-labels: "pinned,security,enhancement,investigating"
-          exempt-pr-labels: "pinned,security,enhancement,investigating"
+          exempt-issue-labels: "pinned,security,enhancement,investigating,neverstale"
+          exempt-pr-labels: "pinned,security,enhancement,investigating,neverstale"
           stale-issue-label: "stale"
           stale-pr-label: "stale"
           exempt-draft-pr: "true"

--- a/data/web/inc/vars.inc.php
+++ b/data/web/inc/vars.inc.php
@@ -195,8 +195,8 @@ $SHOW_LAST_LOGIN = true;
 // true = required
 // false = preferred
 // string 'required' 'preferred' 'discouraged'
-$WEBAUTHN_UV_FLAG_REGISTER = 'discouraged';
-$WEBAUTHN_UV_FLAG_LOGIN = 'discouraged';
+$WEBAUTHN_UV_FLAG_REGISTER = false;
+$WEBAUTHN_UV_FLAG_LOGIN = false;
 $WEBAUTHN_USER_PRESENT_FLAG = true;
 
 $FIDO2_UV_FLAG_REGISTER = 'preferred';

--- a/data/web/inc/vars.inc.php
+++ b/data/web/inc/vars.inc.php
@@ -195,8 +195,8 @@ $SHOW_LAST_LOGIN = true;
 // true = required
 // false = preferred
 // string 'required' 'preferred' 'discouraged'
-$WEBAUTHN_UV_FLAG_REGISTER = false;
-$WEBAUTHN_UV_FLAG_LOGIN = false;
+$WEBAUTHN_UV_FLAG_REGISTER = 'discouraged';
+$WEBAUTHN_UV_FLAG_LOGIN = 'discouraged';
 $WEBAUTHN_USER_PRESENT_FLAG = true;
 
 $FIDO2_UV_FLAG_REGISTER = 'preferred';

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -409,16 +409,14 @@ if (isset($_GET['query'])) {
         break;
         case "fido2-get-args":
           header('Content-Type: application/json');
-          // fetch allowed credentialIds
-          $cids = fido2(array("action" => "get_all_cids"));
-          if (count($cids) == 0) {  
-            print(json_encode(array(
-                'type' => 'error',
-                'msg' => 'Cannot find matching credentialIds'
-            )));
-          }
+          // Login without username, no ids!
+          // $ids = fido2(array("action" => "get_all_cids"));
+          // if (count($ids) == 0) {
+            // return;
+          // }
+          $ids = NULL;
 
-          $getArgs = $WebAuthn->getGetArgs($cids, 30, true, true, true, true, $GLOBALS['FIDO2_UV_FLAG_LOGIN']);
+          $getArgs = $WebAuthn->getGetArgs($ids, 30, true, true, true, true, $GLOBALS['FIDO2_UV_FLAG_LOGIN']);
           print(json_encode($getArgs));
           $_SESSION['challenge'] = $WebAuthn->getChallenge();
           return;


### PR DESCRIPTION
Undo some changes i made, that may lead to some problems when a lot of fido2 devices are registered.

Originally i made those changes, because i experienced some problems with fido2 only authentication on Android with internal authenticator.
Android devices didn't react when the server send getArgs parameters with an empty allowCredentials array.

~~I also set the UV flags for WebAuthn 2FA from false to 'discouraged'. 
This will fix this [issue](https://github.com/mailcow/mailcow-dockerized/issues/4421#issuecomment-1019378066)~~
test failed. I will leave it for now that the UV flags are set to false.