### PR TITLE
[SOGo] Update to 5.6.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,7 +166,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: mailcow/sogo:1.107
+      image: mailcow/sogo:1.108
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}


### PR DESCRIPTION
This PR includes the Update from SOGo to 5.6.0.

The new Docker Tag is mailcow/sogo:1.108 and was already pushed to the Dockerhub.

The Full Changelog can be found here: https://github.com/inverse-inc/sogo/releases/tag/SOGo-5.6.0