### PR TITLE
Fix for /api/v1/get/mailbox/{email}

### DIFF
--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -989,11 +989,15 @@ if (isset($_GET['query'])) {
                 if (isset($_GET['tags']) && $_GET['tags'] != '') 
                   $tags = explode(',', $_GET['tags']);
 
-                $mailboxes = mailbox('get', 'mailboxes', $object, $tags);
-                if (!empty($mailboxes)) {
-                  foreach ($mailboxes as $mailbox) {
-                    if ($details = mailbox('get', 'mailbox_details', $mailbox)) $data[] = $details;
-                    else continue;
+                if ($tags === null) {
+                  $data = mailbox('get', 'mailbox_details', $object);
+                } else {
+                  $mailboxes = mailbox('get', 'mailboxes', $object, $tags);
+                  if (is_array($mailboxes)) {
+                    foreach ($mailboxes as $mailbox) {
+                      if ($details = mailbox('get', 'mailbox_details', $mailbox)) 
+                        $data[] = $details;
+                    }
                   }
                 }
                 process_get_return($data);

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -991,6 +991,7 @@ if (isset($_GET['query'])) {
 
                 if ($tags === null) {
                   $data = mailbox('get', 'mailbox_details', $object);
+                  process_get_return($data);
                 } else {
                   $mailboxes = mailbox('get', 'mailboxes', $object, $tags);
                   if (is_array($mailboxes)) {
@@ -999,8 +1000,8 @@ if (isset($_GET['query'])) {
                         $data[] = $details;
                     }
                   }
+                  process_get_return($data, false);
                 }
-                process_get_return($data);
               break;
             }
           break;


### PR DESCRIPTION
The tagging feature breaks the API endpoint "`/api/v1/get/mailbox/{username}`" (without tags parameter). Prior to the change it returned the mailbox details (directly not as list) when "{username}" matches directly.

At the moment (without this PR) it return a list of all mailboxes when the tags parameter is not set. When tags is set, untagged mailboxes cannot be retrieved and result is always a list.

While a list is ok for the case that tags are specified (or in general when multiple mailboxes can be expected), it is not ok when the details for a single mailbox are requested.

If this was by intention then a breaking change should be documented (and maybe a migration path how to get the details of a single mailbox that has no tags).