### PR TITLE
Add Domain and Mailbox tagging

### DIFF
--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -2720,6 +2720,140 @@ paths:
                   type: object
               type: object
       summary: Delete Transport Maps
+  "/api/v1/delete/mailbox/tag/{mailbox}":
+    post:
+      parameters:
+        - description: name of mailbox
+          in: path
+          name: mailbox
+          example: info@domain.tld
+          required: true
+          schema:
+            type: string
+      responses:
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "200":
+          content:
+            application/json:
+              examples:
+                response:
+                  value:
+                    - log:
+                        - mailbox
+                        - delete
+                        - tags_mailbox
+                        - tags:
+                          - tag1
+                          - tag2
+                          mailbox: info@domain.tld
+                        - null
+                      msg:
+                        - mailbox_modified
+                        - info@domain.tld
+                      type: success
+              schema:
+                properties:
+                  log:
+                    description: contains request object
+                    items: {}
+                    type: array
+                  msg:
+                    items: {}
+                    type: array
+                  type:
+                    enum:
+                      - success
+                      - danger
+                      - error
+                    type: string
+                type: object
+          description: OK
+          headers: {}
+      tags:
+        - Mailboxes
+      description: You can delete one or more mailbox tags.
+      operationId: Delete mailbox tags
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example:
+                - tag1
+                - tag2
+              properties:
+                items:
+                  description: contains list of mailboxes you want to delete
+                  type: object
+              type: object
+      summary: Delete mailbox tags
+  "/api/v1/delete/domain/tag/{domain}":
+    post:
+      parameters:
+        - description: name of domain
+          in: path
+          name: domain
+          example: domain.tld
+          required: true
+          schema:
+            type: string
+      responses:
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "200":
+          content:
+            application/json:
+              examples:
+                response:
+                  value:
+                    - log:
+                        - mailbox
+                        - delete
+                        - tags_domain
+                        - tags:
+                          - tag1
+                          - tag2
+                          domain: domain.tld
+                        - null
+                      msg:
+                        - domain_modified
+                        - domain.tld
+                      type: success
+              schema:
+                properties:
+                  log:
+                    description: contains request object
+                    items: {}
+                    type: array
+                  msg:
+                    items: {}
+                    type: array
+                  type:
+                    enum:
+                      - success
+                      - danger
+                      - error
+                    type: string
+                type: object
+          description: OK
+          headers: {}
+      tags:
+        - Domains
+      description: You can delete one or more domain tags.
+      operationId: Delete domain tags
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example:
+                - tag1
+                - tag2
+              properties:
+                items:
+                  description: contains list of domains you want to delete
+                  type: object
+              type: object
+      summary: Delete domain tags
   /api/v1/edit/alias:
     post:
       responses:

--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -497,6 +497,7 @@ paths:
                           relay_all_recipients: "0"
                           rl_frame: s
                           rl_value: "10"
+                          tags: ["tag1", "tag2"]
                         - null
                       msg:
                         - domain_added
@@ -544,6 +545,7 @@ paths:
                 rl_frame: s
                 rl_value: "10"
                 restart_sogo: "10"
+                tags: ["tag1", "tag2"]
               properties:
                 active:
                   description: is domain active or not
@@ -2865,6 +2867,7 @@ paths:
                   quota: "10240"
                   relay_all_recipients: "0"
                   relayhost: "2"
+                  tags: ["tag3", "tag4"]
                 items: domain.tld
               properties:
                 attr:

--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -1012,6 +1012,7 @@ paths:
                           force_pw_update: "1"
                           tls_enforce_in: "1"
                           tls_enforce_out: "1"
+                          tags: ["tag1", "tag2"]
                         - null
                       msg:
                         - mailbox_added
@@ -1056,6 +1057,7 @@ paths:
                 force_pw_update: "1"
                 tls_enforce_in: "1"
                 tls_enforce_out: "1"
+                tags: ["tag1", "tag2"]
               properties:
                 active:
                   description: is mailbox active or not
@@ -3022,6 +3024,7 @@ paths:
                           sogo_access: "1"
                           username:
                             - info@domain.tld
+                          tags: ["tag3", "tag4"]
                         - null
                       msg:
                         - mailbox_modified
@@ -3069,6 +3072,7 @@ paths:
                     - domain3.tld
                     - "*"
                   sogo_access: "1"
+                  tags: ["tag3", "tag4"]
                 items:
                   - info@domain.tld
               properties:
@@ -3796,6 +3800,11 @@ paths:
               - all
               - mailcow.tld
             type: string
+        - description: comma seperated list of tags to filter by
+          example: "tag1,tag2"
+          in: query
+          name: tags
+          required: false
         - description: e.g. api-key-string
           example: api-key-string
           in: header
