### PR TITLE
Add Domain and Mailbox tagging

### DIFF
--- a/data/conf/nginx/includes/site-defaults.conf
+++ b/data/conf/nginx/includes/site-defaults.conf
@@ -65,7 +65,7 @@
   }
 
   location ~ ^/api/v1/(.*)$ {
-    try_files $uri $uri/ /json_api.php?query=$1;
+    try_files $uri $uri/ /json_api.php?query=$1&$args;
   }
 
   location ^~ /.well-known/acme-challenge/ {

--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -2720,6 +2720,140 @@ paths:
                   type: object
               type: object
       summary: Delete Transport Maps
+  "/api/v1/delete/mailbox/tag/{mailbox}":
+    post:
+      parameters:
+        - description: name of mailbox
+          in: path
+          name: mailbox
+          example: info@domain.tld
+          required: true
+          schema:
+            type: string
+      responses:
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "200":
+          content:
+            application/json:
+              examples:
+                response:
+                  value:
+                    - log:
+                        - mailbox
+                        - delete
+                        - tags_mailbox
+                        - tags:
+                          - tag1
+                          - tag2
+                          mailbox: info@domain.tld
+                        - null
+                      msg:
+                        - mailbox_modified
+                        - info@domain.tld
+                      type: success
+              schema:
+                properties:
+                  log:
+                    description: contains request object
+                    items: {}
+                    type: array
+                  msg:
+                    items: {}
+                    type: array
+                  type:
+                    enum:
+                      - success
+                      - danger
+                      - error
+                    type: string
+                type: object
+          description: OK
+          headers: {}
+      tags:
+        - Mailboxes
+      description: You can delete one or more mailbox tags.
+      operationId: Delete mailbox tags
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example:
+                - tag1
+                - tag2
+              properties:
+                items:
+                  description: contains list of mailboxes you want to delete
+                  type: object
+              type: object
+      summary: Delete mailbox tags
+  "/api/v1/delete/domain/tag/{domain}":
+    post:
+      parameters:
+        - description: name of domain
+          in: path
+          name: domain
+          example: domain.tld
+          required: true
+          schema:
+            type: string
+      responses:
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "200":
+          content:
+            application/json:
+              examples:
+                response:
+                  value:
+                    - log:
+                        - mailbox
+                        - delete
+                        - tags_domain
+                        - tags:
+                          - tag1
+                          - tag2
+                          domain: domain.tld
+                        - null
+                      msg:
+                        - domain_modified
+                        - domain.tld
+                      type: success
+              schema:
+                properties:
+                  log:
+                    description: contains request object
+                    items: {}
+                    type: array
+                  msg:
+                    items: {}
+                    type: array
+                  type:
+                    enum:
+                      - success
+                      - danger
+                      - error
+                    type: string
+                type: object
+          description: OK
+          headers: {}
+      tags:
+        - Domains
+      description: You can delete one or more domain tags.
+      operationId: Delete domain tags
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example:
+                - tag1
+                - tag2
+              properties:
+                items:
+                  description: contains list of domains you want to delete
+                  type: object
+              type: object
+      summary: Delete domain tags
   /api/v1/edit/alias:
     post:
       responses:

--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -497,6 +497,7 @@ paths:
                           relay_all_recipients: "0"
                           rl_frame: s
                           rl_value: "10"
+                          tags: ["tag1", "tag2"]
                         - null
                       msg:
                         - domain_added
@@ -544,6 +545,7 @@ paths:
                 rl_frame: s
                 rl_value: "10"
                 restart_sogo: "10"
+                tags: ["tag1", "tag2"]
               properties:
                 active:
                   description: is domain active or not
@@ -2865,6 +2867,7 @@ paths:
                   quota: "10240"
                   relay_all_recipients: "0"
                   relayhost: "2"
+                  tags: ["tag3", "tag4"]
                 items: domain.tld
               properties:
                 attr:

--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -1012,6 +1012,7 @@ paths:
                           force_pw_update: "1"
                           tls_enforce_in: "1"
                           tls_enforce_out: "1"
+                          tags: ["tag1", "tag2"]
                         - null
                       msg:
                         - mailbox_added
@@ -1056,6 +1057,7 @@ paths:
                 force_pw_update: "1"
                 tls_enforce_in: "1"
                 tls_enforce_out: "1"
+                tags: ["tag1", "tag2"]
               properties:
                 active:
                   description: is mailbox active or not
@@ -3022,6 +3024,7 @@ paths:
                           sogo_access: "1"
                           username:
                             - info@domain.tld
+                          tags: ["tag3", "tag4"]
                         - null
                       msg:
                         - mailbox_modified
@@ -3069,6 +3072,7 @@ paths:
                     - domain3.tld
                     - "*"
                   sogo_access: "1"
+                  tags: ["tag3", "tag4"]
                 items:
                   - info@domain.tld
               properties:
@@ -3796,6 +3800,11 @@ paths:
               - all
               - mailcow.tld
             type: string
+        - description: comma seperated list of tags to filter by
+          example: "tag1,tag2"
+          in: query
+          name: tags
+          required: false
         - description: e.g. api-key-string
           example: api-key-string
           in: header
@@ -3834,6 +3843,7 @@ paths:
                       relay_all_recipients: "0"
                       relayhost: "0"
                       rl: false
+                      tags: ["tag1", "tag2"]
                     - active: "1"
                       aliases_in_domain: 0
                       aliases_left: 400
@@ -3856,6 +3866,7 @@ paths:
                       relay_all_recipients: "0"
                       relayhost: "0"
                       rl: false
+                      tags: ["tag3", "tag4"]
           description: OK
           headers: {}
       tags:
@@ -4348,6 +4359,11 @@ paths:
               - all
               - user@domain.tld
             type: string
+        - description: comma seperated list of tags to filter by
+          example: "tag1,tag2"
+          in: query
+          name: tags
+          required: false
         - description: e.g. api-key-string
           example: api-key-string
           in: header
@@ -4385,6 +4401,7 @@ paths:
                       rl: false
                       spam_aliases: 0
                       username: info@doman3.tld
+                      tags: ["tag1", "tag2"]
           description: OK
           headers: {}
       tags:

--- a/data/web/css/build/008-mailcow.css
+++ b/data/web/css/build/008-mailcow.css
@@ -263,15 +263,16 @@ code {
   height: auto;
 }
 .tag-badge {
-  cursor: pointer;
   transition: 200ms linear;
   margin-top: 5px;
   margin-bottom: 5px;
   margin-left: 2px;
   margin-right: 2px;
 }
-.tag-box .badge:hover {
+.tag-badge.btn-badge {
   cursor: pointer;
+}
+.tag-badge.btn-badge:hover {
   filter: brightness(0.9);
 }
 .tag-input {

--- a/data/web/css/build/008-mailcow.css
+++ b/data/web/css/build/008-mailcow.css
@@ -272,6 +272,9 @@ code {
 .tag-badge.btn-badge {
   cursor: pointer;
 }
+.tag-badge .bi {
+  font-size: 12px;
+}
 .tag-badge.btn-badge:hover {
   filter: brightness(0.9);
 }

--- a/data/web/css/build/008-mailcow.css
+++ b/data/web/css/build/008-mailcow.css
@@ -256,3 +256,36 @@ code {
 .flag-icon {
   margin-right: 5px;
 }
+
+.tag-box {
+  display: flex;
+  flex-wrap: wrap;
+  height: auto;
+}
+.tag-badge {
+  cursor: pointer;
+  transition: 200ms linear;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  margin-left: 2px;
+  margin-right: 2px;
+}
+.tag-box .badge:hover {
+  cursor: pointer;
+  filter: brightness(0.9);
+}
+.tag-input {
+  margin-left: 10px;
+  border: 0;
+  flex: 1;
+  height: 24px;
+  min-width: 150px;
+}
+.tag-input:focus {
+  outline: none;
+}
+.tag-add {
+  padding: 0 5px 0 5px;
+  align-items: center;
+  display: inline-flex;
+}

--- a/data/web/edit.php
+++ b/data/web/edit.php
@@ -54,6 +54,7 @@ if (isset($_SESSION['mailcow_cc_role'])) {
           'rl' => $rl,
           'rlyhosts' => $rlyhosts,
           'dkim' => dkim('details', $domain),
+          'domain_details' => $result,
         ];
     }
     elseif (isset($_GET['oauth2client']) &&

--- a/data/web/edit.php
+++ b/data/web/edit.php
@@ -100,6 +100,7 @@ if (isset($_SESSION['mailcow_cc_role'])) {
         'rlyhosts' => $rlyhosts,
         'sender_acl_handles' => mailbox('get', 'sender_acl_handles', $mailbox),
         'user_acls' => acl('get', 'user', $mailbox),
+        'mailbox_details' => $result
       ];
     }
     elseif (isset($_GET['relayhost']) && is_numeric($_GET["relayhost"]) && !empty($_GET["relayhost"])) {

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -4502,6 +4502,11 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
 
             foreach($tags as $tag){
               // delete tag
+              $_SESSION['return'][] = array(
+                'type' => 'success',
+                'log' => array("tag" => $tag),
+                'msg' => array('tag_log')
+              );
               $stmt = $pdo->prepare("DELETE FROM `tags_domain` WHERE `domain` = :domain AND `tag_name` = :tag_name");
               $stmt->execute(array(
                 ':domain' => $domain,

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -2217,8 +2217,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                 $maxquota             = (!empty($_data['maxquota'])) ? $_data['maxquota'] : ($is_now['max_quota_for_mbox'] / 1048576);
                 $quota                = (!empty($_data['quota'])) ? $_data['quota'] : ($is_now['max_quota_for_domain'] / 1048576);
                 $description          = (!empty($_data['description'])) ? $_data['description'] : $is_now['description'];
-                $tags                 = explode(',', $_data['tags']);
-                $tags                 = (is_array($tags) ? $tags : array());
+                $tags                 = (is_array($_data['tags']) ? $_data['tags'] : array());
                 if ($relay_all_recipients == '1') {
                   $backupmx = '1';
                 }
@@ -4502,16 +4501,12 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             }
 
             foreach($tags as $tag){
-              try {
-                // delete tag
-                $stmt = $pdo->prepare("DELETE FROM `tags_domain` WHERE `domain` = :domain AND `tag_name` = :tag_name");
-                $stmt->execute(array(
-                  ':domain' => $domain,
-                  ':tag_name' => $tag,
-                ));
-              } catch (Exception $e){
-                die($e->getMessage());
-              }
+              // delete tag
+              $stmt = $pdo->prepare("DELETE FROM `tags_domain` WHERE `domain` = :domain AND `tag_name` = :tag_name");
+              $stmt->execute(array(
+                ':domain' => $domain,
+                ':tag_name' => $tag,
+              ));
             }
           }
           $_SESSION['return'][] = array(

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -443,17 +443,15 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           if ($_SESSION['mailcow_cc_role'] != "admin") {
             $_SESSION['return'][] = array(
               'type' => 'danger',
-              'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
+              'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_extra),
               'msg' => 'access_denied'
             );
             return false;
           }
           $domain       = idn_to_ascii(strtolower(trim($_data['domain'])), 0, INTL_IDNA_VARIANT_UTS46);
           $description  = $_data['description'];
-          if (empty($description)) {
-            $description = $domain;
-          }
-          $tags         = $_data['tags'];
+          if (empty($description)) $description = $domain;
+          $tags         = (array)$_data['tags'];
           $aliases      = (int)$_data['aliases'];
           $mailboxes    = (int)$_data['mailboxes'];
           $defquota     = (int)$_data['defquota'];
@@ -4578,12 +4576,12 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           );
         break;
         case 'tags_mailbox':
-          if (!is_array($_data['mailbox'])) {
+          if (!is_array($_data['username'])) {
             $usernames = array();
-            $usernames[] = $_data['mailbox'];
+            $usernames[] = $_data['username'];
           }
           else {
-            $usernames = $_data['mailbox'];
+            $usernames = $_data['username'];
           }
           $tags = $_data['tags'];
           if (!is_array($tags)) $tags = array();

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -453,7 +453,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           if (empty($description)) {
             $description = $domain;
           }
-          $tags         = explode(',', $_data['tags']);
+          $tags         = $_data['tags'];
           $aliases      = (int)$_data['aliases'];
           $mailboxes    = (int)$_data['mailboxes'];
           $defquota     = (int)$_data['defquota'];
@@ -4471,7 +4471,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             );
           }
         break;
-        case 'tag_domain':
+        case 'tags_domain':    
           if (!is_array($_data['domain'])) {
             $domains = array();
             $domains[] = $_data['domain'];
@@ -4479,7 +4479,8 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           else {
             $domains = $_data['domain'];
           }
-          $tag = $_data['tag'];
+          $tags = $_data['tags'];
+          if (!is_array($tags)) $tags = array();
 
           
           if ($_SESSION['mailcow_cc_role'] != "admin") {
@@ -4500,17 +4501,25 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               continue;
             }
 
-            try {
-              // delete tag
-              $stmt = $pdo->prepare("DELETE FROM `tags_domain` WHERE `domain` = :domain AND `tag_name` = :tag_name");
-              $stmt->execute(array(
-                ':domain' => $domain,
-                ':tag_name' => $tag,
-              ));
-            } catch (Exception $e){
-              die($e->getMessage());
+            foreach($tags as $tag){
+              try {
+                // delete tag
+                $stmt = $pdo->prepare("DELETE FROM `tags_domain` WHERE `domain` = :domain AND `tag_name` = :tag_name");
+                $stmt->execute(array(
+                  ':domain' => $domain,
+                  ':tag_name' => $tag,
+                ));
+              } catch (Exception $e){
+                die($e->getMessage());
+              }
             }
           }
+          $_SESSION['return'][] = array(
+            'type' => 'success',
+            'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
+            'msg' => array('domain_tags_removed')
+          );
+          return true;
         break;
         case 'tags_mailbox':
           if (!is_array($_data['username'])) {

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -4529,14 +4529,15 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           else {
             $usernames = $_data['username'];
           }
-          $tags = (is_array($_data['tags']) ? $_data['tags'] : array());
+          $tags = $_data['tags'];
+          if (!is_array($tags)) $tags = array();
 
           foreach ($usernames as $username) {
             if (!filter_var($username, FILTER_VALIDATE_EMAIL)) {
               $_SESSION['return'][] = array(
                 'type' => 'danger',
                 'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
-                'msg' => 'access_denied'
+                'msg' => 'email invalid'
               );
               continue;
             }
@@ -4561,6 +4562,12 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               ));
             }
           }
+          $_SESSION['return'][] = array(
+            'type' => 'success',
+            'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
+            'msg' => array('mailbox_tags_removed')
+          );
+          return true;
         break;
       }
     break;

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -23,35 +23,35 @@ function init_db_schema() {
     }
 
     $views = array(
-    "grouped_mail_aliases" => "CREATE VIEW grouped_mail_aliases (username, aliases) AS
-      SELECT goto, IFNULL(GROUP_CONCAT(address ORDER BY address SEPARATOR ' '), '') AS address FROM alias
-      WHERE address!=goto
-      AND active = '1'
-      AND sogo_visible = '1'
-      AND address NOT LIKE '@%'
-      GROUP BY goto;",
-    // START
-    // Unused at the moment - we cannot allow to show a foreign mailbox as sender address in SOGo, as SOGo does not like this
-    // We need to create delegation in SOGo AND set a sender_acl in mailcow to allow to send as user X
-    "grouped_sender_acl" => "CREATE VIEW grouped_sender_acl (username, send_as_acl) AS
-      SELECT logged_in_as, IFNULL(GROUP_CONCAT(send_as SEPARATOR ' '), '') AS send_as_acl FROM sender_acl
-      WHERE send_as NOT LIKE '@%'
-      GROUP BY logged_in_as;",
-    // END 
-    "grouped_sender_acl_external" => "CREATE VIEW grouped_sender_acl_external (username, send_as_acl) AS
-      SELECT logged_in_as, IFNULL(GROUP_CONCAT(send_as SEPARATOR ' '), '') AS send_as_acl FROM sender_acl
-      WHERE send_as NOT LIKE '@%' AND external = '1'
-      GROUP BY logged_in_as;",
-    "grouped_domain_alias_address" => "CREATE VIEW grouped_domain_alias_address (username, ad_alias) AS
-      SELECT username, IFNULL(GROUP_CONCAT(local_part, '@', alias_domain SEPARATOR ' '), '') AS ad_alias FROM mailbox
-      LEFT OUTER JOIN alias_domain ON target_domain=domain
-      GROUP BY username;",
-    "sieve_before" => "CREATE VIEW sieve_before (id, username, script_name, script_data) AS
-      SELECT md5(script_data), username, script_name, script_data FROM sieve_filters
-      WHERE filter_type = 'prefilter';",
-    "sieve_after" => "CREATE VIEW sieve_after (id, username, script_name, script_data) AS
-      SELECT md5(script_data), username, script_name, script_data FROM sieve_filters
-      WHERE filter_type = 'postfilter';"
+      "grouped_mail_aliases" => "CREATE VIEW grouped_mail_aliases (username, aliases) AS
+        SELECT goto, IFNULL(GROUP_CONCAT(address ORDER BY address SEPARATOR ' '), '') AS address FROM alias
+        WHERE address!=goto
+        AND active = '1'
+        AND sogo_visible = '1'
+        AND address NOT LIKE '@%'
+        GROUP BY goto;",
+      // START
+      // Unused at the moment - we cannot allow to show a foreign mailbox as sender address in SOGo, as SOGo does not like this
+      // We need to create delegation in SOGo AND set a sender_acl in mailcow to allow to send as user X
+      "grouped_sender_acl" => "CREATE VIEW grouped_sender_acl (username, send_as_acl) AS
+        SELECT logged_in_as, IFNULL(GROUP_CONCAT(send_as SEPARATOR ' '), '') AS send_as_acl FROM sender_acl
+        WHERE send_as NOT LIKE '@%'
+        GROUP BY logged_in_as;",
+      // END 
+      "grouped_sender_acl_external" => "CREATE VIEW grouped_sender_acl_external (username, send_as_acl) AS
+        SELECT logged_in_as, IFNULL(GROUP_CONCAT(send_as SEPARATOR ' '), '') AS send_as_acl FROM sender_acl
+        WHERE send_as NOT LIKE '@%' AND external = '1'
+        GROUP BY logged_in_as;",
+      "grouped_domain_alias_address" => "CREATE VIEW grouped_domain_alias_address (username, ad_alias) AS
+        SELECT username, IFNULL(GROUP_CONCAT(local_part, '@', alias_domain SEPARATOR ' '), '') AS ad_alias FROM mailbox
+        LEFT OUTER JOIN alias_domain ON target_domain=domain
+        GROUP BY username;",
+      "sieve_before" => "CREATE VIEW sieve_before (id, username, script_name, script_data) AS
+        SELECT md5(script_data), username, script_name, script_data FROM sieve_filters
+        WHERE filter_type = 'prefilter';",
+      "sieve_after" => "CREATE VIEW sieve_after (id, username, script_name, script_data) AS
+        SELECT md5(script_data), username, script_name, script_data FROM sieve_filters
+        WHERE filter_type = 'postfilter';"
     );
 
     $tables = array(
@@ -251,6 +251,26 @@ function init_db_schema() {
         ),
         "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"
       ),
+      "tags_domain" => array(
+        "cols" => array(
+          "tag_name" => "VARCHAR(255) NOT NULL",
+          "domain" => "VARCHAR(255) NOT NULL"
+        ),
+        "keys" => array(
+          "fkey" => array(
+            "fk_tags_domain" => array(
+              "col" => "domain",
+              "ref" => "domain.domain",
+              "delete" => "CASCADE",
+              "update" => "NO ACTION"
+            ),
+            "unique" => array(
+              "tag_name" => array("tag_name")
+            )
+          )
+        ),
+        "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"
+      ),
       "tls_policy_override" => array(
         "cols" => array(
           "id" => "INT NOT NULL AUTO_INCREMENT",
@@ -321,6 +341,26 @@ function init_db_schema() {
           "key" => array(
             "domain" => array("domain"),
             "kind" => array("kind")
+          )
+        ),
+        "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"
+      ),
+      "tags_mailbox" => array(
+        "cols" => array(
+          "tag_name" => "VARCHAR(255) NOT NULL",
+          "username" => "VARCHAR(255) NOT NULL"
+        ),
+        "keys" => array(
+          "fkey" => array(
+            "fk_tags_mailbox" => array(
+              "col" => "username",
+              "ref" => "mailbox.username",
+              "delete" => "CASCADE",
+              "update" => "NO ACTION"
+            ),
+            "unique" => array(
+              "tag_name" => array("tag_name")
+            )
           )
         ),
         "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -3,7 +3,7 @@ function init_db_schema() {
   try {
     global $pdo;
 
-    $db_version = "22032022_1330";
+    $db_version = "22042022_1330";
 
     $stmt = $pdo->query("SHOW TABLES LIKE 'versions'");
     $num_results = count($stmt->fetchAll(PDO::FETCH_ASSOC));
@@ -263,10 +263,10 @@ function init_db_schema() {
               "ref" => "domain.domain",
               "delete" => "CASCADE",
               "update" => "NO ACTION"
-            ),
-            "unique" => array(
-              "tag_name" => array("tag_name")
             )
+          ),
+          "unique" => array(
+            "tag_name" => array("tag_name")
           )
         ),
         "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"
@@ -357,10 +357,10 @@ function init_db_schema() {
               "ref" => "mailbox.username",
               "delete" => "CASCADE",
               "update" => "NO ACTION"
-            ),
-            "unique" => array(
-              "tag_name" => array("tag_name")
             )
+          ),
+          "unique" => array(
+            "tag_name" => array("tag_name")
           )
         ),
         "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -3,7 +3,7 @@ function init_db_schema() {
   try {
     global $pdo;
 
-    $db_version = "22042022_1330";
+    $db_version = "02052022_1500";
 
     $stmt = $pdo->query("SHOW TABLES LIKE 'versions'");
     $num_results = count($stmt->fetchAll(PDO::FETCH_ASSOC));
@@ -266,7 +266,7 @@ function init_db_schema() {
             )
           ),
           "unique" => array(
-            "tag_name" => array("tag_name")
+            "tag_name" => array("tag_name", "domain")
           )
         ),
         "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"
@@ -360,7 +360,7 @@ function init_db_schema() {
             )
           ),
           "unique" => array(
-            "tag_name" => array("tag_name")
+            "tag_name" => array("tag_name", "username")
           )
         ),
         "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"

