### PR TITLE
[Clamd] Update to ClamAV 0.105

### DIFF
--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -1,4 +1,4 @@
-FROM clamav/clamav:0.104.2-2_base
+FROM clamav/clamav:0.105.0_base
 
 LABEL maintainer "André Peters <andre.peters@servercow.de>"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
             - redis
 
     clamd-mailcow:
-      image: mailcow/clamd:1.51
+      image: mailcow/clamd:1.52
       restart: always
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254


### PR DESCRIPTION
The new Dockertag is **1.52**

The full ClamAV Changelog can be found here: https://blog.clamav.net/2022/05/clamav-01050-01043-01036-released.html