### PR TITLE
[Postfix] Update to 3.5.6 (Rebase to Debian 11)

### DIFF
--- a/data/Dockerfiles/postfix/Dockerfile
+++ b/data/Dockerfiles/postfix/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/data/Dockerfiles/postfix/syslog-ng-redis_slave.conf
+++ b/data/Dockerfiles/postfix/syslog-ng-redis_slave.conf
@@ -1,4 +1,4 @@
-@version: 3.19
+@version: 3.28
 @include "scl.conf"
 options {
   chain_hostnames(off);

--- a/data/Dockerfiles/postfix/syslog-ng.conf
+++ b/data/Dockerfiles/postfix/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.19
+@version: 3.28
 @include "scl.conf"
 options {
   chain_hostnames(off);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,7 +293,7 @@ services:
             - dovecot
 
     postfix-mailcow:
-      image: mailcow/postfix:1.66
+      image: mailcow/postfix:1.67
       depends_on:
         - mysql-mailcow
       volumes:


### PR DESCRIPTION
Image: mailcow/postfix:1.67 already built, uploaded and in testing in my own private instance since almost two weeks.

Works flawlessly so far.