### PR TITLE
[Update.sh] Added skip-ping-check Variable

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -238,8 +238,11 @@ while (($#)); do
     --no-update-compose)
       NO_UPDATE_COMPOSE=y
     ;;
+    --skip-ping-check)
+      SKIP_PING_CHECK=y
+    ;;
     --help|-h)
-    echo './update.sh [-c|--check, --ours, --gc, --no-update-compose, --prefetch, --skip-start, -f|--force, -h|--help]
+    echo './update.sh [-c|--check, --ours, --gc, --no-update-compose, --prefetch, --skip-start, --skip-ping-check, -f|--force, -h|--help]
 
   -c|--check           -   Check for updates and exit (exit codes => 0: update available, 3: no updates)
   --ours               -   Use merge strategy option "ours" to solve conflicts in favor of non-mailcow code (local changes over remote changes), not recommended!
@@ -247,6 +250,7 @@ while (($#)); do
   --no-update-compose  -   Do not update docker-compose
   --prefetch           -   Only prefetch new images and exit (useful to prepare updates)
   --skip-start         -   Do not start mailcow after update
+  --skip-ping-check    -   Skip ICMP Check to public DNS resolvers (Use it only if you´ve blocked any ICMP Connections to your mailcow machine).
   -f|--force           -   Force update, do not ask questions
 '
     exit 1
@@ -533,12 +537,17 @@ elif [[ ${option} == "WATCHDOG_VERBOSE" ]]; then
   fi
 done
 
-echo -en "Checking internet connection... "
-if ! check_online_status; then
-  echo -e "\e[31mfailed\e[0m"
-  exit 1
+if [[( ${SKIP_PING_CHECK} == "y")]]; then
+echo -e "\e[32mSkipping Ping Check...\e[0m"
+
 else
-  echo -e "\e[32mOK\e[0m"
+   echo -en "Checking internet connection... "
+   if ! check_online_status; then
+      echo -e "\e[31mfailed\e[0m"
+      exit 1
+   else
+      echo -e "\e[32mOK\e[0m"
+   fi
 fi
 
 echo -e "\e[32mChecking for newer update script...\e[0m"


### PR DESCRIPTION
This PR adds the skip-ping-check Variable which allows the update.sh Script to continue even without a ping check of the public DNS resolvers.

This feature was requested from a few people and is based of the FR: https://github.com/mailcow/mailcow-dockerized/issues/4552

Works with and without the --skip-ping-check Argument as usual.