### PR TITLE
[Web] Fix missing rspamd description

### DIFF
--- a/data/web/lang/lang.cs.json
+++ b/data/web/lang/lang.cs.json
@@ -298,7 +298,7 @@
         "rsettings_preset_2": "Postmasteři chtějí dostávat spam",
         "rsettings_preset_3": "Povolit jen určité odesílatele pro schránku (např. jen interní schránka)",
         "rsettings_preset_4": "Deaktivujte Rspamd pro doménu",
-        "rspamd-com_settings": "<a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd dokumentace</a>\r\n  - Název nastavení bude automaticky vygenerován, viz níže uvedené předvolby.",
+        "rspamd_com_settings": "<a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd dokumentace</a>\r\n  - Název nastavení bude automaticky vygenerován, viz níže uvedené předvolby.",
         "rspamd_global_filters": "Mapa globálních filtrů",
         "rspamd_global_filters_agree": "Budu opatrný!",
         "rspamd_global_filters_info": "Mapa globálních filtrů obsahuje jiné globální black- a whitelisty.",

--- a/data/web/lang/lang.da.json
+++ b/data/web/lang/lang.da.json
@@ -276,7 +276,7 @@
         "rsettings_preset_1": "Deaktiver alt undtagen DKIM og satsgrænse for godkendte brugere",
         "rsettings_preset_2": "Postmestere ønsker spam",
         "rsettings_preset_3": "Tillad kun specifikke afsendere til en postkasse (dvs. kun brug som intern postkasse)",
-        "rspamd-com_settings": "Et indstillingsnavn genereres automatisk, se eksemplet på forudindstillinger nedenfor. For flere detaljer se <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd docs</a>",
+        "rspamd_com_settings": "Et indstillingsnavn genereres automatisk, se eksemplet på forudindstillinger nedenfor. For flere detaljer se <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd docs</a>",
         "rspamd_global_filters": "Globale filterkort",
         "rspamd_global_filters_agree": "Jeg vil være forsigtig!",
         "rspamd_global_filters_info": "Global filter maps contain different kind of global black and whitelists.",

--- a/data/web/lang/lang.de.json
+++ b/data/web/lang/lang.de.json
@@ -295,7 +295,7 @@
         "rsettings_preset_2": "Spam an Postmaster-Adressen nicht blockieren",
         "rsettings_preset_3": "Nur einem oder vielen Absendern erlauben, eine Mailbox anzuschreiben (etwa interne Mailboxen)",
         "rsettings_preset_4": "Rspamd für eine Domain deaktivieren",
-        "rspamd-com_settings": "Ein Name wird automatisch generiert. Beispielinhalte zur Einsicht stehen nachstehend bereit. Siehe auch <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd docs</a>",
+        "rspamd_com_settings": "Ein Name wird automatisch generiert. Beispielinhalte zur Einsicht stehen nachstehend bereit. Siehe auch <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd docs</a>",
         "rspamd_global_filters": "Globale Filter-Maps",
         "rspamd_global_filters_agree": "Ich werde vorsichtig sein!",
         "rspamd_global_filters_info": "Globale Filter-Maps steuern globales White- und Blacklisting dieses Servers.",

--- a/data/web/lang/lang.en.json
+++ b/data/web/lang/lang.en.json
@@ -299,7 +299,7 @@
         "rsettings_preset_2": "Postmasters want spam",
         "rsettings_preset_3": "Only allow specific senders for a mailbox (i.e. usage as internal mailbox only)",
         "rsettings_preset_4": "Disable Rspamd for a domain",
-        "rspamd-com_settings": "A setting name will be auto-generated, please see the example presets below. For more details see <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd docs</a>",
+        "rspamd_com_settings": "A setting name will be auto-generated, please see the example presets below. For more details see <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd docs</a>",
         "rspamd_global_filters": "Global filter maps",
         "rspamd_global_filters_agree": "I will be careful!",
         "rspamd_global_filters_info": "Global filter maps contain different kind of global black and whitelists.",