@@ -3834,6 +3843,7 @@ paths:
                       relay_all_recipients: "0"
                       relayhost: "0"
                       rl: false
+                      tags: ["tag1", "tag2"]
                     - active: "1"
                       aliases_in_domain: 0
                       aliases_left: 400
@@ -3856,6 +3866,7 @@ paths:
                       relay_all_recipients: "0"
                       relayhost: "0"
                       rl: false
+                      tags: ["tag3", "tag4"]
           description: OK
           headers: {}
       tags:
@@ -4348,6 +4359,11 @@ paths:
               - all
               - user@domain.tld
             type: string
+        - description: comma seperated list of tags to filter by
+          example: "tag1,tag2"
+          in: query
+          name: tags
+          required: false
         - description: e.g. api-key-string
           example: api-key-string
           in: header
@@ -4385,6 +4401,7 @@ paths:
                       rl: false
                       spam_aliases: 0
                       username: info@doman3.tld
+                      tags: ["tag1", "tag2"]
           description: OK
           headers: {}
       tags:

--- a/data/web/css/build/008-mailcow.css
+++ b/data/web/css/build/008-mailcow.css
@@ -272,6 +272,9 @@ code {
 .tag-badge.btn-badge {
   cursor: pointer;
 }
+.tag-badge .bi {
+  font-size: 12px;
+}
 .tag-badge.btn-badge:hover {
   filter: brightness(0.9);
 }

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -443,17 +443,15 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           if ($_SESSION['mailcow_cc_role'] != "admin") {
             $_SESSION['return'][] = array(
               'type' => 'danger',
-              'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
+              'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_extra),
               'msg' => 'access_denied'
             );
             return false;
           }
           $domain       = idn_to_ascii(strtolower(trim($_data['domain'])), 0, INTL_IDNA_VARIANT_UTS46);
           $description  = $_data['description'];
-          if (empty($description)) {
-            $description = $domain;
-          }
-          $tags         = $_data['tags'];
+          if (empty($description)) $description = $domain;
+          $tags         = (array)$_data['tags'];
           $aliases      = (int)$_data['aliases'];
           $mailboxes    = (int)$_data['mailboxes'];
           $defquota     = (int)$_data['defquota'];
@@ -4578,12 +4576,12 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           );
         break;
         case 'tags_mailbox':
-          if (!is_array($_data['mailbox'])) {
+          if (!is_array($_data['username'])) {
             $usernames = array();
-            $usernames[] = $_data['mailbox'];
+            $usernames[] = $_data['username'];
           }
           else {
-            $usernames = $_data['mailbox'];
+            $usernames = $_data['username'];
           }
           $tags = $_data['tags'];
           if (!is_array($tags)) $tags = array();

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -3,7 +3,7 @@ function init_db_schema() {
   try {
     global $pdo;
 
-    $db_version = "22042022_1330";
+    $db_version = "02052022_1500";
 
     $stmt = $pdo->query("SHOW TABLES LIKE 'versions'");
     $num_results = count($stmt->fetchAll(PDO::FETCH_ASSOC));
@@ -266,7 +266,7 @@ function init_db_schema() {
             )
           ),
           "unique" => array(
-            "tag_name" => array("tag_name")
+            "tag_name" => array("tag_name", "domain")
           )
         ),
         "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"
@@ -360,7 +360,7 @@ function init_db_schema() {
             )
           ),
           "unique" => array(
-            "tag_name" => array("tag_name")
+            "tag_name" => array("tag_name", "username")
           )
         ),
         "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"

