### PR TITLE
[Web] Swagger UI: explicitly define used OpenAPI specifications

### DIFF
--- a/data/web/api/index.html
+++ b/data/web/api/index.html
@@ -39,7 +39,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/api/openapi.yaml",
+        urls: [{url: "/api/openapi.yaml", name: "mailcow API"}],
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [


### PR DESCRIPTION
Update Swagger UI configuration to explicitly define used OpenAPI specifications. This does prevent the potential loading of arbitrary content from any other, external specifications. See #4586 for context.