### PR TITLE
Can't restore from older backup because script crashes?

### DIFF
--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -23,7 +23,7 @@ function init_db_schema() {
     }
 
     $views = array(
-    "grouped_mail_aliases" => "CREATE VIEW grouped_mail_aliases (username, aliases) AS
+    "grouped_mail_aliases" => "CREATE VIEW IF NOT EXISTS grouped_mail_aliases (username, aliases) AS
       SELECT goto, IFNULL(GROUP_CONCAT(address ORDER BY address SEPARATOR ' '), '') AS address FROM alias
       WHERE address!=goto
       AND active = '1'
@@ -33,23 +33,23 @@ function init_db_schema() {
     // START
     // Unused at the moment - we cannot allow to show a foreign mailbox as sender address in SOGo, as SOGo does not like this
     // We need to create delegation in SOGo AND set a sender_acl in mailcow to allow to send as user X
-    "grouped_sender_acl" => "CREATE VIEW grouped_sender_acl (username, send_as_acl) AS
+    "grouped_sender_acl" => "CREATE VIEW IF NOT EXISTS grouped_sender_acl (username, send_as_acl) AS
       SELECT logged_in_as, IFNULL(GROUP_CONCAT(send_as SEPARATOR ' '), '') AS send_as_acl FROM sender_acl
       WHERE send_as NOT LIKE '@%'
       GROUP BY logged_in_as;",
     // END 
-    "grouped_sender_acl_external" => "CREATE VIEW grouped_sender_acl_external (username, send_as_acl) AS
+    "grouped_sender_acl_external" => "CREATE VIEW IF NOT EXISTS grouped_sender_acl_external (username, send_as_acl) AS
       SELECT logged_in_as, IFNULL(GROUP_CONCAT(send_as SEPARATOR ' '), '') AS send_as_acl FROM sender_acl
       WHERE send_as NOT LIKE '@%' AND external = '1'
       GROUP BY logged_in_as;",
-    "grouped_domain_alias_address" => "CREATE VIEW grouped_domain_alias_address (username, ad_alias) AS
+    "grouped_domain_alias_address" => "CREATE VIEW IF NOT EXISTS grouped_domain_alias_address (username, ad_alias) AS
       SELECT username, IFNULL(GROUP_CONCAT(local_part, '@', alias_domain SEPARATOR ' '), '') AS ad_alias FROM mailbox
       LEFT OUTER JOIN alias_domain ON target_domain=domain
       GROUP BY username;",
-    "sieve_before" => "CREATE VIEW sieve_before (id, username, script_name, script_data) AS
+    "sieve_before" => "CREATE VIEW IF NOT EXISTS sieve_before (id, username, script_name, script_data) AS
       SELECT md5(script_data), username, script_name, script_data FROM sieve_filters
       WHERE filter_type = 'prefilter';",
-    "sieve_after" => "CREATE VIEW sieve_after (id, username, script_name, script_data) AS
+    "sieve_after" => "CREATE VIEW IF NOT EXISTS sieve_after (id, username, script_name, script_data) AS
       SELECT md5(script_data), username, script_name, script_data FROM sieve_filters
       WHERE filter_type = 'postfilter';"
     );


### PR DESCRIPTION
Hi, i had an older mailcow instance (don't know how old exactly... 2 years max). I created a backup(helper script) and deleted the old mailcow server. Then i made a fresh mailcow install. After it came up once i tried to restore my backup on it but after doing so the server was endless stuck on the still processing page. Sogo spammed the log with `Waiting for schema update...`. After looking through the logs a bit longer i found that the `data/web/inc/init_db.inc.php` script faild because a few views already existed in the DB (because they were already added through the restored backup), but whatever comes after the view creation would have been necessary to make the `Waiting for schema update...` problem go away and make the site work in general. 

Long story short after adding an `IF NOT EXISTS` check to the view creation part of the `data/web/inc/init_db.inc.php` script my backup restore problem was gone and since i don't see how that change could harm someone but maybe prevent other people  from running into the same problem as me i made it into a pull request. 