### PR TITLE
[API] Add version endpoint

### DIFF
--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -5072,6 +5072,27 @@ paths:
         of used storage.
       operationId: Get vmail status
       summary: Get vmail status
+  /api/v1/get/status/version:
+    get:
+      responses:
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "200":
+          content:
+            application/json:
+              examples:
+                response:
+                  value:
+                    version: "2022-04"
+          description: OK
+          headers: {}
+      tags:
+        - Status
+      description: >-
+        Using this endpoint you can get the current running release of this
+        instance.
+      operationId: Get version status
+      summary: Get version status
   /api/v1/get/syncjobs/all/no_log:
     get:
       responses:

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -1472,6 +1472,10 @@ if (isset($_GET['query'])) {
                   'solr_documents' => $solr_documents
                 ));
               break;
+              case "version":
+                echo json_encode(array(
+                  'version' => $GLOBALS['MAILCOW_GIT_VERSION']
+                ));
               }
             }
           break;

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -1476,6 +1476,7 @@ if (isset($_GET['query'])) {
                 echo json_encode(array(
                   'version' => $GLOBALS['MAILCOW_GIT_VERSION']
                 ));
+              break;
               }
             }
           break;


### PR DESCRIPTION
Add API endpoint to get current running release of Mailcow.

The new get API endpoint `https://mailcow.example/api/v1/get/status/version` returns the following output.
```json
{
  "version": "2022-04"
}
```

resolves #4553