--- a/data/web/lang/lang.es.json
+++ b/data/web/lang/lang.es.json
@@ -224,7 +224,7 @@
         "rsettings_insert_preset": "Insertar ejemplo preestablecido \"%s\"",
         "rsettings_preset_1": "Deshabilita todos menos DKIM y el límite de velocidad para usuarios autenticados",
         "rsettings_preset_2": "Postmaster quiere correo no deseado",
-        "rspamd-com_settings": "<a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Documentación de Rspamd</a>\r\n  - Se generará automáticamente un nombre de configuración, consulte los ajustes preestablecidos de ejemplo a continuación:",
+        "rspamd_com_settings": "<a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Documentación de Rspamd</a>\r\n  - Se generará automáticamente un nombre de configuración, consulte los ajustes preestablecidos de ejemplo a continuación:",
         "rspamd_settings_map": "Reglas de ajustes de rspamd",
         "save": "Guardar cambios",
         "search_domain_da": "Buscar dominios",

--- a/data/web/lang/lang.fi.json
+++ b/data/web/lang/lang.fi.json
@@ -250,7 +250,7 @@
         "rsettings_insert_preset": "Lisää esimerkki esimääritetty \"%s\"",
         "rsettings_preset_1": "Poista käytöstä kaikki paitsi DKIM-ja Rate Limit-oikeudet todennetuille käyttäjille",
         "rsettings_preset_2": "Postimaisteri haluaa roska postia",
-        "rspamd-com_settings": "<a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd docs</a>\r\n  - Asetus nimi luodaan automaattisesti, Katso esimerkki esiasetukset alla.",
+        "rspamd_com_settings": "<a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd docs</a>\r\n  - Asetus nimi luodaan automaattisesti, Katso esimerkki esiasetukset alla.",
         "rspamd_settings_map": "Rspamd-asetukset",
         "save": "Tallenna muutokset",
         "search_domain_da": "Etsi verkko tunnuksia",

--- a/data/web/lang/lang.fr.json
+++ b/data/web/lang/lang.fr.json
@@ -278,7 +278,7 @@
         "rsettings_preset_1": "Désactiver tout sauf DKIM et la limite tarifaire pour les utilisateurs authentifiés",
         "rsettings_preset_2": "Les postmasters veulent du spam",
         "rsettings_preset_3": "Autoriser uniquement des expéditeurs particuliers pour une boîte (c.-à-d. utilisation comme boîte interne seulement)",
-        "rspamd-com_settings": "Un nom de paramètre sera généré automatiquement, voir l’exemple de préréglages ci-dessous. Pour plus de détails voir : <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Docs Rspamd</a>",
+        "rspamd_com_settings": "Un nom de paramètre sera généré automatiquement, voir l’exemple de préréglages ci-dessous. Pour plus de détails voir : <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Docs Rspamd</a>",
         "rspamd_global_filters": "Cartes des filtres globaux",
         "rspamd_global_filters_agree": "Je serai prudent !",
         "rspamd_global_filters_info": "Les cartes de filtres globales contiennent différents types de listes noires et blanches globales.",

--- a/data/web/lang/lang.it.json
+++ b/data/web/lang/lang.it.json
@@ -294,7 +294,7 @@
         "rsettings_preset_1": "Disable all but DKIM and rate limit for authenticated users",
         "rsettings_preset_2": "I postmaster vogliono lo spam",
         "rsettings_preset_3": "Consenti solo mittenti specifici per una casella di posta (ad esempio: utilizzo solo come casella di posta interna)",
-        "rspamd-com_settings": "A setting name will be auto-generated, please see the example presets below. For more details see <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd docs</a>",
+        "rspamd_com_settings": "A setting name will be auto-generated, please see the example presets below. For more details see <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd docs</a>",
         "rspamd_global_filters": "Global filter maps",
         "rspamd_global_filters_agree": "Starò attento!",
         "rspamd_global_filters_info": "Global filter maps contain different kind of global black and whitelists.",

--- a/data/web/lang/lang.ko.json
+++ b/data/web/lang/lang.ko.json
@@ -269,7 +269,7 @@
         "rsettings_preset_1": "인증된 사용자에 대해 DKIM과 속도 제한을 제외한 모든 것을 비활성화",
         "rsettings_preset_2": "포스트 마스터가 스팸을 원함",
         "rsettings_preset_3": "메일박스에 특정 발신자만 허용 (i.e. 서버 내부 메일함으로만 이용)",