--- a/data/web/js/build/012-api.js
+++ b/data/web/js/build/012-api.js
@@ -341,10 +341,6 @@ $(document).ready(function() {
       multi_data[id].splice($.inArray($(this).data('item'), multi_data[id]), 1);
       multi_data[id].push($(this).data('item'));
     }
-    // If clicked element #delete_selected has data-api-attr attribute, it is added to "attr"
-    var data_attr = {};
-    if (typeof $(this).data('api-attr') !== 'undefined')
-      data_attr = $(this).data('api-attr');
 
     if (typeof $(this).data('text') !== 'undefined') {
       $("#DeleteText").empty();
@@ -372,7 +368,6 @@ $(document).ready(function() {
           cache: false,
           data: {
             "items": JSON.stringify(data_array),
-            "attr": JSON.stringify(data_attr),
             "csrf_token": csrf_token
           },
           url: '/api/v1/' + api_url,

--- a/data/web/js/build/014-mailcow.js
+++ b/data/web/js/build/014-mailcow.js
@@ -278,8 +278,11 @@ $(document).ready(function() {
   $('.tag-box .tag-add').click(function(){
     addTag(this);
   });
-  $(".tag-box .tag-input").keyup(function (e) {
-    if (e.which == 13) addTag(this);
+  $(".tag-box .tag-input").keydown(function (e) {
+    if (e.which == 13){
+      e.preventDefault();
+      addTag(this);
+    } 
   });
   function addTag(tagAddElem){
     var tagboxElem = $(tagAddElem).parent();
@@ -314,12 +317,6 @@ $(document).ready(function() {
 });
 
 
-function unescapeHtml (string) {
-  var entityMap = {'&amp;': '&','&lt;': '<','&gt;': '>','&quot;': '"',"&#39;": "'",'&#x2F;': '/','&#x60;': '`','&#x3D;': '='}; 
-  return String(string).replace(/&amp;|&lt;|&gt;|&quot;|&#39;|&#x2F|&#x60|&#x3D;/g, function (s) {
-    return entityMap[s];
-  });
-}
-
 // http://stackoverflow.com/questions/24816/escaping-html-strings-with-jquery
 function escapeHtml(n){var entityMap={"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;","/":"&#x2F;","`":"&#x60;","=":"&#x3D;"}; return String(n).replace(/[&<>"'`=\/]/g,function(n){return entityMap[n]})}
+function unescapeHtml(t){var n={"&amp;":"&","&lt;":"<","&gt;":">","&quot;":'"',"&#39;":"'","&#x2F;":"/","&#x60;":"`","&#x3D;":"="};return String(t).replace(/&amp;|&lt;|&gt;|&quot;|&#39;|&#x2F|&#x60|&#x3D;/g,function(t){return n[t]})}

--- a/data/web/js/build/014-mailcow.js
+++ b/data/web/js/build/014-mailcow.js
@@ -297,7 +297,7 @@ $(document).ready(function() {
     if (!Array.isArray(value_tags)) value_tags = [];
     if (value_tags.includes(tag)) return;
 
-    $('<span class="badge badge-primary tag-badge btn-badge">' + tag + '</span>').insertBefore('.tag-input').click(function(){
+    $('<span class="badge badge-primary tag-badge btn-badge"><i class="bi bi-tag-fill"></i> ' + tag + '</span>').insertBefore('.tag-input').click(function(){
       var del_tag = unescapeHtml($(this).text());
       var del_tags = [];
       try {

--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -331,7 +331,7 @@ jQuery(function($){
             if (Array.isArray(item.tags)){
               var tags = '';
               for (var i = 0; i < item.tags.length; i++)
-                tags += '<span class="badge badge-primary tag-badge">' + escapeHtml(item.tags[i]) + '</span>';
+                tags += '<span class="badge badge-primary tag-badge"><i class="bi bi-tag-fill"></i> ' + escapeHtml(item.tags[i]) + '</span>';
               item.tags = tags;
             }
 
@@ -507,7 +507,7 @@ jQuery(function($){
             if (Array.isArray(item.tags)){
               var tags = '';
               for (var i = 0; i < item.tags.length; i++)
-                tags += '<span class="badge badge-primary tag-badge">' + escapeHtml(item.tags[i]) + '</span>';
+                tags += '<span class="badge badge-primary tag-badge"><i class="bi bi-tag-fill"></i> ' + escapeHtml(item.tags[i]) + '</span>';
               item.tags = tags;
             }
           });

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -80,8 +80,7 @@ if (isset($_GET['query'])) {
 
     // delete
     if ($action == 'delete') {
-      $_POST['attr']  = json_encode($requestDecoded['attr']);
-      $_POST['items'] = json_encode($requestDecoded['items']);
+      $_POST['items'] = $request;
     }
   }
   api_log($_POST);
@@ -1521,7 +1520,6 @@ if (isset($_GET['query'])) {
       }
       else {
         $items = (array)json_decode($_POST['items'], true);
-        $attr = isset($_POST['attr']) ? (array)json_decode($_POST['attr'], true) : null;
       }
       // only allow POST requests to POST API endpoints
       if ($_SERVER['REQUEST_METHOD'] != 'POST') {
@@ -1579,19 +1577,25 @@ if (isset($_GET['query'])) {
           process_delete_return(dkim('delete', array('domains' => $items)));
         break;
         case "domain":
-          process_delete_return(mailbox('delete', 'domain', array('domain' => $items)));
-        break;
-        case "tags_domain": 
-          process_delete_return(mailbox('delete', 'tags_domain', array('tags' => $items, 'domain' => $attr["domain"])));
+          switch ($object){
+            case "tag":
+              process_delete_return(mailbox('delete', 'tags_domain', array('tags' => $items, 'domain' => $extra)));
+            break;
+            default:
+              process_delete_return(mailbox('delete', 'domain', array('domain' => $items)));
+          }
         break;
         case "alias-domain":
           process_delete_return(mailbox('delete', 'alias_domain', array('alias_domain' => $items)));
         break;
         case "mailbox":
-          process_delete_return(mailbox('delete', 'mailbox', array('username' => $items)));
-        break;
-        case "tags_mailbox": 
-          process_delete_return(mailbox('delete', 'tags_mailbox', array('tags' => $items, 'mailbox' => $attr["mailbox"])));
+          switch ($object){
+            case "tag":
+              process_delete_return(mailbox('delete', 'tags_mailbox', array('tags' => $items, 'username' => $extra)));
+            break;
+            default:
+              process_delete_return(mailbox('delete', 'mailbox', array('username' => $items)));
+          }
         break;
         case "resource":
           process_delete_return(mailbox('delete', 'resource', array('name' => $items)));

--- a/data/web/templates/edit/domain.twig
+++ b/data/web/templates/edit/domain.twig
@@ -28,7 +28,7 @@
         <div class="col-sm-10">
           <div class="form-control tag-box">
             {% for tag in domain_details.tags %}
-              <span data-action='delete_selected' data-item="{{ tag|url_encode }}" data-api-attr='{"domain": "{{ domain }}"}' data-id="domain_tag_{{ tag }}" data-api-url='delete/tags_domain' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
+              <span data-action='delete_selected' data-item="{{ tag|url_encode }}" data-id="domain_tag_{{ tag }}" data-api-url='delete/domain/tag/{{ domain }}' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
             {% endfor %}
             <input type="text" class="tag-input">
             <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>

--- a/data/web/templates/edit/domain.twig
+++ b/data/web/templates/edit/domain.twig
@@ -28,7 +28,10 @@
         <div class="col-sm-10">
           <div class="form-control tag-box">
             {% for tag in domain_details.tags %}
-              <span data-action='delete_selected' data-item="{{ tag|url_encode }}" data-id="domain_tag_{{ tag }}" data-api-url='delete/domain/tag/{{ domain }}' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
+              <span data-action='delete_selected' data-item="{{ tag|url_encode }}" data-id="domain_tag_{{ tag }}" data-api-url='delete/domain/tag/{{ domain }}' class="badge badge-primary tag-badge btn-badge">
+                <i class="bi bi-tag-fill"></i> 
+                {{ tag }}
+              </span>
             {% endfor %}
             <input type="text" class="tag-input">
             <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>

--- a/data/web/templates/edit/mailbox.twig
+++ b/data/web/templates/edit/mailbox.twig
@@ -27,7 +27,10 @@
         <div class="col-sm-10">
           <div class="form-control tag-box">
             {% for tag in mailbox_details.tags %}
-              <span data-action='delete_selected' data-item="{{ tag }}" data-id="mailbox_tag_{{ tag }}" data-api-url='delete/mailbox/tag/{{ mailbox }}' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
+              <span data-action='delete_selected' data-item="{{ tag }}" data-id="mailbox_tag_{{ tag }}" data-api-url='delete/mailbox/tag/{{ mailbox }}' class="badge badge-primary tag-badge btn-badge">
+                <i class="bi bi-tag-fill"></i> 
+                {{ tag }}
+              </span>
             {% endfor %}
             <input type="text" class="tag-input">
             <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>

--- a/data/web/templates/edit/mailbox.twig
+++ b/data/web/templates/edit/mailbox.twig
@@ -27,7 +27,7 @@
         <div class="col-sm-10">
           <div class="form-control tag-box">
             {% for tag in mailbox_details.tags %}
-              <span data-action='delete_selected' data-item="{{ tag }}" data-api-attr='{"mailbox": "{{ mailbox }}"}' data-id="mailbox_tag_{{ tag }}" data-api-url='delete/tags_mailbox' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
+              <span data-action='delete_selected' data-item="{{ tag }}" data-id="mailbox_tag_{{ tag }}" data-api-url='delete/mailbox/tag/{{ mailbox }}' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
             {% endfor %}
             <input type="text" class="tag-input">
             <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>


### PR DESCRIPTION
Allows administrators to tag domains and mailboxes for later filtering.
No breaking changes were made to the api. Some slightly changes were made and two new functions were introduced.

### New
/api/v1/delete/mailbox/tag/{mailbox}
/api/v1/delete/domain/tag/{domain}

### Extended
/api/v1/add/domain
/api/v1/edit/domain
/api/v1/add/mailbox
/api/v1/edit/mailbox
/api/v1/get/domain/{id}
/api/v1/get/mailbox/{id}

The changed GET requests can now also be used like this.
/api/v1/get/domain/all?tags=tag1,tag2
/api/v1/get/mailbox/all?tags=tag1,tag2
/api/v1/get/mailbox/domain.tld?tags=tag1,tag2