### PR TITLE
Increase Mailadmin performance

### DIFF
--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -99,37 +99,6 @@ $(document).ready(function() {
   });
   auto_fill_quota($('#addSelectDomain').val());
 
-  // Read bcc local dests
-  // Using ajax to not be a blocking moo
-  $.get("/api/v1/get/bcc-destination-options", function(data){
-    // Domains
-    var optgroup = "<optgroup label='" + lang.domains + "'>";
-    $.each(data.domains, function(index, domain){
-      optgroup += "<option value='" + domain + "'>" + domain + "</option>"
-    });
-    optgroup += "</optgroup>"
-    $('#bcc-local-dest').append(optgroup);
-    // Alias domains
-    var optgroup = "<optgroup label='" + lang.domain_aliases + "'>";
-    $.each(data.alias_domains, function(index, alias_domain){
-      optgroup += "<option value='" + alias_domain + "'>" + alias_domain + "</option>"
-    });
-    optgroup += "</optgroup>"
-    $('#bcc-local-dest').append(optgroup);
-    // Mailboxes and aliases
-    $.each(data.mailboxes, function(mailbox, aliases){
-      var optgroup = "<optgroup label='" + mailbox + "'>";
-      $.each(aliases, function(index, alias){
-        optgroup += "<option value='" + alias + "'>" + alias + "</option>"
-      });
-      optgroup += "</optgroup>"
-      $('#bcc-local-dest').append(optgroup);
-    });
-    // Finish
-    $('#bcc-local-dest').find('option:selected').remove();
-    $('#bcc-local-dest').selectpicker('refresh');
-  });
-
   $(".goto_checkbox").click(function( event ) {
    $("form[data-id='add_alias'] .goto_checkbox").not(this).prop('checked', false);
     if ($("form[data-id='add_alias'] .goto_checkbox:checked").length > 0) {
@@ -610,6 +579,37 @@ jQuery(function($){
     });
   }
   function draw_bcc_table() {
+  // Read bcc local dests
+  // Using ajax to not be a blocking moo
+  $.get("/api/v1/get/bcc-destination-options", function(data){
+    // Domains
+    var optgroup = "<optgroup label='" + lang.domains + "'>";
+    $.each(data.domains, function(index, domain){
+      optgroup += "<option value='" + domain + "'>" + domain + "</option>"
+    });
+    optgroup += "</optgroup>"
+    $('#bcc-local-dest').append(optgroup);
+    // Alias domains
+    var optgroup = "<optgroup label='" + lang.domain_aliases + "'>";
+    $.each(data.alias_domains, function(index, alias_domain){
+      optgroup += "<option value='" + alias_domain + "'>" + alias_domain + "</option>"
+    });
+    optgroup += "</optgroup>"
+    $('#bcc-local-dest').append(optgroup);
+    // Mailboxes and aliases
+    $.each(data.mailboxes, function(mailbox, aliases){
+      var optgroup = "<optgroup label='" + mailbox + "'>";
+      $.each(aliases, function(index, alias){
+        optgroup += "<option value='" + alias + "'>" + alias + "</option>"
+      });
+      optgroup += "</optgroup>"
+      $('#bcc-local-dest').append(optgroup);
+    });
+    // Finish
+    $('#bcc-local-dest').find('option:selected').remove();
+    $('#bcc-local-dest').selectpicker('refresh');
+  });
+
     ft_bcc_table = FooTable.init('#bcc_table', {
       "columns": [
         {"name":"chkbox","title":"","style":{"min-width":"60px","width":"60px"},"filterable": false,"sortable": false,"type":"html"},
@@ -1147,15 +1147,33 @@ jQuery(function($){
     event.stopPropagation();
   })
 
-  draw_domain_table();
-  draw_mailbox_table();
-  draw_resource_table();
-  draw_alias_table();
-  draw_aliasdomain_table();
-  draw_sync_job_table();
-  draw_filter_table();
-  draw_bcc_table();
-  draw_recipient_map_table();
-  draw_tls_policy_table();
+  // detect element visibility changes
+  function onVisible(element, callback) {
+    $(element).ready(function() {
+      element_object = document.querySelector(element)
+      new IntersectionObserver((entries, observer) => {
+        entries.forEach(entry => {
+          if(entry.intersectionRatio > 0) {
+            callback(element_object);
+            observer.disconnect();
+          }
+        });
+      }).observe(element_object);
+    });
+  }
+
+  // Load only if the tab is visible
+  onVisible("#tab-domains", () => draw_domain_table());
+  onVisible("#tab-mailboxes", () => draw_mailbox_table());
+  onVisible("#tab-resources", () => draw_resource_table());
+  onVisible("#tab-mbox-aliases", () => draw_alias_table());
+  onVisible("#tab-domain-aliases", () => draw_aliasdomain_table());
+  onVisible("#tab-syncjobs", () => draw_sync_job_table());
+  onVisible("#tab-filters", () => draw_filter_table());
+  onVisible("#tab-bcc", () => {
+    draw_bcc_table();
+    draw_recipient_map_table();
+  });
+  onVisible("#tab-tls-policy", () => draw_tls_policy_table());
 
 });

--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -1163,17 +1163,17 @@ jQuery(function($){
   }
 
   // Load only if the tab is visible
-  onVisible("#tab-domains", () => draw_domain_table());
-  onVisible("#tab-mailboxes", () => draw_mailbox_table());
-  onVisible("#tab-resources", () => draw_resource_table());
-  onVisible("#tab-mbox-aliases", () => draw_alias_table());
-  onVisible("#tab-domain-aliases", () => draw_aliasdomain_table());
-  onVisible("#tab-syncjobs", () => draw_sync_job_table());
-  onVisible("#tab-filters", () => draw_filter_table());
-  onVisible("#tab-bcc", () => {
+  onVisible("[id^=tab-domains]", () => draw_domain_table());
+  onVisible("[id^=tab-mailboxes]", () => draw_mailbox_table());
+  onVisible("[id^=tab-resources]", () => draw_resource_table());
+  onVisible("[id^=tab-mbox-aliases]", () => draw_alias_table());
+  onVisible("[id^=tab-domain-aliases]", () => draw_aliasdomain_table());
+  onVisible("[id^=tab-syncjobs]", () => draw_sync_job_table());
+  onVisible("[id^=tab-filters]", () => draw_filter_table());
+  onVisible("[id^=tab-bcc]", () => {
     draw_bcc_table();
     draw_recipient_map_table();
   });
-  onVisible("#tab-tls-policy", () => draw_tls_policy_table());
+  onVisible("[id^=tab-tls-policy]", () => draw_tls_policy_table());
 
 });


### PR DESCRIPTION
We were looking for a solution because we have installations with more than 1000 domains and mailboxes and noticed that the Mailadmin becomes very slow.

This proposal does not solve what I think is the problem (that the API does not have paging) but it improves the situation significantly, without touching the actual functionality too much.

This is only a first draft and the question if there is interest in this customization, currently it leads to errors in the mobile view, but if there is interest i am willing to fix those and improve this customization further.

## Test environment

Local mailcow with 946 domains and 3946 mailboxes.

### Before customization
* Calling `/mailbox` takes about ~40s
* All API calls are executed at once

### After customization
* Calling `/mailbox` takes about ~10s
* API calls are executed only when the corresponding tab is opened.

I would appreciate ideas and feedback