### PR TITLE
[ClamAV] Move to official ClamAV Docker container

### DIFF
--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -1,76 +1,17 @@
-FROM debian:bullseye-slim
+FROM clamav/clamav:0.104.2-2_base
 
 LABEL maintainer "André Peters <andre.peters@servercow.de>"
 
-ARG CLAMAV=0.104.2
-ARG TINI_VERSION=v0.19.0
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  ca-certificates \
-  build-essential \
-  pkg-config \
-  python3 \
-  python3-pip \
-  valgrind \
-  check \
-  libbz2-dev \
-  libcurl4-openssl-dev \
-  libjson-c-dev \
-  libmilter-dev \
-  libncurses5-dev \
-  libpcre2-dev \
-  libssl-dev \
-  libxml2-dev \
-  zlib1g-dev \
-  curl \
-  bash \
-  wget \
-  tzdata \
-  dnsutils \
+RUN apk upgrade --no-cache \
+  && apk add --update --no-cache \
   rsync \
-  dos2unix \
-  netcat \
-  && python3 -m pip install cmake \
-  && rm -rf /var/lib/apt/lists/* \
-  && wget -O - https://www.clamav.net/downloads/production/clamav-${CLAMAV}.tar.gz | tar xfvz - \
-  && cd clamav-${CLAMAV} \
-  && cmake . \
-      -D CMAKE_INSTALL_PREFIX=/usr \
-      -D CMAKE_INSTALL_LIBDIR=/usr/lib \
-      -D APP_CONFIG_DIRECTORY=/etc/clamav \
-      -D CMAKE_INSTALL_MANDIR=/usr/share/man \
-      -D CMAKE_INSTALL_INFODIR=/usr/share/info \
-      -D CLAMAV_USER=clamav \
-      -D CLAMAV_GROUP=clamav \
-      -D DATABASE_DIRECTORY=/var/lib/clamav \
-      -D ENABLE_APP=ON \
-      -D ENABLE_JSON_SHARED=OFF \
-      -D CMAKE_BUILD_TYPE=MinSizeRel \
-  && cmake --build . -j4 \
-  && cmake --build . --target install \
-  && cd .. && rm -rf clamav-${CLAMAV} \
-  && apt-get -y --auto-remove purge build-essential \
-  && apt-get -y purge pkg-config \
-  python3 \
-  python3-pip \
-  valgrind \
-  check \
-  libbz2-dev \
-  libcurl4-openssl-dev \
-  libjson-c-dev \
-  libmilter-dev \
-  libncurses5-dev \
-  libpcre2-dev \
-  libssl-dev \
-  libxml2-dev \
-  zlib1g-dev \
-
-  && addgroup --system --gid 700 clamav \
-  && adduser --system --no-create-home --home /var/lib/clamav --uid 700 --gid 700 --disabled-login clamav \
-  && rm -rf /tmp/* /var/tmp/*
+  vim \
+  nano \
+  bind-tools \
+  bash 
 
 COPY clamd.sh ./
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
 RUN chmod +x /sbin/tini
 
+ENTRYPOINT []
 CMD ["/sbin/tini", "-g", "--", "/clamd.sh"]

--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -5,8 +5,6 @@ LABEL maintainer "André Peters <andre.peters@servercow.de>"
 RUN apk upgrade --no-cache \
   && apk add --update --no-cache \
   rsync \
-  vim \
-  nano \
   bind-tools \
   bash 
 

--- a/data/Dockerfiles/clamd/clamd.sh
+++ b/data/Dockerfiles/clamd/clamd.sh
@@ -14,10 +14,10 @@ rm -rf /var/lib/clamav/clamav-*.tmp
 
 mkdir -p /run/clamav /var/lib/clamav
 
-if [[ -s /etc/clamav/whitelist.ign2 ]]; then
-  echo "Copying non-empty whitelist.ign2 to /var/lib/clamav/whitelist.ign2"
-  cp /etc/clamav/whitelist.ign2 /var/lib/clamav/whitelist.ign2
-fi
+#if [[ -s /etc/clamav/whitelist.ign2 ]]; then
+#  echo "Copying non-empty whitelist.ign2 to /var/lib/clamav/whitelist.ign2"
+#  cp /etc/clamav/whitelist.ign2 /var/lib/clamav/whitelist.ign2
+#fi
 
 if [[ ! -f /var/lib/clamav/whitelist.ign2 ]]; then
   echo "Creating /var/lib/clamav/whitelist.ign2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
             - redis
 
     clamd-mailcow:
-      image: mailcow/clamd:dev-offcontainers
+      image: mailcow/clamd:1.50
       restart: always
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
             - redis
 
     clamd-mailcow:
-      image: mailcow/clamd:1.44
+      image: mailcow/clamd:dev-offcontainers
       restart: always
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
@@ -67,6 +67,7 @@ services:
         - SKIP_CLAMD=${SKIP_CLAMD:-n}
       volumes:
         - ./data/conf/clamav/:/etc/clamav/:Z
+        - clamd-db-vol-1:/var/lib/clamav:z
       networks:
         mailcow-network:
           aliases:
@@ -631,3 +632,4 @@ volumes:
   crypt-vol-1:
   sogo-web-vol-1:
   sogo-userdata-backup-vol-1:
+  clamd-db-vol-1:


### PR DESCRIPTION
Since ClamAV [starts to offer Docker containers](https://blog.clamav.net/2021/09/clamav-01040-released.html) this PR introduces said containers so we don't need to build the container on our own anymore. This was an easy task until v0.104, but then ClamAV changed its buildprocess to use cmake and with v0.105 it also needs the Rust toolchain -> https://docs.clamav.net/manual/Installing/Installing-from-source-Unix.html#ubuntu--debian

Here are the main changes for the new container

1. Creates clamd-db-vol-1 volume
2. Still uses the same config files
3. Downloads ClamAV databases in said volume
4. Smaller container footprint [13MB](https://hub.docker.com/layers/clamd/mailcow/clamd/1.50/images/sha256-eed91e1d8bf82f781c5b2a7ac7529260a1dc9ec177e2bb6ad6cd38e4812f5db6?context=exploree) vs [150MB](https://hub.docker.com/layers/clamd/mailcow/clamd/1.44/images/sha256-d6faa494e8d8664db0bc7a650a80c65843a65ff1afcf8ed32c74fe625cbde76d?context=explore)



First start:
```
clamd-mailcow_1      | Cleaning up tmp files...
clamd-mailcow_1      | Creating /var/lib/clamav/whitelist.ign2
clamd-mailcow_1      |   File: /var/lib/clamav/whitelist.ign2
clamd-mailcow_1      |   Size: 190              Blocks: 8          IO Block: 4096   regular file
clamd-mailcow_1      | Device: 803h/2051d       Inode: 1212595     Links: 1
clamd-mailcow_1      | Access: (0644/-rw-r--r--)  Uid: (  100/  clamav)   Gid: (  101/  clamav)
clamd-mailcow_1      | Access: 2022-03-26 14:44:07.111649389 +0000
clamd-mailcow_1      | Modify: 2022-03-26 14:44:07.111649389 +0000
clamd-mailcow_1      | Change: 2022-03-26 14:44:07.111649389 +0000
clamd-mailcow_1      | Running freshclam...
clamd-mailcow_1      | Sat Mar 26 14:44:07 2022 -> ClamAV update process started at Sat Mar 26 14:44:07 2022
clamd-mailcow_1      | Sat Mar 26 14:44:07 2022 -> daily database available for download (remote version: 26493)
clamd-mailcow_1      | Sat Mar 26 14:44:11 2022 -> Testing database: '/var/lib/clamav/tmp.746604b10e/clamav-9867dd87acdf2e6cb1f6839cc1db2f6c.tmp-daily.cvd' ...
clamd-mailcow_1      | Sat Mar 26 14:44:17 2022 -> Database test passed.
clamd-mailcow_1      | Sat Mar 26 14:44:17 2022 -> daily.cvd updated (version: 26493, sigs: 1976870, f-level: 90, builder: raynman)
clamd-mailcow_1      | Sat Mar 26 14:44:17 2022 -> main database available for download (remote version: 62)
clamd-mailcow_1      | Sat Mar 26 14:44:22 2022 -> Testing database: '/var/lib/clamav/tmp.746604b10e/clamav-bb149066ad7c2df03ab0d41469f04857.tmp-main.cvd' ...
clamd-mailcow_1      | Sat Mar 26 14:44:30 2022 -> Database test passed.
clamd-mailcow_1      | Sat Mar 26 14:44:30 2022 -> main.cvd updated (version: 62, sigs: 6647427, f-level: 90, builder: sigmgr)
clamd-mailcow_1      | Sat Mar 26 14:44:30 2022 -> bytecode database available for download (remote version: 333)
clamd-mailcow_1      | Sat Mar 26 14:44:30 2022 -> Testing database: '/var/lib/clamav/tmp.746604b10e/clamav-7982d8126e952716c50f2f3992cee6a1.tmp-bytecode.cvd' ...
clamd-mailcow_1      | Sat Mar 26 14:44:30 2022 -> Database test passed.
clamd-mailcow_1      | Sat Mar 26 14:44:30 2022 -> bytecode.cvd updated (version: 333, sigs: 92, f-level: 63, builder: awillia2)
clamd-mailcow_1      | Sat Mar 26 14:44:30 2022 -> ^Clamd was NOT notified: Can't connect to clamd through /run/clamav/clamd.sock: Connection refused
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: Global time limit set to 120000 milliseconds.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: Global size limit set to 52428800 bytes.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: File size limit set to 26214400 bytes.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: Recursion level limit set to 5.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: Files limit set to 200.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxEmbeddedPE limit set to 10485760 bytes.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxHTMLNormalize limit set to 10485760 bytes.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxHTMLNoTags limit set to 2097152 bytes.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxScriptNormalize limit set to 5242880 bytes.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxZipTypeRcg limit set to 1048576 bytes.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxPartitions limit set to 50.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxIconsPE limit set to 100.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxRecHWP3 limit set to 16.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: PCREMatchLimit limit set to 100000.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: PCRERecMatchLimit limit set to 2000.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: PCREMaxFileSize limit set to 26214400.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Archive support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> AlertExceedsMax heuristic detection disabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Heuristic alerts enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Portable Executable support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> ELF support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Mail files support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> OLE2 support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> PDF support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> SWF support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> HTML support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> XMLDOCS support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> HWP3 support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Heuristic: precedence enabled
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Self checking every 3600 seconds.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Set stacksize to 1048576
clamd-mailcow_1      | Sat Mar 26 14:47:57 2022 -> instream(172.22.1.11@37680): OK
clamd-mailcow_1      | Sat Mar 26 14:48:43 2022 -> instream(local): OK
```


SKIP_CLAMD=y

```
Attaching to mailcowdockerized_clamd-mailcow_1
clamd-mailcow_1      | SKIP_CLAMD=y, skipping ClamAV...
```
```
PID  PPID USER     STAT   VSZ %VSZ CPU %CPU COMMAND
  8     0 root     S     2572   0%   1   0% bash
  6     1 root     S     2308   0%   1   0% {clamd.sh} /bin/bash /clamd.sh
 14     8 root     R     1588   0%   1   0% top
  7     6 root     S     1576   0%   0   0% sleep 365d
  1     0 root     S      796   0%   1   0% /sbin/tini -g -- /clamd.sh
```



SKIP_CLAMD=n

```
clamd-mailcow_1      | Cleaning up tmp files...
clamd-mailcow_1      | Creating /var/lib/clamav/whitelist.ign2
clamd-mailcow_1      |   File: /var/lib/clamav/whitelist.ign2
clamd-mailcow_1      |   Size: 190              Blocks: 8          IO Block: 4096   regular file
clamd-mailcow_1      | Device: 803h/2051d       Inode: 1212595     Links: 1
clamd-mailcow_1      | Access: (0644/-rw-r--r--)  Uid: (  100/  clamav)   Gid: (  101/  clamav)
clamd-mailcow_1      | Access: 2022-03-26 14:44:07.111649389 +0000
clamd-mailcow_1      | Modify: 2022-03-26 14:44:07.111649389 +0000
clamd-mailcow_1      | Change: 2022-03-26 14:44:07.111649389 +0000
clamd-mailcow_1      | Running freshclam...
clamd-mailcow_1      | Sat Mar 26 14:44:07 2022 -> ClamAV update process started at Sat Mar 26 14:44:07 2022
clamd-mailcow_1      | Sat Mar 26 14:44:07 2022 -> daily database available for download (remote version: 26493)
clamd-mailcow_1      | Sat Mar 26 14:44:11 2022 -> Testing database: '/var/lib/clamav/tmp.746604b10e/clamav-9867dd87acdf2e6cb1f6839cc1db2f6c.tmp-daily.cvd' ...
clamd-mailcow_1      | Sat Mar 26 14:44:17 2022 -> Database test passed.
clamd-mailcow_1      | Sat Mar 26 14:44:17 2022 -> daily.cvd updated (version: 26493, sigs: 1976870, f-level: 90, builder: raynman)
clamd-mailcow_1      | Sat Mar 26 14:44:17 2022 -> main database available for download (remote version: 62)
clamd-mailcow_1      | Sat Mar 26 14:44:22 2022 -> Testing database: '/var/lib/clamav/tmp.746604b10e/clamav-bb149066ad7c2df03ab0d41469f04857.tmp-main.cvd' ...
clamd-mailcow_1      | Sat Mar 26 14:44:30 2022 -> Database test passed.
clamd-mailcow_1      | Sat Mar 26 14:44:30 2022 -> main.cvd updated (version: 62, sigs: 6647427, f-level: 90, builder: sigmgr)
clamd-mailcow_1      | Sat Mar 26 14:44:30 2022 -> bytecode database available for download (remote version: 333)
clamd-mailcow_1      | Sat Mar 26 14:44:30 2022 -> Testing database: '/var/lib/clamav/tmp.746604b10e/clamav-7982d8126e952716c50f2f3992cee6a1.tmp-bytecode.cvd' ...
clamd-mailcow_1      | Sat Mar 26 14:44:30 2022 -> Database test passed.
clamd-mailcow_1      | Sat Mar 26 14:44:30 2022 -> bytecode.cvd updated (version: 333, sigs: 92, f-level: 63, builder: awillia2)
clamd-mailcow_1      | Sat Mar 26 14:44:30 2022 -> ^Clamd was NOT notified: Can't connect to clamd through /run/clamav/clamd.sock: Connection refused
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: Global time limit set to 120000 milliseconds.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: Global size limit set to 52428800 bytes.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: File size limit set to 26214400 bytes.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: Recursion level limit set to 5.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: Files limit set to 200.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxEmbeddedPE limit set to 10485760 bytes.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxHTMLNormalize limit set to 10485760 bytes.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxHTMLNoTags limit set to 2097152 bytes.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxScriptNormalize limit set to 5242880 bytes.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxZipTypeRcg limit set to 1048576 bytes.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxPartitions limit set to 50.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxIconsPE limit set to 100.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: MaxRecHWP3 limit set to 16.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: PCREMatchLimit limit set to 100000.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: PCRERecMatchLimit limit set to 2000.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Limits: PCREMaxFileSize limit set to 26214400.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Archive support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> AlertExceedsMax heuristic detection disabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Heuristic alerts enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Portable Executable support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> ELF support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Mail files support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> OLE2 support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> PDF support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> SWF support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> HTML support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> XMLDOCS support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> HWP3 support enabled.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Heuristic: precedence enabled
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Self checking every 3600 seconds.
clamd-mailcow_1      | Sat Mar 26 14:44:49 2022 -> Set stacksize to 1048576
clamd-mailcow_1      | Sat Mar 26 14:47:57 2022 -> instream(172.22.1.11@37680): OK
clamd-mailcow_1      | Sat Mar 26 14:48:43 2022 -> instream(local): OK
clamd-mailcow_1      |
clamd-mailcow_1      | @ERROR: max connections (30) reached -- try again later
clamd-mailcow_1      | rsync error: error starting client-server protocol (code 5) at main.c(1814) [Receiver=3.2.3]
clamd-mailcow_1      | receiving incremental file list
clamd-mailcow_1      | ./
clamd-mailcow_1      | blurl.ndb
clamd-mailcow_1      | junk.ndb
clamd-mailcow_1      | jurlbl.ndb
clamd-mailcow_1      | phish.ndb
clamd-mailcow_1      | phishtank.ndb
clamd-mailcow_1      | rogue.hdb
clamd-mailcow_1      | sanesecurity.ftm
clamd-mailcow_1      | scam.ndb
clamd-mailcow_1      | sigwhitelist.ign2
clamd-mailcow_1      | spamimg.hdb
clamd-mailcow_1      |
clamd-mailcow_1      | sent 420 bytes  received 15,067,626 bytes  10,045,364.00 bytes/sec
clamd-mailcow_1      | total size is 15,065,112  speedup is 1.00
clamd-mailcow_1      | RELOADING
clamd-mailcow_1      | Sat Mar 26 14:54:33 2022 -> Reading databases from /var/lib/clamav
clamd-mailcow_1      | Sat Mar 26 14:54:53 2022 -> Database correctly reloaded (8735628 signatures)
clamd-mailcow_1      | Sat Mar 26 14:54:53 2022 -> Database reload completed.
clamd-mailcow_1      | Sat Mar 26 14:54:53 2022 -> Activating the newly loaded database...
clamd-mailcow_1      | receiving incremental file list
clamd-mailcow_1      | ./
clamd-mailcow_1      | blurl.ndb
clamd-mailcow_1      | phishtank.ndb
clamd-mailcow_1      |
clamd-mailcow_1      | sent 9,438 bytes  received 16,089 bytes  17,018.00 bytes/sec
clamd-mailcow_1      | total size is 15,066,632  speedup is 590.22
clamd-mailcow_1      | RELOADING
clamd-mailcow_1      | Sat Mar 26 15:18:03 2022 -> Reading databases from /var/lib/clamav
clamd-mailcow_1      | Sat Mar 26 15:18:23 2022 -> Database correctly reloaded (8735640 signatures)
clamd-mailcow_1      | Sat Mar 26 15:18:23 2022 -> Database reload completed.
clamd-mailcow_1      | Sat Mar 26 15:18:23 2022 -> Activating the newly loaded database...
clamd-mailcow_1      | Sat Mar 26 15:26:43 2022 -> instream(172.22.1.11@45850): OK
clamd-mailcow_1      | Sat Mar 26 16:00:41 2022 -> instream(local): OK
clamd-mailcow_1      | Sat Mar 26 16:08:32 2022 -> SelfCheck: Database status OK.
```
```
PID  PPID USER     STAT   VSZ %VSZ CPU %CPU COMMAND
 27     6 clamav   SN   1299m  16%   0   0% clamd
155     0 root     S     2572   0%   1   0% bash
 26     6 root     S     2336   0%   0   0% {clamd.sh} /bin/bash /clamd.sh
  6     1 root     S     2328   0%   0   0% {clamd.sh} /bin/bash /clamd.sh
 25     6 root     S     2308   0%   1   0% {clamd.sh} /bin/bash /clamd.sh
162   155 root     R     1588   0%   1   0% top
106    26 root     S     1576   0%   1   0% sleep 12h
 28    25 root     S     1576   0%   0   0% sleep 12600
154     6 root     S     1576   0%   1   0% sleep 10
  1     0 root     S      796   0%   0   0% /sbin/tini -g -- /clamd.sh
```

