### PR TITLE
oletools: disable template injection detection

### DIFF
--- a/data/Dockerfiles/olefy/Dockerfile
+++ b/data/Dockerfiles/olefy/Dockerfile
@@ -9,8 +9,8 @@ RUN apk add --virtual .build-deps gcc musl-dev python3-dev libffi-dev openssl-de
   && pip3 install --upgrade pip \
   && pip3 install --upgrade asyncio python-magic \
   && pip3 install --upgrade https://github.com/HeinleinSupport/oletools/archive/master.zip \
-  && apk del .build-deps
-#  && sed -i 's/decompress_stream(bytearray(compressed_code))/bytes2str(decompress_stream(bytearray(compressed_code)))/g' /usr/lib/python3.8/site-packages/oletools/olevba.py
+  && apk del .build-deps \
+  && sed -i 's/template_injection_detected = True/template_injection_detected = False/g' /usr/lib/python3.9/site-packages/oletools/olevba.py
 
 ADD olefy.py /app/
 


### PR DESCRIPTION
This check seems to be causing a lot of false positives lately. It misrecognizes Office documents that were created from a template as embedding remote files -- when really they are only referring to the file path of their template. So let's disable it for now.

This check was actually disabled in upstream oletools in May 2021 (https://github.com/decalage2/oletools/commit/3cae86e62d99a29858721ca6f99c8c2cf15be8e4) and in Heinlein's fork in December 2021 (https://github.com/HeinleinSupport/oletools/commit/3d7f26c696604dbf434fb354a579fa9d73688e96). We are currently using Heinlein's master branch, which is severely outdated (November 2020). We should switch to their stable-patched branch (change master.zip to stable-patched.zip in line 11), but since that's potentially a bigger change that will require additional testing, for now I am only disabling this check. My server has been running with this patch for a few weeks now without problems and without false positives.