### PR TITLE
[Web] Add ratelimits

### DIFF
--- a/data/conf/nginx/includes/site-defaults.conf
+++ b/data/conf/nginx/includes/site-defaults.conf
@@ -40,6 +40,7 @@
   location ~ ^/(fonts|js|css|img)/ {
     expires max;
     add_header Cache-Control public;
+    limit_conn addr 20;
   }
 
   error_log  /var/log/nginx/error.log;
@@ -50,27 +51,33 @@
 
   location / {
     try_files $uri $uri/ @strip-ext;
+    limit_conn addr 20;
   }
 
   location /qhandler {
     rewrite ^/qhandler/(.*)/(.*) /qhandler.php?action=$1&hash=$2;
+    limit_conn addr 20;
   }
 
   location /edit {
     rewrite ^/edit/(.*)/(.*) /edit.php?$1=$2;
+    limit_conn addr 20;
   }
 
   location @strip-ext {
     rewrite ^(.*)$ $1.php last;
+    limit_conn addr 20;
   }
 
   location ~ ^/api/v1/(.*)$ {
     try_files $uri $uri/ /json_api.php?query=$1&$args;
+    limit_conn addr 20;
   }
 
   location ^~ /.well-known/acme-challenge/ {
     allow all;
     default_type "text/plain";
+    limit_conn addr 20;
   }
 
   # If behind reverse proxy, forwards the correct IP
@@ -86,11 +93,13 @@
 
   location ^~ /principals {
     return 301 /SOGo/dav;
+    limit_conn addr 20;
   }
 
   location ^~ /inc/lib/ {
     deny all;
     return 403;
+    limit_conn addr 20;
   }
 
   location ~ \.php$ {
@@ -103,6 +112,7 @@
     fastcgi_param PATH_INFO $fastcgi_path_info;
     fastcgi_read_timeout 3600;
     fastcgi_send_timeout 3600;
+    limit_conn addr 20;
   }
 
   location /rspamd/ {
@@ -121,6 +131,7 @@
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_redirect off;
+    limit_conn addr 20;
   }
 
   location ~* ^/Autodiscover/Autodiscover.xml {
@@ -129,6 +140,7 @@
     include /etc/nginx/fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     try_files /autodiscover.php =404;
+    limit_conn addr 20;
   }
 
   location ~* ^/Autodiscover/Autodiscover.json {
@@ -137,6 +149,7 @@
     include /etc/nginx/fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     try_files /autodiscover-json.php =404;
+    limit_conn addr 20;
   }
 
   location ~ /(?:m|M)ail/(?:c|C)onfig-v1.1.xml {
@@ -145,6 +158,7 @@
     include /etc/nginx/fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     try_files /autoconfig.php =404;
+    limit_conn addr 20;
   }
 
   location /sogo-auth-verify {
@@ -155,6 +169,7 @@
     proxy_set_header  Content-Length "";
     proxy_pass        http://127.0.0.1:65510/sogo-auth;
     proxy_pass_request_body off;
+    limit_conn addr 20;
   }
 
   location ^~ /Microsoft-Server-ActiveSync {
@@ -171,6 +186,7 @@
     proxy_set_header Host $http_host;
     client_body_buffer_size 512k;
     client_max_body_size 0;
+    limit_conn addr 20;
   }
 
   location ^~ /SOGo {
@@ -206,27 +222,33 @@
     proxy_read_timeout 3600;
     client_body_buffer_size 128k;
     client_max_body_size 0;
+    limit_conn addr 20;
     break;
   }
 
   location ~* /sogo$ {
     return 301 $client_req_scheme://$http_host/SOGo;
+    limit_conn addr 20;
   }
 
   location /SOGo.woa/WebServerResources/ {
     alias /usr/lib/GNUstep/SOGo/WebServerResources/;
+    limit_conn addr 20;
   }
 
   location /.woa/WebServerResources/ {
     alias /usr/lib/GNUstep/SOGo/WebServerResources/;
+    limit_conn addr 20;
   }
 
   location /SOGo/WebServerResources/ {
     alias /usr/lib/GNUstep/SOGo/WebServerResources/;
+    limit_conn addr 20;
   }
 
   location (^/SOGo/so/ControlPanel/Products/[^/]*UI/Resources/.*\.(jpg|png|gif|css|js)$) {
     alias /usr/lib/GNUstep/SOGo/$1.SOGo/Resources/$2;
+    limit_conn addr 20;
   }
 
   include /etc/nginx/conf.d/site.*.custom;
@@ -235,8 +257,10 @@
 
   location @awaitingupstream {
     rewrite ^(.*)$ /_status.502.html break;
+    limit_conn addr 20;
   }
 
   location ~ ^/cache/(.*)$ {
       try_files $uri $uri/ /resource.php?file=$1;
+    limit_conn addr 20;
   }

--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -1,5 +1,6 @@
 proxy_cache_path /tmp levels=1:2 keys_zone=sogo:10m inactive=24h  max_size=1g;
 server_names_hash_bucket_size 64;
+limit_conn_zone $binary_remote_addr zone=addr:10m;
 
 map $http_x_forwarded_proto $client_req_scheme {
      default $scheme;


### PR DESCRIPTION
A friend of mine recently asked if my mail server ha a dos protection and tested it with a simple script. That lead to 100% CPU utilization and made the web interface unusable. Adding these rate limits resolved the lock-up.

Maybe this is not the ideal solution, but some kind of rate-limiting would be nice in my opinion :)