--- a/data/web/inc/vars.inc.php
+++ b/data/web/inc/vars.inc.php
@@ -148,6 +148,9 @@ $ACCESS_TOKEN_LIFETIME = 86400;
 // Logout from mailcow after first OAuth2 session profile request
 $OAUTH2_FORGET_SESSION_AFTER_LOGIN = false;
 
+// Set a limit for mailbox and domain tagging
+$TAGGING_LIMIT = 25;
+
 // MAILBOX_DEFAULT_ATTRIBUTES define default attributes for new mailboxes
 // These settings will not change existing mailboxes
 

--- a/data/web/js/build/012-api.js
+++ b/data/web/js/build/012-api.js
@@ -263,6 +263,12 @@ $(document).ready(function() {
       });
       if (!invalid) {
         var attr_to_merge = $(this).closest("form").serializeObject();
+        // parse possible JSON Strings
+        for (var [key, value] of Object.entries(attr_to_merge)) {
+          try {
+            attr_to_merge[key] = JSON.parse(attr_to_merge[key]);
+          } catch {}
+        }
         var api_attr = $.extend(api_attr, attr_to_merge)
       } else {
         return false;
@@ -329,6 +335,11 @@ $(document).ready(function() {
       multi_data[id].splice($.inArray($(this).data('item'), multi_data[id]), 1);
       multi_data[id].push($(this).data('item'));
     }
+    // If clicked element #delete_selected has data-api-attr attribute, it is added to "attr"
+    var data_attr = {};
+    if (typeof $(this).data('api-attr') !== 'undefined')
+      data_attr = $(this).data('api-attr');
+
     if (typeof $(this).data('text') !== 'undefined') {
       $("#DeleteText").empty();
       $("#DeleteText").text($(this).data('text'));
@@ -340,7 +351,7 @@ $(document).ready(function() {
       $("#ItemsToDelete").empty();
       for (var i in data_array) {
         data_array[i] = decodeURIComponent(data_array[i]);
-        $("#ItemsToDelete").append("<li>" + data_array[i] + "</li>");
+        $("#ItemsToDelete").append("<li>" + replaceHtmlChars(data_array[i]) + "</li>");
       }
     })
     $('#ConfirmDeleteModal').modal({
@@ -355,6 +366,7 @@ $(document).ready(function() {
           cache: false,
           data: {
             "items": JSON.stringify(data_array),
+            "attr": JSON.stringify(data_attr),
             "csrf_token": csrf_token
           },
           url: '/api/v1/' + api_url,

--- a/data/web/js/build/012-api.js
+++ b/data/web/js/build/012-api.js
@@ -341,10 +341,6 @@ $(document).ready(function() {
       multi_data[id].splice($.inArray($(this).data('item'), multi_data[id]), 1);
       multi_data[id].push($(this).data('item'));
     }
-    // If clicked element #delete_selected has data-api-attr attribute, it is added to "attr"
-    var data_attr = {};
-    if (typeof $(this).data('api-attr') !== 'undefined')
-      data_attr = $(this).data('api-attr');
 
     if (typeof $(this).data('text') !== 'undefined') {
       $("#DeleteText").empty();
@@ -372,7 +368,6 @@ $(document).ready(function() {
           cache: false,
           data: {
             "items": JSON.stringify(data_array),
-            "attr": JSON.stringify(data_attr),
             "csrf_token": csrf_token
           },
           url: '/api/v1/' + api_url,

--- a/data/web/js/build/012-api.js
+++ b/data/web/js/build/012-api.js
@@ -156,6 +156,12 @@ $(document).ready(function() {
       });
       if (!invalid) {
         var attr_to_merge = $(this).closest("form").serializeObject();
+        // parse possible JSON Strings
+        for (var [key, value] of Object.entries(attr_to_merge)) {
+          try {
+            attr_to_merge[key] = JSON.parse(attr_to_merge[key]);
+          } catch {}
+        }
         var api_attr = $.extend(api_attr, attr_to_merge)
       } else {
         return false;

--- a/data/web/js/build/012-api.js
+++ b/data/web/js/build/012-api.js
@@ -357,9 +357,9 @@ $(document).ready(function() {
       $("#ItemsToDelete").empty();
       for (var i in data_array) {
         data_array[i] = decodeURIComponent(data_array[i]);
-        $("#ItemsToDelete").append("<li>" + replaceHtmlChars(data_array[i]) + "</li>");
+        $("#ItemsToDelete").append("<li>" + escapeHtml(data_array[i]) + "</li>");
       }
-    })
+    });
     $('#ConfirmDeleteModal').modal({
         backdrop: 'static',
         keyboard: false

--- a/data/web/js/build/014-mailcow.js
+++ b/data/web/js/build/014-mailcow.js
@@ -286,7 +286,7 @@ $(document).ready(function() {
     var tagInputElem = $(tagboxElem).find(".tag-input")[0];
     var tagValuesElem = $(tagboxElem).find(".tag-values")[0];
 
-    var tag = replaceHtmlChars($(tagInputElem).val());
+    var tag = escapeHtml($(tagInputElem).val());
     var value_tags = [];
     try {
       value_tags = JSON.parse($(tagValuesElem).val());
@@ -294,8 +294,8 @@ $(document).ready(function() {
     if (!Array.isArray(value_tags)) value_tags = [];
     if (value_tags.includes(tag)) return;
 
-    $('<span class="badge badge-primary tag-badge">' + tag + '</span>').insertBefore('.tag-input').click(function(){
-      var del_tag = undoHtmlChars($(this).text());
+    $('<span class="badge badge-primary tag-badge btn-badge">' + tag + '</span>').insertBefore('.tag-input').click(function(){
+      var del_tag = unescapeHtml($(this).text());
       var del_tags = [];
       try {
         del_tags = JSON.parse($(tagValuesElem).val());
@@ -314,33 +314,12 @@ $(document).ready(function() {
 });
 
 
-function undoHtmlChars (string) {
-  var htmlEscapeEntityMap = {
-    '&amp;': '&',
-    '&lt;': '<',
-    '&gt;': '>',
-    '&quot;': '"',
-    "&#39;": "'",
-    '&#x2F;': '/',
-    '&#x60;': '`',
-    '&#x3D;': '='
-  }; 
+function unescapeHtml (string) {
+  var entityMap = {'&amp;': '&','&lt;': '<','&gt;': '>','&quot;': '"',"&#39;": "'",'&#x2F;': '/','&#x60;': '`','&#x3D;': '='}; 
   return String(string).replace(/&amp;|&lt;|&gt;|&quot;|&#39;|&#x2F|&#x60|&#x3D;/g, function (s) {
-    return htmlEscapeEntityMap[s];
+    return entityMap[s];
   });
 }
-function replaceHtmlChars (string) {
-  var htmlEscapeEntityMap = {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#39;',
-    '/': '&#x2F;',
-    '`': '&#x60;',
-    '=': '&#x3D;'
-  }; 
-  return String(string).replace(/[&<>"'`=\/]/g, function (s) {
-    return htmlEscapeEntityMap[s];
-  });
-}
+
+// http://stackoverflow.com/questions/24816/escaping-html-strings-with-jquery
+function escapeHtml(n){var entityMap={"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;","/":"&#x2F;","`":"&#x60;","=":"&#x3D;"}; return String(n).replace(/[&<>"'`=\/]/g,function(n){return entityMap[n]})}

--- a/data/web/js/build/014-mailcow.js
+++ b/data/web/js/build/014-mailcow.js
@@ -278,8 +278,11 @@ $(document).ready(function() {
   $('.tag-box .tag-add').click(function(){
     addTag(this);
   });
-  $(".tag-box .tag-input").keyup(function (e) {
-    if (e.which == 13) addTag(this);
+  $(".tag-box .tag-input").keydown(function (e) {
+    if (e.which == 13){
+      e.preventDefault();
+      addTag(this);
+    } 
   });
   function addTag(tagAddElem){
     var tagboxElem = $(tagAddElem).parent();
@@ -314,12 +317,6 @@ $(document).ready(function() {
 });
 
 
-function unescapeHtml (string) {
-  var entityMap = {'&amp;': '&','&lt;': '<','&gt;': '>','&quot;': '"',"&#39;": "'",'&#x2F;': '/','&#x60;': '`','&#x3D;': '='}; 
-  return String(string).replace(/&amp;|&lt;|&gt;|&quot;|&#39;|&#x2F|&#x60|&#x3D;/g, function (s) {
-    return entityMap[s];
-  });
-}
-
 // http://stackoverflow.com/questions/24816/escaping-html-strings-with-jquery
 function escapeHtml(n){var entityMap={"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;","/":"&#x2F;","`":"&#x60;","=":"&#x3D;"}; return String(n).replace(/[&<>"'`=\/]/g,function(n){return entityMap[n]})}
+function unescapeHtml(t){var n={"&amp;":"&","&lt;":"<","&gt;":">","&quot;":'"',"&#39;":"'","&#x2F;":"/","&#x60;":"`","&#x3D;":"="};return String(t).replace(/&amp;|&lt;|&gt;|&quot;|&#39;|&#x2F|&#x60|&#x3D;/g,function(t){return n[t]})}

--- a/data/web/js/build/014-mailcow.js
+++ b/data/web/js/build/014-mailcow.js
@@ -297,7 +297,7 @@ $(document).ready(function() {
     if (!Array.isArray(value_tags)) value_tags = [];
     if (value_tags.includes(tag)) return;
 
-    $('<span class="badge badge-primary tag-badge btn-badge">' + tag + '</span>').insertBefore('.tag-input').click(function(){
+    $('<span class="badge badge-primary tag-badge btn-badge"><i class="bi bi-tag-fill"></i> ' + tag + '</span>').insertBefore('.tag-input').click(function(){
       var del_tag = unescapeHtml($(this).text());
       var del_tags = [];
       try {

--- a/data/web/js/build/014-mailcow.js
+++ b/data/web/js/build/014-mailcow.js
@@ -49,36 +49,6 @@ $(document).ready(function() {
     }
     $(div).animate({ left: 0},interval);
   } 
-  function undoHtmlChars (string) {
-    var htmlEscapeEntityMap = {
-      '&amp;': '&',
-      '&lt;': '<',
-      '&gt;': '>',
-      '&quot;': '"',
-      "&#39;": "'",
-      '&#x2F;': '/',
-      '&#x60;': '`',
-      '&#x3D;': '='
-    }; 
-    return String(string).replace(/&amp;|&lt;|&gt;|&quot;|&#39;|&#x2F|&#x60|&#x3D;/g, function (s) {
-      return htmlEscapeEntityMap[s];
-    });
-  }
-  function replaceHtmlChars (string) {
-    var htmlEscapeEntityMap = {
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-      "'": '&#39;',
-      '/': '&#x2F;',
-      '`': '&#x60;',
-      '=': '&#x3D;'
-    }; 
-    return String(string).replace(/[&<>"'`=\/]/g, function (s) {
-      return htmlEscapeEntityMap[s];
-    });
-  }
 
   // form cache
   $('[data-cached-form="true"]').formcache({key: $(this).data('id')});
@@ -314,48 +284,63 @@ $(document).ready(function() {
   function addTag(tagAddElem){
     var tagboxElem = $(tagAddElem).parent();
     var tagInputElem = $(tagboxElem).find(".tag-input")[0];
-    var tagInputHiddenElem = $(tagboxElem).find(".tag-input-hidden")[0];
+    var tagValuesElem = $(tagboxElem).find(".tag-values")[0];
 
     var tag = replaceHtmlChars($(tagInputElem).val());
-    if ($(tagInputHiddenElem).val().includes(tag)) return;
+    var value_tags = [];
+    try {
+      value_tags = JSON.parse($(tagValuesElem).val());
+    } catch {}
+    if (!Array.isArray(value_tags)) value_tags = [];
+    if (value_tags.includes(tag)) return;
 
     $('<span class="badge badge-primary tag-badge">' + tag + '</span>').insertBefore('.tag-input').click(function(){
       var del_tag = undoHtmlChars($(this).text());
-      var values = $(tagInputHiddenElem).val();
-      if (values.includes(del_tag + ',') || values.includes(',' + del_tag + ',')) del_tag = del_tag + ',';
-      else if (values.includes(',' + del_tag)) del_tag = ',' + del_tag;
-      $(tagInputHiddenElem).val(values.replace(del_tag, ''));
+      var del_tags = [];
+      try {
+        del_tags = JSON.parse($(tagValuesElem).val());
+      } catch {}
+      if (Array.isArray(del_tags)){
+        del_tags.splice(del_tags.indexOf(del_tag), 1);
+        $(tagValuesElem).val(JSON.stringify(del_tags));
+      }
       $(this).remove();
     });
 
-    if ($(tagInputHiddenElem).val() !== '') tag = ',' + tag;
-    $(tagInputHiddenElem).val($(tagInputHiddenElem).val() + tag);
+    value_tags.push($(tagInputElem).val());
+    $(tagValuesElem).val(JSON.stringify(value_tags));
     $(tagInputElem).val('');
   }
-  $('.tag-badge.saved').click(function(){
-    var tagboxElem = $(this).parent();
-    var tagInputHiddenElem = $(tagboxElem).find(".tag-input-hidden")[0];
-
-    var del_tag = undoHtmlChars($(this).text());
-    var values = $(tagInputHiddenElem).val();
-    if (values.includes(del_tag + ',') || values.includes(',' + del_tag + ',')) del_tag = del_tag + ',';
-    else if (values.includes(',' + del_tag)) del_tag = ',' + del_tag;
-
-    
-    $.ajax({
-      url: "/api/v1/delete/tag_domain",
-      type: 'POST',
-      contentType : 'application/json',
-      data: JSON.stringify({
-        items: $(this).data('item'),
-        tag_name: del_tag
-      }),
-      success: function(res) {
-        console.log(res);
-      }
-    });
-
-    $(tagInputHiddenElem).val(values.replace(del_tag, ''));
-    $(this).remove();
-  });
 });
+
+
+function undoHtmlChars (string) {
+  var htmlEscapeEntityMap = {
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&quot;': '"',
+    "&#39;": "'",
+    '&#x2F;': '/',
+    '&#x60;': '`',
+    '&#x3D;': '='
+  }; 
+  return String(string).replace(/&amp;|&lt;|&gt;|&quot;|&#39;|&#x2F|&#x60|&#x3D;/g, function (s) {
+    return htmlEscapeEntityMap[s];
+  });
+}
+function replaceHtmlChars (string) {
+  var htmlEscapeEntityMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+    '/': '&#x2F;',
+    '`': '&#x60;',
+    '=': '&#x3D;'
+  }; 
+  return String(string).replace(/[&<>"'`=\/]/g, function (s) {
+    return htmlEscapeEntityMap[s];
+  });
+}

--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -236,9 +236,6 @@ $(document).ready(function() {
 
 });
 jQuery(function($){
-  // http://stackoverflow.com/questions/24816/escaping-html-strings-with-jquery
-  var entityMap={"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;","/":"&#x2F;","`":"&#x60;","=":"&#x3D;"};
-  function escapeHtml(n){return String(n).replace(/[&<>"'`=\/]/g,function(n){return entityMap[n]})}
   // http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
   function humanFileSize(i){if(Math.abs(i)<1024)return i+" B";var B=["KiB","MiB","GiB","TiB","PiB","EiB","ZiB","YiB"],e=-1;do{i/=1024,++e}while(Math.abs(i)>=1024&&e<B.length-1);return i.toFixed(1)+" "+B[e]}
   function unix_time_format(i){return""==i?'<i class="bi bi-x-lg"></i>':new Date(i?1e3*i:0).toLocaleDateString(void 0,{year:"numeric",month:"2-digit",day:"2-digit",hour:"2-digit",minute:"2-digit",second:"2-digit"})}
@@ -293,6 +290,7 @@ jQuery(function($){
         {"name":"rl","title":"RL","breakpoints":"xs sm md lg","style":{"min-width":"100px","width":"100px"}},
         {"name":"backupmx","filterable": false,"style":{"min-width":"120px","width":"120px"},"title":lang.backup_mx,"breakpoints":"xs sm md lg","formatter": function(value){return 1==value?'<i class="bi bi-check-lg"></i>':0==value&&'<i class="bi bi-x-lg"></i>';}},
         {"name":"domain_admins","title":lang.domain_admins,"style":{"word-break":"break-all","min-width":"200px"},"breakpoints":"xs sm md lg","filterable":(role == "admin"),"visible":(role == "admin")},
+        {"name":"tags","title":"Tags","style":{},"breakpoints":"xs sm md lg"},
         {"name":"active","filterable": false,"style":{"min-width":"80px","width":"80px"},"title":lang.active,"formatter": function(value){return 1==value?'<i class="bi bi-check-lg"></i>':0==value&&'<i class="bi bi-x-lg"></i>';}},
         {"name":"action","filterable": false,"sortable": false,"style":{"text-align":"right","min-width":"240px","width":"240px"},"type":"html","title":lang.action,"breakpoints":"xs sm md"}
       ],
@@ -328,6 +326,13 @@ jQuery(function($){
             else {
               item.action += '<a href="/edit/domain/' + encodeURIComponent(item.domain_name) + '" class="btn btn-xs btn-xs-half btn-default"><i class="bi bi-pencil-fill"></i> ' + lang.edit + '</a>' +
               '<a href="#dnsInfoModal" class="btn btn-xs btn-xs-half btn-info" data-toggle="modal" data-domain="' + encodeURIComponent(item.domain_name) + '"><i class="bi bi-globe2"></i> DNS</a></div>';
+            }
+
+            if (Array.isArray(item.tags)){
+              var tags = '';
+              for (var i = 0; i < item.tags.length; i++)
+                tags += '<span class="badge badge-primary tag-badge">' + escapeHtml(item.tags[i]) + '</span>';
+              item.tags = tags;
             }
 
             if (item.backupmx == 1) {

--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -423,6 +423,7 @@ jQuery(function($){
         },
         {"name":"messages","filterable": false,"title":lang.msg_num,"breakpoints":"xs sm md"},
         /* {"name":"rl","title":"RL","breakpoints":"all","style":{"width":"125px"}}, */
+        {"name":"tags","title":"Tags","style":{},"breakpoints":"xs sm md lg"},
         {"name":"active","filterable": false,"style":{"min-width":"80px","width":"80px"},"title":lang.active,"formatter": function(value){return 1==value?'<i class="bi bi-check-lg"></i>':(0==value?'<i class="bi bi-x-lg"></i>':2==value&&'&#8212;');}},
         {"name":"action","filterable": false,"sortable": false,"style":{"min-width":"290px","text-align":"right"},"type":"html","title":lang.action,"breakpoints":"xs sm md"}
       ],
@@ -502,6 +503,13 @@ jQuery(function($){
               '<div class="progress-bar-mailbox progress-bar progress-bar-' + item.percent_class + '" role="progressbar" aria-valuenow="' + item.percent_in_use + '" aria-valuemin="0" aria-valuemax="100" ' +
               'style="min-width:2em;width:' + item.percent_in_use + '%">' + item.percent_in_use + '%' + '</div></div>';
             item.username = escapeHtml(item.username);
+            
+            if (Array.isArray(item.tags)){
+              var tags = '';
+              for (var i = 0; i < item.tags.length; i++)
+                tags += '<span class="badge badge-primary tag-badge">' + escapeHtml(item.tags[i]) + '</span>';
+              item.tags = tags;
+            }
           });
         }
       }),

--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -331,7 +331,7 @@ jQuery(function($){
             if (Array.isArray(item.tags)){
               var tags = '';
               for (var i = 0; i < item.tags.length; i++)
-                tags += '<span class="badge badge-primary tag-badge">' + escapeHtml(item.tags[i]) + '</span>';
+                tags += '<span class="badge badge-primary tag-badge"><i class="bi bi-tag-fill"></i> ' + escapeHtml(item.tags[i]) + '</span>';
               item.tags = tags;
             }
 
@@ -507,7 +507,7 @@ jQuery(function($){
             if (Array.isArray(item.tags)){
               var tags = '';
               for (var i = 0; i < item.tags.length; i++)
-                tags += '<span class="badge badge-primary tag-badge">' + escapeHtml(item.tags[i]) + '</span>';
+                tags += '<span class="badge badge-primary tag-badge"><i class="bi bi-tag-fill"></i> ' + escapeHtml(item.tags[i]) + '</span>';
               item.tags = tags;
             }
           });

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -80,11 +80,12 @@ if (isset($_GET['query'])) {
 
     // delete
     if ($action == 'delete') {
-      $_POST['items'] = $request;
+      $_POST['attr']  = json_encode($requestDecoded['attr']);
+      $_POST['items'] = json_encode($requestDecoded['items']);
     }
-
   }
   api_log($_POST);
+
 
   $request_incomplete = json_encode(array(
     'type' => 'error',
@@ -1518,6 +1519,7 @@ if (isset($_GET['query'])) {
       }
       else {
         $items = (array)json_decode($_POST['items'], true);
+        $attr = isset($_POST['attr']) ? (array)json_decode($_POST['attr'], true) : null;
       }
       // only allow POST requests to POST API endpoints
       if ($_SERVER['REQUEST_METHOD'] != 'POST') {
@@ -1577,8 +1579,8 @@ if (isset($_GET['query'])) {
         case "domain":
           process_delete_return(mailbox('delete', 'domain', array('domain' => $items)));
         break;
-        case "tag_domain":
-          process_delete_return(mailbox('delete', 'tag_domain', array('domain' => $items, 'tag' => $_POST['tag_name'])));
+        case "tags_domain": 
+          process_delete_return(mailbox('delete', 'tags_domain', array('tags' => $items, 'domain' => $attr["domain"])));
         break;
         case "alias-domain":
           process_delete_return(mailbox('delete', 'alias_domain', array('alias_domain' => $items)));

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -80,8 +80,7 @@ if (isset($_GET['query'])) {
 
     // delete
     if ($action == 'delete') {
-      $_POST['attr']  = json_encode($requestDecoded['attr']);
-      $_POST['items'] = json_encode($requestDecoded['items']);
+      $_POST['items'] = $request;
     }
   }
   api_log($_POST);
@@ -1521,7 +1520,6 @@ if (isset($_GET['query'])) {
       }
       else {
         $items = (array)json_decode($_POST['items'], true);
-        $attr = isset($_POST['attr']) ? (array)json_decode($_POST['attr'], true) : null;
       }
       // only allow POST requests to POST API endpoints
       if ($_SERVER['REQUEST_METHOD'] != 'POST') {
@@ -1579,19 +1577,25 @@ if (isset($_GET['query'])) {
           process_delete_return(dkim('delete', array('domains' => $items)));
         break;
         case "domain":
-          process_delete_return(mailbox('delete', 'domain', array('domain' => $items)));
-        break;
-        case "tags_domain": 
-          process_delete_return(mailbox('delete', 'tags_domain', array('tags' => $items, 'domain' => $attr["domain"])));
+          switch ($object){
+            case "tag":
+              process_delete_return(mailbox('delete', 'tags_domain', array('tags' => $items, 'domain' => $extra)));
+            break;
+            default:
+              process_delete_return(mailbox('delete', 'domain', array('domain' => $items)));
+          }
         break;
         case "alias-domain":
           process_delete_return(mailbox('delete', 'alias_domain', array('alias_domain' => $items)));
         break;
         case "mailbox":
-          process_delete_return(mailbox('delete', 'mailbox', array('username' => $items)));
-        break;
-        case "tags_mailbox": 
-          process_delete_return(mailbox('delete', 'tags_mailbox', array('tags' => $items, 'mailbox' => $attr["mailbox"])));
+          switch ($object){
+            case "tag":
+              process_delete_return(mailbox('delete', 'tags_mailbox', array('tags' => $items, 'username' => $extra)));
+            break;
+            default:
+              process_delete_return(mailbox('delete', 'mailbox', array('username' => $items)));
+          }
         break;
         case "resource":
           process_delete_return(mailbox('delete', 'resource', array('name' => $items)));

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -487,7 +487,11 @@ if (isset($_GET['query'])) {
           case "domain":
             switch ($object) {
               case "all":
-                $domains = mailbox('get', 'domains');
+                if (!isset($_GET['tags']))
+                  $domains = mailbox('get', 'domains');
+                else
+                  $domains = mailbox('get', 'domains', explode(',', $_GET['tags']));
+
                 if (!empty($domains)) {
                   foreach ($domains as $domain) {
                     if ($details = mailbox('get', 'domain_details', $domain)) {
@@ -961,15 +965,12 @@ if (isset($_GET['query'])) {
                 }
                 if (!empty($domains)) {
                   foreach ($domains as $domain) {
-                    $mailboxes = mailbox('get', 'mailboxes', $domain);
+                    if (isset($_GET['tags'])) $mailboxes = mailbox('get', 'mailboxes', $domain, explode(',', $_GET['tags']));
+                    else $mailboxes = mailbox('get', 'mailboxes', $domain);
                     if (!empty($mailboxes)) {
                       foreach ($mailboxes as $mailbox) {
-                        if ($details = mailbox('get', 'mailbox_details', $mailbox, $object)) {
-                          $data[] = $details;
-                        }
-                        else {
-                          continue;
-                        }
+                        if ($details = mailbox('get', 'mailbox_details', $mailbox, $object)) $data[] = $details;
+                        else continue;
                       }
                     }
                   }
@@ -1590,6 +1591,7 @@ if (isset($_GET['query'])) {
         break;
         case "tags_mailbox": 
           process_delete_return(mailbox('delete', 'tags_mailbox', array('tags' => $items, 'mailbox' => $attr["mailbox"])));
+        break;
         case "resource":
           process_delete_return(mailbox('delete', 'resource', array('name' => $items)));
         break;

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -1588,6 +1588,8 @@ if (isset($_GET['query'])) {
         case "mailbox":
           process_delete_return(mailbox('delete', 'mailbox', array('username' => $items)));
         break;
+        case "tags_mailbox": 
+          process_delete_return(mailbox('delete', 'tags_mailbox', array('tags' => $items, 'mailbox' => $attr["mailbox"])));
         case "resource":
           process_delete_return(mailbox('delete', 'resource', array('name' => $items)));
         break;

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -487,10 +487,11 @@ if (isset($_GET['query'])) {
           case "domain":
             switch ($object) {
               case "all":
-                if (!isset($_GET['tags']))
-                  $domains = mailbox('get', 'domains');
-                else
-                  $domains = mailbox('get', 'domains', explode(',', $_GET['tags']));
+                $tags = null;
+                if (isset($_GET['tags']) && $_GET['tags'] != '') 
+                  $tags = explode(',', $_GET['tags']);
+
+                $domains = mailbox('get', 'domains', null, $tags);
 
                 if (!empty($domains)) {
                   foreach ($domains as $domain) {
@@ -957,16 +958,16 @@ if (isset($_GET['query'])) {
             switch ($object) {
               case "all":
               case "reduced":
-                if (empty($extra)) {
-                  $domains = mailbox('get', 'domains');
-                }
-                else {
-                  $domains = explode(',', $extra);
-                }
+                $tags = null;
+                if (isset($_GET['tags']) && $_GET['tags'] != '') 
+                  $tags = explode(',', $_GET['tags']);
+
+                if (empty($extra)) $domains = mailbox('get', 'domains');
+                else $domains = explode(',', $extra);
+
                 if (!empty($domains)) {
                   foreach ($domains as $domain) {
-                    if (isset($_GET['tags'])) $mailboxes = mailbox('get', 'mailboxes', $domain, explode(',', $_GET['tags']));
-                    else $mailboxes = mailbox('get', 'mailboxes', $domain);
+                    $mailboxes = mailbox('get', 'mailboxes', $domain, $tags);
                     if (!empty($mailboxes)) {
                       foreach ($mailboxes as $mailbox) {
                         if ($details = mailbox('get', 'mailbox_details', $mailbox, $object)) $data[] = $details;

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -1577,6 +1577,9 @@ if (isset($_GET['query'])) {
         case "domain":
           process_delete_return(mailbox('delete', 'domain', array('domain' => $items)));
         break;
+        case "tag_domain":
+          process_delete_return(mailbox('delete', 'tag_domain', array('domain' => $items, 'tag' => $_POST['tag_name'])));
+        break;
         case "alias-domain":
           process_delete_return(mailbox('delete', 'alias_domain', array('alias_domain' => $items)));
         break;

--- a/data/web/lang/lang.en.json
+++ b/data/web/lang/lang.en.json
@@ -99,6 +99,7 @@
         "subscribeall": "Subscribe all folders",
         "syncjob": "Add sync job",
         "syncjob_hint": "Be aware that passwords need to be saved plain-text!",
+        "tags": "Tags",
         "target_address": "Goto addresses",
         "target_address_info": "<small>Full email address/es (comma-separated).</small>",
         "target_domain": "Target domain",

--- a/data/web/templates/edit/domain.twig
+++ b/data/web/templates/edit/domain.twig
@@ -28,7 +28,7 @@
         <div class="col-sm-10">
           <div class="form-control tag-box">
             {% for tag in domain_details.tags %}
-              <span data-action='delete_selected' data-item="{{ tag }}" data-api-attr='{"domain": "{{ domain }}"' data-id="domain_tag_{{ tag }}" data-api-url='delete/tags_domain' class="badge badge-primary tag-badge">{{ tag }}</span>
+              <span data-action='delete_selected' data-item="{{ tag }}" data-api-attr='{"domain": "{{ domain }}"}' data-id="domain_tag_{{ tag }}" data-api-url='delete/tags_domain' class="badge badge-primary tag-badge">{{ tag }}</span>
             {% endfor %}
             <input type="text" class="tag-input">
             <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>

--- a/data/web/templates/edit/domain.twig
+++ b/data/web/templates/edit/domain.twig
@@ -28,7 +28,7 @@
         <div class="col-sm-10">
           <div class="form-control tag-box">
             {% for tag in domain_details.tags %}
-              <span data-action='delete_selected' data-item="{{ tag|url_encode }}" data-api-attr='{"domain": "{{ domain }}"}' data-id="domain_tag_{{ tag }}" data-api-url='delete/tags_domain' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
+              <span data-action='delete_selected' data-item="{{ tag|url_encode }}" data-id="domain_tag_{{ tag }}" data-api-url='delete/domain/tag/{{ domain }}' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
             {% endfor %}
             <input type="text" class="tag-input">
             <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>

--- a/data/web/templates/edit/domain.twig
+++ b/data/web/templates/edit/domain.twig
@@ -28,7 +28,7 @@
         <div class="col-sm-10">
           <div class="form-control tag-box">
             {% for tag in domain_details.tags %}
-              <span data-action='delete_selected' data-item="{{ tag }}" data-api-attr='{"domain": "{{ domain }}"}' data-id="domain_tag_{{ tag }}" data-api-url='delete/tags_domain' class="badge badge-primary tag-badge">{{ tag }}</span>
+              <span data-action='delete_selected' data-item="{{ tag }}" data-api-attr='{"domain": "{{ domain }}"}' data-id="domain_tag_{{ tag }}" data-api-url='delete/tags_domain' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
             {% endfor %}
             <input type="text" class="tag-input">
             <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>

--- a/data/web/templates/edit/domain.twig
+++ b/data/web/templates/edit/domain.twig
@@ -28,7 +28,10 @@
         <div class="col-sm-10">
           <div class="form-control tag-box">
             {% for tag in domain_details.tags %}
-              <span data-action='delete_selected' data-item="{{ tag|url_encode }}" data-id="domain_tag_{{ tag }}" data-api-url='delete/domain/tag/{{ domain }}' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
+              <span data-action='delete_selected' data-item="{{ tag|url_encode }}" data-id="domain_tag_{{ tag }}" data-api-url='delete/domain/tag/{{ domain }}' class="badge badge-primary tag-badge btn-badge">
+                <i class="bi bi-tag-fill"></i> 
+                {{ tag }}
+              </span>
             {% endfor %}
             <input type="text" class="tag-input">
             <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>

--- a/data/web/templates/edit/domain.twig
+++ b/data/web/templates/edit/domain.twig
@@ -24,6 +24,19 @@
         </div>
       </div>
       <div class="form-group">
+        <label class="control-label col-sm-2" for="aliases">{{ lang.add.tags }}</label>
+        <div class="col-sm-10">
+          <div class="form-control tag-box">
+            {% for tag in domain_details.tags %}
+              <span data-item="{{ domain }}" class="badge badge-primary tag-badge saved">{{ tag }}</span>
+            {% endfor %}
+            <input type="text" class="tag-input" name="aliases">
+            <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>
+            <input type="hidden" name="tags" class="tag-input-hidden">
+          </div>
+        </div>
+      </div>
+      <div class="form-group">
         <label class="control-label col-sm-2" for="relayhost">{{ lang.edit.relayhost }}</label>
         <div class="col-sm-10">
           <select data-acl="{{ acl.domain_relayhost }}" data-live-search="true" id="relayhost" name="relayhost" class="form-control">

--- a/data/web/templates/edit/domain.twig
+++ b/data/web/templates/edit/domain.twig
@@ -24,15 +24,15 @@
         </div>
       </div>
       <div class="form-group">
-        <label class="control-label col-sm-2" for="aliases">{{ lang.add.tags }}</label>
+        <label class="control-label col-sm-2">{{ lang.add.tags }}</label>
         <div class="col-sm-10">
           <div class="form-control tag-box">
             {% for tag in domain_details.tags %}
-              <span data-item="{{ domain }}" class="badge badge-primary tag-badge saved">{{ tag }}</span>
+              <span data-action='delete_selected' data-item="{{ tag }}" data-api-attr='{"domain": "{{ domain }}"' data-id="domain_tag_{{ tag }}" data-api-url='delete/tags_domain' class="badge badge-primary tag-badge">{{ tag }}</span>
             {% endfor %}
-            <input type="text" class="tag-input" name="aliases">
+            <input type="text" class="tag-input">
             <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>
-            <input type="hidden" name="tags" class="tag-input-hidden">
+            <input type="hidden" value="" name="tags" class="tag-values" />
           </div>
         </div>
       </div>

--- a/data/web/templates/edit/domain.twig
+++ b/data/web/templates/edit/domain.twig
@@ -28,7 +28,7 @@
         <div class="col-sm-10">
           <div class="form-control tag-box">
             {% for tag in domain_details.tags %}
-              <span data-action='delete_selected' data-item="{{ tag }}" data-api-attr='{"domain": "{{ domain }}"}' data-id="domain_tag_{{ tag }}" data-api-url='delete/tags_domain' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
+              <span data-action='delete_selected' data-item="{{ tag|url_encode }}" data-api-attr='{"domain": "{{ domain }}"}' data-id="domain_tag_{{ tag }}" data-api-url='delete/tags_domain' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
             {% endfor %}
             <input type="text" class="tag-input">
             <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>

--- a/data/web/templates/edit/mailbox.twig
+++ b/data/web/templates/edit/mailbox.twig
@@ -26,8 +26,8 @@
         <label class="control-label col-sm-2">{{ lang.add.tags }}</label>
         <div class="col-sm-10">
           <div class="form-control tag-box">
-            {% for tag in domain_details.tags %}
-              <span data-action='delete_selected' data-item="{{ tag }}" data-api-attr='{"mailbox": "{{ mailbox }}"}' data-id="mailbox_tag_{{ tag }}" data-api-url='delete/tags_mailbox' class="badge badge-primary tag-badge">{{ tag }}</span>
+            {% for tag in mailbox_details.tags %}
+              <span data-action='delete_selected' data-item="{{ tag }}" data-api-attr='{"mailbox": "{{ mailbox }}"}' data-id="mailbox_tag_{{ tag }}" data-api-url='delete/tags_mailbox' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
             {% endfor %}
             <input type="text" class="tag-input">
             <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>

--- a/data/web/templates/edit/mailbox.twig
+++ b/data/web/templates/edit/mailbox.twig
@@ -27,7 +27,10 @@
         <div class="col-sm-10">
           <div class="form-control tag-box">
             {% for tag in mailbox_details.tags %}
-              <span data-action='delete_selected' data-item="{{ tag }}" data-id="mailbox_tag_{{ tag }}" data-api-url='delete/mailbox/tag/{{ mailbox }}' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
+              <span data-action='delete_selected' data-item="{{ tag }}" data-id="mailbox_tag_{{ tag }}" data-api-url='delete/mailbox/tag/{{ mailbox }}' class="badge badge-primary tag-badge btn-badge">
+                <i class="bi bi-tag-fill"></i> 
+                {{ tag }}
+              </span>
             {% endfor %}
             <input type="text" class="tag-input">
             <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>

--- a/data/web/templates/edit/mailbox.twig
+++ b/data/web/templates/edit/mailbox.twig
@@ -23,6 +23,19 @@
         </div>
       </div>
       <div class="form-group">
+        <label class="control-label col-sm-2">{{ lang.add.tags }}</label>
+        <div class="col-sm-10">
+          <div class="form-control tag-box">
+            {% for tag in domain_details.tags %}
+              <span data-action='delete_selected' data-item="{{ tag }}" data-api-attr='{"mailbox": "{{ mailbox }}"}' data-id="mailbox_tag_{{ tag }}" data-api-url='delete/tags_mailbox' class="badge badge-primary tag-badge">{{ tag }}</span>
+            {% endfor %}
+            <input type="text" class="tag-input">
+            <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>
+            <input type="hidden" value="" name="tags" class="tag-values" />
+          </div>
+        </div>
+      </div>
+      <div class="form-group">
         <label class="control-label col-sm-2" for="quota">{{ lang.edit.quota_mb }}
           <br><span id="quotaBadge" class="badge">max. {{ (result.max_new_quota / 1048576) }} MiB</span>
         </label>

--- a/data/web/templates/edit/mailbox.twig
+++ b/data/web/templates/edit/mailbox.twig
@@ -27,7 +27,7 @@
         <div class="col-sm-10">
           <div class="form-control tag-box">
             {% for tag in mailbox_details.tags %}
-              <span data-action='delete_selected' data-item="{{ tag }}" data-api-attr='{"mailbox": "{{ mailbox }}"}' data-id="mailbox_tag_{{ tag }}" data-api-url='delete/tags_mailbox' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
+              <span data-action='delete_selected' data-item="{{ tag }}" data-id="mailbox_tag_{{ tag }}" data-api-url='delete/mailbox/tag/{{ mailbox }}' class="badge badge-primary tag-badge btn-badge">{{ tag }}</span>
             {% endfor %}
             <input type="text" class="tag-input">
             <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>

--- a/data/web/templates/modals/mailbox.twig
+++ b/data/web/templates/modals/mailbox.twig
@@ -31,6 +31,16 @@
             </div>
           </div>
           <div class="form-group">
+            <label class="control-label col-sm-2">{{ lang.add.tags }}</label>
+            <div class="col-sm-10">
+              <div class="form-control tag-box">
+                <input type="text" class="tag-input">
+                <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>
+                <input type="hidden" value="" name="tags" class="tag-values" />
+              </div>
+            </div>
+          </div>
+          <div class="form-group">
             <label class="control-label col-sm-2" for="addInputQuota">{{ lang.add.quota_mb }}
               <br /><span id="quotaBadge" class="badge">max. - MiB</span>
             </label>

--- a/data/web/templates/modals/mailbox.twig
+++ b/data/web/templates/modals/mailbox.twig
@@ -95,6 +95,16 @@
             </div>
           </div>
           <div class="form-group">
+            <label class="control-label col-sm-2" for="aliases">{{ lang.add.tags }}</label>
+            <div class="col-sm-10">
+              <div class="form-control tag-box">
+                <input type="text" class="tag-input" name="aliases">
+                <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>
+                <input type="hidden" name="tags" class="tag-input-hidden">
+              </div>
+            </div>
+          </div>
+          <div class="form-group">
             <label class="control-label col-sm-2" for="aliases">{{ lang.add.max_aliases }}</label>
             <div class="col-sm-10">
               <input type="number" class="form-control" name="aliases" value="400" required>

--- a/data/web/templates/modals/mailbox.twig
+++ b/data/web/templates/modals/mailbox.twig
@@ -95,12 +95,12 @@
             </div>
           </div>
           <div class="form-group">
-            <label class="control-label col-sm-2" for="aliases">{{ lang.add.tags }}</label>
+            <label class="control-label col-sm-2">{{ lang.add.tags }}</label>
             <div class="col-sm-10">
               <div class="form-control tag-box">
-                <input type="text" class="tag-input" name="aliases">
+                <input type="text" class="tag-input">
                 <span class="btn tag-add"><i class="bi bi-plus-lg"></i></span>
-                <input type="hidden" name="tags" class="tag-input-hidden">
+                <input type="hidden" value="" name="tags" class="tag-values" />
               </div>
             </div>
           </div>
@@ -198,11 +198,11 @@
           <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10 btn-group">
               {% if not skip_sogo %}
-              <button class="btn btn-xs-lg btn-xs-half visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline btn-default" data-action="add_item" data-id="add_domain" data-api-url='add/domain' data-api-attr='{}' href="#">{{ lang.add.add_domain_only }}</button>
-              <button class="btn btn-xs-lg btn-xs-half visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline btn-default" data-action="add_item" data-id="add_domain" data-api-url='add/domain' data-api-attr='{"restart_sogo":"1"}' href="#">{{ lang.add.add_domain_restart }}</button>
+              <button class="btn btn-xs-lg btn-xs-half visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline btn-default" data-action="add_item" data-id="add_domain" data-api-url='add/domain' data-api-attr='{"tags": []}' href="#">{{ lang.add.add_domain_only }}</button>
+              <button class="btn btn-xs-lg btn-xs-half visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline btn-default" data-action="add_item" data-id="add_domain" data-api-url='add/domain' data-api-attr='{"restart_sogo":"1", "tags": []}' href="#">{{ lang.add.add_domain_restart }}</button>
               <div class="clearfix visible-xs"></div>
               {% else %}
-              <button class="btn btn-xs-lg visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline btn-success" data-action="add_item" data-id="add_domain" data-api-url='add/domain' data-api-attr='{}' href="#">{{ lang.add.add }}</button>
+              <button class="btn btn-xs-lg visible-xs-block visible-sm-inline visible-md-inline visible-lg-inline btn-success" data-action="add_item" data-id="add_domain" data-api-url='add/domain' data-api-attr='{"tags": []}' href="#">{{ lang.add.add }}</button>
               {% endif %}
             </div>
           </div>


### PR DESCRIPTION
Allows administrators to tag domains and mailboxes for later filtering.
No breaking changes were made to the api. Some slightly changes were made and two new functions were introduced.

New
/api/v1/delete/mailbox/tag/{mailbox}
/api/v1/delete/domain/tag/{domain}

Extended
/api/v1/add/domain
/api/v1/edit/domain
/api/v1/add/mailbox
/api/v1/edit/mailbox
/api/v1/get/domain/{id}
/api/v1/get/mailbox/{id}

The changed GET requests can now also be used like this.
/api/v1/get/domain/all?tags=tag1,tag2
/api/v1/get/mailbox/all?tags=tag1,tag2
/api/v1/get/mailbox/domain.tld?tags=tag1,tag2