### PR TITLE
[Dovecot] Updated syslogng Version to 3.28

### DIFF
--- a/data/Dockerfiles/dovecot/syslog-ng-redis_slave.conf
+++ b/data/Dockerfiles/dovecot/syslog-ng-redis_slave.conf
@@ -1,4 +1,4 @@
-@version: 3.19
+@version: 3.28
 @include "scl.conf"
 options {
   chain_hostnames(off);

--- a/data/Dockerfiles/dovecot/syslog-ng.conf
+++ b/data/Dockerfiles/dovecot/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.19
+@version: 3.28
 @include "scl.conf"
 options {
   chain_hostnames(off);


### PR DESCRIPTION
This PR fixes the error:
![2022-03-02 11_51_05-pve - Proxmox Virtual Environment](https://user-images.githubusercontent.com/62480600/156349158-02068a30-7796-4c71-bfdb-ef1d9399ba61.png)

Rest works as usual.