### PR TITLE
[Web] Fix resource.php and /cache/ warning message

### DIFF
--- a/data/web/resource.php
+++ b/data/web/resource.php
@@ -1,6 +1,15 @@
 <?php
 
+if (!isset($_GET['file']) ) {
+    http_response_code(404);
+    exit;
+}
 $pathinfo = pathinfo($_GET['file']);
+
+if (!array_key_exists('extension', $pathinfo)) {
+    http_response_code(404);
+    exit;
+}
 $extension = strtolower($pathinfo['extension']);
 
 $filepath = '/tmp/' . $pathinfo['basename'];


### PR DESCRIPTION
If http://mail.example.tld/cache/ or http://mail.example.tld/resource.php are called without the required parameters it returns one or two warnings.

This fix returns an 404 code instead of displaying the warning message and stops the program.

Fix for issue: https://github.com/mailcow/mailcow-dockerized/issues/4383