-        "rspamd-com_settings": "설정 이름은 자동으로 생성되며 아래 사전 설정 예제를 참고하세요. 자세한 내용은 <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd 문서</a>를 참조하세요.",
+        "rspamd_com_settings": "설정 이름은 자동으로 생성되며 아래 사전 설정 예제를 참고하세요. 자세한 내용은 <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd 문서</a>를 참조하세요.",
         "rspamd_global_filters": "글로벌 필터 맵",
         "rspamd_global_filters_agree": "조심할게!",
         "rspamd_global_filters_info": "글로벌 필터 맵은 다른 종류의 글로벌 블랙리스트와 화이트리스트를 포함합니다.",

--- a/data/web/lang/lang.nl.json
+++ b/data/web/lang/lang.nl.json
@@ -277,7 +277,7 @@
         "rsettings_preset_1": "Schakel alles uit voor geauthenticeerde gebruikers, behalve ARC/DKIM en ratelimiting",
         "rsettings_preset_2": "Laat postmasters spam ontvangen",
         "rsettings_preset_3": "Sta uitsluitend specifieke afzenders toe voor een mailbox (bijvoorbeeld als interne mailbox)",
-        "rspamd-com_settings": "Een beschrijving voor deze instelling zal automatisch worden gegenereerd, gebruik de onderstaande presets als voorbeeld. Raadpleeg de <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd-documentatie</a> voor meer informatie.",
+        "rspamd_com_settings": "Een beschrijving voor deze instelling zal automatisch worden gegenereerd, gebruik de onderstaande presets als voorbeeld. Raadpleeg de <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd-documentatie</a> voor meer informatie.",
         "rspamd_global_filters": "Globale filters",
         "rspamd_global_filters_agree": "Ik ben me ervan bewust dat aanpassingen desastreuze gevolgen kunnen hebben",
         "rspamd_global_filters_info": "Ieder globaal filter heeft zijn eigen functie, zie de namen.",

--- a/data/web/lang/lang.ro.json
+++ b/data/web/lang/lang.ro.json
@@ -299,7 +299,7 @@
         "rsettings_preset_2": "Postmasterii doresc spam",
         "rsettings_preset_3": "Permiteți numai expeditori specifici pentru o căsuță poștală (ex: utilizare numai ca adresa de email internă)",
         "rsettings_preset_4": "Dezactivați Rspamd pentru domeniu",
-        "rspamd-com_settings": "<a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Documente Rspamd</a>\n  - Un nume de setare va fi generat automat, te rog să consulți presetările exemplu de mai jos.",
+        "rspamd_com_settings": "<a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Documente Rspamd</a>\n  - Un nume de setare va fi generat automat, te rog să consulți presetările exemplu de mai jos.",
         "rspamd_global_filters": "Hărți cu filtru global",
         "rspamd_global_filters_agree": "Voi fi atent!",
         "rspamd_global_filters_info": "Hărțile cu filtre globale conțin diferite tipuri de liste negre și albe.",

--- a/data/web/lang/lang.ru.json
+++ b/data/web/lang/lang.ru.json
@@ -298,7 +298,7 @@
         "rsettings_preset_2": "Не проверять письма на спам Postmaster",
         "rsettings_preset_3": "Разрешить только определённых отправителей для почтового ящика (использование только в качестве внутреннего почтового ящика)",
         "rsettings_preset_4": "Отключить Rspamd для домена",
-        "rspamd-com_settings": "Имена правил будут сгенерированы на основе их ID.<br> Инструкция доступна на сайте <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">документация Rspamd user settings</a>, заготовленные шаблоны:",
+        "rspamd_com_settings": "Имена правил будут сгенерированы на основе их ID.<br> Инструкция доступна на сайте <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">документация Rspamd user settings</a>, заготовленные шаблоны:",
         "rspamd_global_filters": "Глобальные правила фильтрации",
         "rspamd_global_filters_agree": "Я понимаю, что я делаю, и буду осторожен!",
         "rspamd_global_filters_info": "Глобальные правила фильтрации содержат различные виды глобальных черных и белых списков.",

