### PR TITLE
Update issue templates to issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,60 +1,94 @@
----
 name: 🐞 Bug Report
-about: Report a reproducible bug for mailcow. (NOT to be used for support questions.)
-labels: bug
----
+description: Report a reproducible bug for mailcow. (NOT to be used for support questions.)
+labels: ["bug"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Contribution guidelines
+      description: Please read the contribution guidelines before proceeding.
+      options:
+        - label: I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree
+          required: true
+  - type: checkboxes
+    attributes:
+      label: I've found a bug and checked that ...
+      description: Prior to placing the issue, please check following:** *(fill out each checkbox with an `X` once done)*
+      options:
+      - label: ... I understand that not following the below instructions will result in immediate closure and/or deletion of my issue.
+        required: true
+      - label: ... I have understood that this bug report is dedicated for bugs, and not for support-related inquiries.
+        required: true
+      - label: ... I have understood that answers are voluntary and community-driven, and not commercial support.
+        required: true
+      - label: ... I have verified that my issue has not been already answered in the past. I also checked previous [issues](https://github.com/mailcow/mailcow-dockerized/issues).
+        required: true
+  - type: textarea
+    attributes:
+      label: Description
+      description: Please provide a brief description of the bug in 1-2 sentences. If applicable, add screenshots to help explain your problem. Very useful for bugs in mailcow UI.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Logs
+      description: Please take a look at the [official documentation](https://mailcow.github.io/mailcow-dockerized-docs/debug-logs/) and post the last few lines of logs, when the error occurs. For example, docker container logs of affected containers. This will be automatically formatted into code, so no need for backticks.
+      render: bash
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Please describe the steps to reproduce the bug. Screenshots can be added, if helpful.
+      placeholder: |-
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: System information
+      description: In this stage we would kindly ask you to attach general system information about your setup.
+      value: |-
+             | Question | Answer |
+             | --- | --- |
+             | My operating system | I_DO_REPLY_HERE |
+             | Is Apparmor, SELinux or similar active? | I_DO_REPLY_HERE |
+             | Virtualization technlogy (KVM, VMware, Xen, etc - **LXC and OpenVZ are not supported** | I_DO_REPLY_HERE |
+             | Server/VM specifications (Memory, CPU Cores) | I_DO_REPLY_HERE |
+             | Docker Version (`docker version`) | I_DO_REPLY_HERE |
+             | Docker-Compose Version (`docker-compose version`) | I_DO_REPLY_HERE |
+             | Reverse proxy (custom solution) | I_DO_REPLY_HERE |
 
-<!--
-  Please DO NOT delete this template or use it for support questions.
-  You are welcome to visit us on our community channels listed at https://mailcow.github.io/mailcow-dockerized-docs/#community-support
-  For official support, please check https://mailcow.github.io/mailcow-dockerized-docs/#commercial-support
--->
+             Output of `git diff origin/master`, any other changes to the code? If so, **please post them**:
+             ```
+             YOUR OUTPUT GOES HERE
+             ```
 
-**Prior to placing the issue, please check following:** *(fill out each checkbox with an `X` once done)*
-- [ ] I understand that not following or deleting the below instructions will result in immediate closure and/or deletion of my issue.
-- [ ] I have understood that this bug report is dedicated for bugs, and not for support-related inquiries.
-- [ ] I have understood that answers are voluntary and community-driven, and not commercial support.
-- [ ] I have verified that my issue has not been already answered in the past. I also checked previous [issues](https://github.com/mailcow/mailcow-dockerized/issues).
+             All third-party firewalls and custom iptables rules are unsupported. **Please check the Docker docs about how to use Docker with your own ruleset**. Nevertheless, iptabels output can help us to help you:
+             iptables -L -vn:
+             ```
+             YOUR OUTPUT GOES HERE
+             ```
 
-## Summary
-<!--
-  This should be a clear and concise description of what the bug is. What EXACTLY does happen?
-  If applicable, add screenshots to help explain your problem. Very useful for bugs in mailcow UI.
-  Write your detailed description below.
+             ip6tables -L -vn:
+             ```
+             YOUR OUTPUT GOES HERE
+             ```
 
-  Also mention on which commit/date your mailcow instance was last updated.
--->
+             iptables -L -vn -t nat:
+             ```
+             YOUR OUTPUT GOES HERE
+             ```
 
-## Logs
-<!--
-  Please take a look at the [official documentation](https://mailcow.github.io/mailcow-dockerized-docs/debug-logs/) and post the last
-  few lines of logs, when the error occurs. For example, docker container logs of affected containers.
--->
+             ip6tables -L -vn -t nat:
+             ```
+             YOUR OUTPUT GOES HERE
+             ```
 
-## Reproduction
-<!--
-  It is really helpful to know how exactly you are able to reproduce the reported issue.
-  Have you tried to fix the issue? What did you try?
-  What are the exact steps to get the above described behavior?
-  Screenshots can be added, if helpful. Add the text below.
--->
-
-## System information
-<!--
-  In this stage we would kindly ask you to attach general system information about your setup.
-  Please carefully read the questions and instructions below.
--->
-
-| Question | Answer |
-| --- | --- |
-| My operating system | I_DO_REPLY_HERE |
-| Is Apparmor, SELinux or similar active? | I_DO_REPLY_HERE |
-| Virtualization technlogy (KVM, VMware, Xen, etc - **LXC and OpenVZ are not supported** | I_DO_REPLY_HERE |
-| Server/VM specifications (Memory, CPU Cores) | I_DO_REPLY_HERE |
-| Docker Version (`docker version`) | I_DO_REPLY_HERE |
-| Docker-Compose Version (`docker-compose version`) | I_DO_REPLY_HERE |
-| Reverse proxy (custom solution) | I_DO_REPLY_HERE |
-
-- Output of `git diff origin/master`, any other changes to the code? If so, **please post them**.
-- All third-party firewalls and custom iptables rules are unsupported. *Please check the Docker docs about how to use Docker with your own ruleset*. Nevertheless, iptabels output can help us to help you: `iptables -L -vn`, `ip6tables -L -vn`, `iptables -L -vn -t nat` and `ip6tables -L -vn -t nat`.
-- DNS problems? Please run `docker exec -it $(docker ps -qf name=acme-mailcow) dig +short stackoverflow.com @172.22.1.254` (set the IP accordingly, if you changed the internal mailcow network) and post the output.
+             DNS problems? Please run `docker exec -it $(docker ps -qf name=acme-mailcow) dig +short stackoverflow.com @172.22.1.254` (set the IP accordingly, if you changed the internal mailcow network) and post the output:
+             ```
+             YOUR OUTPUT GOES HERE
+             ```
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,29 +1,20 @@
----
 name: 💡 Feature Request
-about: Suggest an idea for mailcow.
-labels: enhancement
----
-
-<!--
-  Please note that the mailcow team and its contributors do have finite
-  resources and that we can not work on all filed feature requests.
-
-  However making us aware about certain ideas can help us improving
-  mailcow together.
-  
-  We're also happy to help you getting a specific  feature implemented.
--->
-
-## Summary
-
-A clear and concise description of what the problem is.
-For example: I'm always frustrated when [...]
-
-## Motivation
-
-What are you about to solve or improve with this idea?
-What would be the benefit for most users?
-
-## Additional context
-
-Add any other context or screenshots about the feature request.
+description: Suggest an idea for mailcow.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    attributes:
+      label: Summary
+      description: Please describe your idea in a reasonable amount of detail.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: Please describe how your idea would benefit you and other users.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request.


### PR DESCRIPTION
This PR updates the issue templates to GitHubs _new_ [issue forms](https://github.blog/changelog/2021-06-23-issues-forms-beta-for-public-repositories/)

I selected staging because it will go in master branch with the next release anyway