### PR TITLE
increase opcache.interned_strings_buffer to 16

### DIFF
--- a/data/conf/phpfpm/php-conf.d/opcache-recommended.ini
+++ b/data/conf/phpfpm/php-conf.d/opcache-recommended.ini
@@ -1,6 +1,6 @@
 opcache.enable=1
 opcache.enable_cli=1
-opcache.interned_strings_buffer=8
+opcache.interned_strings_buffer=16
 opcache.max_accelerated_files=10000
 opcache.memory_consumption=128
 opcache.save_comments=1


### PR DESCRIPTION
since version 23.0.2 Nextcloud recommends having a value greater than 8 for `opcache.interned_strings_buffer`. As this memory will be only used when needed this should have no impact on installations that are not using nextcloud.

related discussion: https://help.nextcloud.com/t/nextcloud-23-02-opcache-interned-strings-buffer/134007/19
related nextcloud issue: https://github.com/nextcloud/server/issues/31223