--- a/data/web/lang/lang.sk.json
+++ b/data/web/lang/lang.sk.json
@@ -299,7 +299,7 @@
         "rsettings_preset_2": "Prijať každý spam",
         "rsettings_preset_3": "Povoliť len špecifických odosielateľov (využitie ako interná schránka pre lokálne doručovanie)",
         "rsettings_preset_4": "Deaktivujte Rspamd pre doménu",
-        "rspamd-com_settings": "Názov nastavenia bude automaticky vygenerovaný, pozrite sa prosím na ukážky uvedené nižšie. Pre viac informácií navštívte <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd dokumentáciu</a>",
+        "rspamd_com_settings": "Názov nastavenia bude automaticky vygenerovaný, pozrite sa prosím na ukážky uvedené nižšie. Pre viac informácií navštívte <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd dokumentáciu</a>",
         "rspamd_global_filters": "Mapy globálnych filtrov",
         "rspamd_global_filters_agree": "Budem opatrný!",
         "rspamd_global_filters_info": "Mapy globálnych filtrov obsahujú rozličné druhy globálnych blacklistov a whitelistov.",

--- a/data/web/lang/lang.sv.json
+++ b/data/web/lang/lang.sv.json
@@ -288,7 +288,7 @@
         "rsettings_preset_1": "Inaktivera allt förutom DKIM och hastighetsbegränsningar för inloggade användare",
         "rsettings_preset_2": "Avvisa inte skräppost till postmasteradresser",
         "rsettings_preset_3": "Tillåt bara en eller flera avsändare att skriva till en brevlåda (t.ex. interna brevlådor)",
-        "rspamd-com_settings": "Ett inställningsnamn kommer att genereras automatiskt, se exemplet nedan. För mer detaljer se <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd dokumentationen</a>",
+        "rspamd_com_settings": "Ett inställningsnamn kommer att genereras automatiskt, se exemplet nedan. För mer detaljer se <a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd dokumentationen</a>",
         "rspamd_global_filters": "Globala filterregler",
         "rspamd_global_filters_agree": "Jag ska vara försiktig!",
         "rspamd_global_filters_info": "En global filterregel kan styra den globala vita- och svartlistan på denna server.",

--- a/data/web/lang/lang.zh.json
+++ b/data/web/lang/lang.zh.json
@@ -274,7 +274,7 @@
         "rsettings_preset_1": "为已认证用户关闭除DKIM和ratelimit规则外的所有规则",
         "rsettings_preset_2": "管理员(postmaster)想要垃圾邮件",
         "rsettings_preset_3": "只允许指定的发件人 (如只允许内部邮箱发送)",
-        "rspamd-com_settings": "自动生成设置名称，请看下方的示例预设。查看<a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd docs</a>以了解更多细节。",
+        "rspamd_com_settings": "自动生成设置名称，请看下方的示例预设。查看<a href=\"https://rspamd.com/doc/configuration/settings.html#settings-structure\" target=\"_blank\">Rspamd docs</a>以了解更多细节。",
         "rspamd_global_filters": "全局过滤规则",
         "rspamd_global_filters_agree": "我会小心谨慎的!",
         "rspamd_global_filters_info": "全局过滤规则包含了不同类型的全局黑名单和白名单。",

--- a/data/web/templates/modals/admin.twig
+++ b/data/web/templates/modals/admin.twig
@@ -34,7 +34,7 @@
           </div>
         </form>
         <hr>
-        <p>{{ lang.admin.rspamd-com_settings }}</p>
+        <p>{{ lang.admin.rspamd_com_settings }}</p>
         <ul id="rspamd_presets"></ul>
       </div>
     </div>

--- a/data/web/templates/modals/admin.twig
+++ b/data/web/templates/modals/admin.twig
@@ -34,7 +34,7 @@
           </div>
         </form>
         <hr>
-        <p>{{ lang.admin.rspamd_com_settings }}</p>
+        <p>{{ lang.admin.rspamd_com_settings | raw }}</p>
         <ul id="rspamd_presets"></ul>
       </div>
     </div>


### PR DESCRIPTION
When adding a Rspamd rule, a 0 is displayed in the modal footer instead of a description