### PR TITLE
Update and fix oletools

### DIFF
--- a/data/Dockerfiles/olefy/Dockerfile
+++ b/data/Dockerfiles/olefy/Dockerfile
@@ -8,9 +8,9 @@ RUN apk add --virtual .build-deps gcc musl-dev python3-dev libffi-dev openssl-de
   && apk add --update --no-cache python3 py3-pip openssl tzdata libmagic \
   && pip3 install --upgrade pip \
   && pip3 install --upgrade asyncio python-magic \
-  && pip3 install --upgrade https://github.com/HeinleinSupport/oletools/archive/master.zip \
-  && apk del .build-deps \
-  && sed -i 's/template_injection_detected = True/template_injection_detected = False/g' /usr/lib/python3.9/site-packages/oletools/olevba.py
+  && pip3 install --upgrade https://github.com/decalage2/oletools/archive/master.zip \
+  && apk del .build-deps
+#  && sed -i 's/template_injection_detected = True/template_injection_detected = False/g' /usr/lib/python3.9/site-packages/oletools/olevba.py
 
 ADD olefy.py /app/
 

--- a/data/Dockerfiles/rspamd/Dockerfile
+++ b/data/Dockerfiles/rspamd/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update && apt-get install -y \
   && apt-get clean \
   && mkdir -p /run/rspamd \
   && chown _rspamd:_rspamd /run/rspamd \
-  && echo 'alias ll="ls -la --color"' >> ~/.bashrc
+  && echo 'alias ll="ls -la --color"' >> ~/.bashrc \
+  && sed -i 's/#analysis_keyword_table > 0/analysis_cat_table.macro_exist == "M"/g' /usr/share/rspamd/lualib/lua_scanners/oletools.lua
 
 COPY settings.conf /etc/rspamd/settings.conf
 COPY metadata_exporter.lua /usr/share/rspamd/plugins/metadata_exporter.lua

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
             - clamd
 
     rspamd-mailcow:
-      image: mailcow/rspamd:1.79
+      image: mailcow/rspamd:1.80
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow
@@ -540,7 +540,7 @@ services:
             - solr
 
     olefy-mailcow:
-      image: mailcow/olefy:1.8.1
+      image: mailcow/olefy:1.9
       restart: always
       environment:
         - TZ=${TZ}
@@ -548,7 +548,7 @@ services:
         - OLEFY_BINDPORT=10055
         - OLEFY_TMPDIR=/tmp
         - OLEFY_PYTHON_PATH=/usr/bin/python3
-        - OLEFY_OLEVBA_PATH=/usr/bin/olevba3
+        - OLEFY_OLEVBA_PATH=/usr/bin/olevba
         - OLEFY_LOGLVL=20
         - OLEFY_MINLENGTH=500
         - OLEFY_DEL_TMP=1


### PR DESCRIPTION
As noticed by @MAGICCC (https://github.com/mailcow/mailcow-dockerized/pull/4464#issuecomment-1042347368), our olefy image does not work anymore if you rebuild it. This is because @HeinleinSupport recently updated their repository with the changes from @decalage2's repository, which renamed `olvba3` to `olevba`. Since @HeinleinSupport does not recommend using its own patched branch and is very slow in pulling in changes from upstream (@decalage2), let's switch to the latter. This also allowed me to revert #4464.

Finally, a minor patch to rspamd is necessary. While the [documentation](https://rspamd.com/doc/modules/external_services.html#oletools-extended-mode) says

> In the extended mode the oletools module will not trigger on specific categories, but will always set a threat string with all found flags when at least a macro was found.

This is not actually true -- it only sets it when _suspicious_ or _autoexec_ threats were detected. But it's a one-line patch to make rspamd behave as documented and we should submit that patch to @rspamd too. With this patch, I have confirmed that Mailcow will reject any incoming, non-whitelisted message containing attachments with macros.