### PR TITLE
[Compose] Update to Docker Compose v2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -374,8 +374,8 @@ services:
         - ./data/conf/rspamd/meta_exporter:/meta_exporter:ro,z
         - sogo-web-vol-1:/usr/lib/GNUstep/SOGo/:z
       ports:
-        - "${HTTPS_BIND:-:}:${HTTPS_PORT:-443}:${HTTPS_PORT:-443}"
-        - "${HTTP_BIND:-:}:${HTTP_PORT:-80}:${HTTP_PORT:-80}"
+        - "${HTTPS_BIND:-0.0.0.0:}:${HTTPS_PORT:-443}:${HTTPS_PORT:-443}"
+        - "${HTTP_BIND:-0.0.0.0:}:${HTTP_PORT:-80}:${HTTP_PORT:-80}"
       restart: always
       networks:
         mailcow-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -375,8 +375,8 @@ services:
         - ./data/conf/rspamd/meta_exporter:/meta_exporter:ro,z
         - sogo-web-vol-1:/usr/lib/GNUstep/SOGo/:z
       ports:
-        - "${HTTPS_BIND:-0.0.0.0:}:${HTTPS_PORT:-443}:${HTTPS_PORT:-443}"
-        - "${HTTP_BIND:-0.0.0.0:}:${HTTP_PORT:-80}:${HTTP_PORT:-80}"
+        - "${HTTPS_BIND:-0.0.0.0}:${HTTPS_PORT:-443}:${HTTPS_PORT:-443}"
+        - "${HTTP_BIND:-0.0.0.0}:${HTTP_PORT:-80}:${HTTP_PORT:-80}"
       restart: always
       networks:
         mailcow-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
     clamd-mailcow:
       image: mailcow/clamd:1.52
       restart: always
+      depends_on:
+        - unbound-mailcow
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,8 @@ services:
         - unbound-mailcow
       stop_grace_period: 45s
       volumes:
-        - mysql-vol-1:/var/lib/mysql/:Z
-        - mysql-socket-vol-1:/var/run/mysqld/:z
+        - mysql-vol-1:/var/lib/mysql/
+        - mysql-socket-vol-1:/var/run/mysqld/
         - ./data/conf/mysql/:/etc/mysql/conf.d/:ro,Z
       environment:
         - TZ=${TZ}
@@ -43,7 +43,7 @@ services:
     redis-mailcow:
       image: redis:6-alpine
       volumes:
-        - redis-vol-1:/data/:Z
+        - redis-vol-1:/data/
       restart: always
       ports:
         - "${REDIS_PORT:-127.0.0.1:7654}:6379"
@@ -67,7 +67,7 @@ services:
         - SKIP_CLAMD=${SKIP_CLAMD:-n}
       volumes:
         - ./data/conf/clamav/:/etc/clamav/:Z
-        - clamd-db-vol-1:/var/lib/clamav:z
+        - clamd-db-vol-1:/var/lib/clamav
       networks:
         mailcow-network:
           aliases:
@@ -113,8 +113,8 @@ services:
         - ./data/web:/web:z
         - ./data/conf/rspamd/dynmaps:/dynmaps:ro,z
         - ./data/conf/rspamd/custom/:/rspamd_custom_maps:z
-        - rspamd-vol-1:/var/lib/rspamd:z
-        - mysql-socket-vol-1:/var/run/mysqld/:z
+        - rspamd-vol-1:/var/lib/rspamd
+        - mysql-socket-vol-1:/var/run/mysqld/
         - ./data/conf/sogo/:/etc/sogo/:z
         - ./data/conf/rspamd/meta_exporter:/meta_exporter:ro,z
         - ./data/conf/phpfpm/sogo-sso/:/etc/sogo-sso/:z
@@ -192,9 +192,9 @@ services:
         - ./data/conf/sogo/custom-favicon.ico:/usr/lib/GNUstep/SOGo/WebServerResources/img/sogo.ico:z
         - ./data/conf/sogo/custom-theme.js:/usr/lib/GNUstep/SOGo/WebServerResources/js/theme.js:z
         - ./data/conf/sogo/custom-sogo.js:/usr/lib/GNUstep/SOGo/WebServerResources/js/custom-sogo.js:z
-        - mysql-socket-vol-1:/var/run/mysqld/:z
-        - sogo-web-vol-1:/sogo_web:z
-        - sogo-userdata-backup-vol-1:/sogo_backup:Z
+        - mysql-socket-vol-1:/var/run/mysqld/
+        - sogo-web-vol-1:/sogo_web
+        - sogo-userdata-backup-vol-1:/sogo_backup
       labels:
         ofelia.enabled: "true"
         ofelia.job-exec.sogo_sessions.schedule: "@every 1m"
@@ -226,13 +226,13 @@ services:
         - ./data/assets/ssl:/etc/ssl/mail/:ro,z
         - ./data/conf/sogo/:/etc/sogo/:z
         - ./data/conf/phpfpm/sogo-sso/:/etc/phpfpm/:z
-        - vmail-vol-1:/var/vmail:Z
-        - vmail-index-vol-1:/var/vmail_index:Z
-        - crypt-vol-1:/mail_crypt/:z
+        - vmail-vol-1:/var/vmail
+        - vmail-index-vol-1:/var/vmail_index
+        - crypt-vol-1:/mail_crypt/
         - ./data/conf/rspamd/custom/:/etc/rspamd/custom:z
         - ./data/assets/templates:/templates:z
-        - rspamd-vol-1:/var/lib/rspamd:z
-        - mysql-socket-vol-1:/var/run/mysqld/:z
+        - rspamd-vol-1:/var/lib/rspamd
+        - mysql-socket-vol-1:/var/run/mysqld/
       environment:
         - DOVECOT_MASTER_USER=${DOVECOT_MASTER_USER:-}
         - DOVECOT_MASTER_PASS=${DOVECOT_MASTER_PASS:-}
@@ -300,10 +300,10 @@ services:
         - ./data/hooks/postfix:/hooks:Z
         - ./data/conf/postfix:/opt/postfix/conf:z
         - ./data/assets/ssl:/etc/ssl/mail/:ro,z
-        - postfix-vol-1:/var/spool/postfix:z
-        - crypt-vol-1:/var/lib/zeyple:z
-        - rspamd-vol-1:/var/lib/rspamd:z
-        - mysql-socket-vol-1:/var/run/mysqld/:z
+        - postfix-vol-1:/var/spool/postfix
+        - crypt-vol-1:/var/lib/zeyple
+        - rspamd-vol-1:/var/lib/rspamd
+        - mysql-socket-vol-1:/var/run/mysqld/
       environment:
         - LOG_LINES=${LOG_LINES:-9999}
         - TZ=${TZ}
@@ -373,7 +373,7 @@ services:
         - ./data/assets/ssl/:/etc/ssl/mail/:ro,z
         - ./data/conf/nginx/:/etc/nginx/conf.d/:z
         - ./data/conf/rspamd/meta_exporter:/meta_exporter:ro,z
-        - sogo-web-vol-1:/usr/lib/GNUstep/SOGo/:z
+        - sogo-web-vol-1:/usr/lib/GNUstep/SOGo/
       ports:
         - "${HTTPS_BIND:-0.0.0.0}:${HTTPS_PORT:-443}:${HTTPS_PORT:-443}"
         - "${HTTP_BIND:-0.0.0.0}:${HTTP_PORT:-80}:${HTTP_PORT:-80}"
@@ -414,7 +414,7 @@ services:
         - ./data/web/.well-known/acme-challenge:/var/www/acme:z
         - ./data/assets/ssl:/var/lib/acme/:z
         - ./data/assets/ssl-example:/var/lib/ssl-example/:ro,Z
-        - mysql-socket-vol-1:/var/run/mysqld/:z
+        - mysql-socket-vol-1:/var/run/mysqld/
       restart: always
       networks:
         mailcow-network:
@@ -451,9 +451,9 @@ services:
       tmpfs:
         - /tmp
       volumes:
-        - rspamd-vol-1:/var/lib/rspamd:z
-        - mysql-socket-vol-1:/var/run/mysqld/:z
-        - postfix-vol-1:/var/spool/postfix:z
+        - rspamd-vol-1:/var/lib/rspamd
+        - mysql-socket-vol-1:/var/run/mysqld/
+        - postfix-vol-1:/var/spool/postfix
         - ./data/assets/ssl:/etc/ssl/mail/:ro,z
       restart: always
       environment:
@@ -528,7 +528,7 @@ services:
       image: mailcow/solr:1.8.1
       restart: always
       volumes:
-        - solr-vol-1:/opt/solr/server/solr/dovecot-fts/data:Z
+        - solr-vol-1:/opt/solr/server/solr/dovecot-fts/data
       ports:
         - "${SOLR_PORT:-127.0.0.1:18983}:8983"
       environment:

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -40,6 +40,7 @@ then
     sleep 3
 
 elif ! docker compose version --short | grep "^2" > /dev/null 2>&1
+then
     >&2 echo -e "\e[31mCannot find Docker-Compose v1 or v2 on your System. Please install Docker-Compose v2 and re-run the Script.\e[0m"
     exit 1
 fi

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -25,9 +25,24 @@ if cp --help 2>&1 | grep -q -i "busybox"; then
   exit 1
 fi
 
-for bin in openssl curl docker-compose docker git awk sha1sum; do
+for bin in openssl curl docker git awk sha1sum; do
   if [[ -z $(which ${bin}) ]]; then echo "Cannot find ${bin}, exiting..."; exit 1; fi
 done
+
+if docker-compose version --short | grep -m1 "^1" > /dev/null 2>&1
+then
+    >&2 echo -e "\e[31mWARN: Your machine is using Docker-Compose v1!\e[0m"
+    >&2 echo -e "\e[31mmailcow will drop the Docker-Compose v1 Support in December 2022\e[0m"
+    >&2 echo -e "\e[31mPlease consider a upgrade to Docker-Compose v2.\e[0m"
+    >&2 echo
+    >&2 echo
+    >&2 echo -e "\e[33mContinuing...\e[0m"
+    sleep 3
+
+elif ! docker compose version --short | grep "^2" > /dev/null 2>&1
+    >&2 echo -e "\e[31mCannot find Docker-Compose v1 or v2 on your System. Please install Docker-Compose v2 and re-run the Script.\e[0m"
+    exit 1
+fi
 
 if [ -f mailcow.conf ]; then
   read -r -p "A config file exists and will be overwritten, are you sure you want to continue? [y/N] " response

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -144,14 +144,14 @@ DBROOT=$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 | head -c 28)
 # Do _not_ use IP:PORT in HTTP(S)_BIND or HTTP(S)_PORT
 # IMPORTANT: Do not use port 8081, 9081 or 65510!
 # Example: HTTP_BIND=1.2.3.4
-# For IPv4 and IPv6 leave it empty: HTTP_BIND= & HTTPS_PORT=
+# For IPv4 and IPv6 leave it as it is (0.0.0.0): HTTP_BIND= & HTTPS_PORT=
 # For IPv6 see https://mailcow.github.io/mailcow-dockerized-docs/post_installation/firststeps-ip_bindings/
 
 HTTP_PORT=80
-HTTP_BIND=
+HTTP_BIND=0.0.0.0
 
 HTTPS_PORT=443
-HTTPS_BIND=
+HTTPS_BIND=0.0.0.0
 
 # ------------------------------
 # Other bindings

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -163,14 +163,14 @@ DBROOT=$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 | head -c 28)
 # Do _not_ use IP:PORT in HTTP(S)_BIND or HTTP(S)_PORT
 # IMPORTANT: Do not use port 8081, 9081 or 65510!
 # Example: HTTP_BIND=1.2.3.4
-# For IPv4 and IPv6 leave it as it is (0.0.0.0): HTTP_BIND= & HTTPS_PORT=
+# For IPv4 leave it as it is: HTTP_BIND= & HTTPS_PORT=
 # For IPv6 see https://mailcow.github.io/mailcow-dockerized-docs/post_installation/firststeps-ip_bindings/
 
 HTTP_PORT=80
-HTTP_BIND=0.0.0.0
+HTTP_BIND=
 
 HTTPS_PORT=443
-HTTPS_BIND=0.0.0.0
+HTTPS_BIND=
 
 # ------------------------------
 # Other bindings

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -33,7 +33,7 @@ echo "checking docker compose version...";
 if docker --help | grep compose
 then
     echo ''
-if docker-compose version --short | grep -m1 "^1" > /dev/null 2>&1
+elif docker-compose version --short | grep -m1 "^1" > /dev/null 2>&1
 then
     >&2 echo -e "\e[31mWARN: Your machine is using Docker-Compose v1!\e[0m"
     >&2 echo -e "\e[31mmailcow will drop the Docker-Compose v1 Support in December 2022\e[0m"

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -29,6 +29,10 @@ for bin in openssl curl docker git awk sha1sum; do
   if [[ -z $(which ${bin}) ]]; then echo "Cannot find ${bin}, exiting..."; exit 1; fi
 done
 
+echo "checking docker compose version...";
+if docker --help | grep compose
+then
+    echo ''
 if docker-compose version --short | grep -m1 "^1" > /dev/null 2>&1
 then
     >&2 echo -e "\e[31mWARN: Your machine is using Docker-Compose v1!\e[0m"
@@ -39,8 +43,7 @@ then
     >&2 echo -e "\e[33mContinuing...\e[0m"
     sleep 3
 
-elif ! docker compose version --short | grep "^2" > /dev/null 2>&1
-then
+else
     >&2 echo -e "\e[31mCannot find Docker-Compose v1 or v2 on your System. Please install Docker-Compose v2 and re-run the Script.\e[0m"
     exit 1
 fi

--- a/helper-scripts/_cold-standby.sh
+++ b/helper-scripts/_cold-standby.sh
@@ -77,7 +77,7 @@ function preflight_local_checks() {
     exit 1
   fi
 
-  for bin in rsync docker-compose docker grep cut; do
+  for bin in rsync docker grep cut; do
     if [[ -z $(which ${bin}) ]]; then
       >&2 echo -e "\e[31mCannot find ${bin} in local PATH, exiting...\e[0m"
       exit 1
@@ -85,11 +85,7 @@ function preflight_local_checks() {
   done
 
 
-  if docker compose version --short | grep "^2" > /dev/null 2>&1 || docker-compose version --short | grep "^2" > /dev/null 2>&1
-  then
-     echo
-
-  elif docker-compose version --short | grep -m1 "^1" > /dev/null 2>&1
+  if docker-compose version --short | grep -m1 "^1" > /dev/null 2>&1
   then
      >&2 echo -e "\e[31mWARN: Your machine is using Docker-Compose v1!\e[0m"
      >&2 echo -e "\e[31mmailcow will drop the Docker-Compose v1 Support in December 2022\e[0m"
@@ -99,7 +95,7 @@ function preflight_local_checks() {
      >&2 echo -e "\e[33mContinuing...\e[0m"
      sleep 3
 
-  else
+  elif ! docker compose version --short | grep "^2" > /dev/null 2>&1
      >&2 echo -e "\e[31mCannot find Docker-Compose v1 or v2 on your System. Please install Docker-Compose v2 and re-run the Script.\e[0m"
      exit 1
   fi
@@ -131,7 +127,7 @@ function preflight_remote_checks() {
       exit 1
   fi
 
-  for bin in rsync docker-compose docker; do
+  for bin in rsync docker; do
     if ! ssh -o StrictHostKeyChecking=no \
       -i "${REMOTE_SSH_KEY}" \
       ${REMOTE_SSH_HOST} \
@@ -146,15 +142,9 @@ function preflight_remote_checks() {
       -i "${REMOTE_SSH_KEY}" \
       ${REMOTE_SSH_HOST} \
       -p ${REMOTE_SSH_PORT} \
-     -t 'docker compose version --short' | grep "^2" > /dev/null 2>&1 || ssh -q -o StrictHostKeyChecking=no \
-      -i "${REMOTE_SSH_KEY}" \
-      ${REMOTE_SSH_HOST} \
-      -p ${REMOTE_SSH_PORT} \
-     -t 'docker-compose version --short' | grep "^2" > /dev/null 2>&1
+     -t 'docker compose version --short' | grep "^2" > /dev/null 2>&1
   then
-     >&2 echo -e "\e[33mINFO: Remote is using Docker-Compose v2.\e[0m"
      COMPOSE_COMMAND="docker compose"
-
   elif ssh -q -o StrictHostKeyChecking=no \
       -i "${REMOTE_SSH_KEY}" \
       ${REMOTE_SSH_HOST} \
@@ -169,7 +159,6 @@ function preflight_remote_checks() {
      >&2 echo -e "\e[33mContinuing...\e[0m"
      sleep 3
      COMPOSE_COMMAND="docker-compose"
-
   else
      >&2 echo -e "\e[31mCannot find Docker-Compose v1 or v2 on the Remote Machine! Please install Docker-Compose v2 on that and re-run the script.\e[0m"
      exit 1

--- a/helper-scripts/_cold-standby.sh
+++ b/helper-scripts/_cold-standby.sh
@@ -85,7 +85,11 @@ function preflight_local_checks() {
   done
 
 
-  if docker-compose version --short | grep -m1 "^1" > /dev/null 2>&1
+  echo "checking docker compose version...";
+  if docker --help | grep compose
+  then
+    echo ''
+  elif docker-compose version --short | grep -m1 "^1" > /dev/null 2>&1
   then
      >&2 echo -e "\e[31mWARN: Your machine is using Docker-Compose v1!\e[0m"
      >&2 echo -e "\e[31mmailcow will drop the Docker-Compose v1 Support in December 2022\e[0m"
@@ -95,8 +99,7 @@ function preflight_local_checks() {
      >&2 echo -e "\e[33mContinuing...\e[0m"
      sleep 3
 
-  elif ! docker compose version --short | grep "^2" > /dev/null 2>&1
-  then
+  else
      >&2 echo -e "\e[31mCannot find Docker-Compose v1 or v2 on your System. Please install Docker-Compose v2 and re-run the Script.\e[0m"
      exit 1
   fi
@@ -139,11 +142,12 @@ function preflight_remote_checks() {
     fi
   done
 
+  echo "checking docker compose version on remote...";
   if ssh -q -o StrictHostKeyChecking=no \
       -i "${REMOTE_SSH_KEY}" \
       ${REMOTE_SSH_HOST} \
       -p ${REMOTE_SSH_PORT} \
-     -t 'docker compose version --short' | grep "^2" > /dev/null 2>&1
+     -t docker --help | grep compose
   then
      COMPOSE_COMMAND="docker compose"
   elif ssh -q -o StrictHostKeyChecking=no \

--- a/helper-scripts/_cold-standby.sh
+++ b/helper-scripts/_cold-standby.sh
@@ -298,7 +298,7 @@ if ! ssh -o StrictHostKeyChecking=no \
 fi
 echo "OK"
 
-  echo -e "\e[33mPulling images from remote...\e[0m"
+  echo -e "\e[33mPulling images on remote...\e[0m"
   echo -e "\e[33mProcess is NOT stuck! Please wait...\e[0m"
 
   if ! ssh -o StrictHostKeyChecking=no \
@@ -309,7 +309,7 @@ echo "OK"
       >&2 echo -e "\e[31m[ERR]\e[0m - Could not pull images on remote"
   fi
 
-echo -e "\033[1mForcing garbage cleanup on remote...\033[0m"
+echo -e "\033[1mExecuting update script and forcing garbage cleanup on remote...\033[0m"
 if ! ssh -o StrictHostKeyChecking=no \
   -i "${REMOTE_SSH_KEY}" \
   ${REMOTE_SSH_HOST} \

--- a/helper-scripts/_cold-standby.sh
+++ b/helper-scripts/_cold-standby.sh
@@ -96,6 +96,7 @@ function preflight_local_checks() {
      sleep 3
 
   elif ! docker compose version --short | grep "^2" > /dev/null 2>&1
+  then
      >&2 echo -e "\e[31mCannot find Docker-Compose v1 or v2 on your System. Please install Docker-Compose v2 and re-run the Script.\e[0m"
      exit 1
   fi

--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -76,7 +76,8 @@ else
   CMPS_PRJ=$(echo ${COMPOSE_PROJECT_NAME} | tr -cd "[0-9A-Za-z-_]")
 fi
 
-if docker compose version --short | grep "^2" > /dev/null 2>&1
+echo "checking docker compose version...";
+if docker --help | grep compose
 then
     COMPOSE_COMMAND="docker compose"
 elif docker-compose version --short | grep -m1 "^1" > /dev/null 2>&1

--- a/update.sh
+++ b/update.sh
@@ -40,10 +40,29 @@ PATH=$PATH:/opt/bin
 
 umask 0022
 
-for bin in curl docker-compose docker git awk sha1sum; do
+for bin in curl docker git awk sha1sum; do
   if [[ -z $(which ${bin}) ]]; then echo "Cannot find ${bin}, exiting..."; exit 1; fi
 done
 
+if docker compose version --short | grep "^2" > /dev/null 2>&1 || docker-compose version --short | grep "^2" > /dev/null 2>&1 
+then
+     COMPOSE_COMMAND="docker compose"
+
+elif docker-compose version --short | grep -m1 "^1" > /dev/null 2>&1
+then
+    >&2 echo -e "\e[31mWARN: Your machine is using Docker-Compose v1!\e[0m"
+    >&2 echo -e "\e[31mmailcow will drop the Docker-Compose v1 Support in December 2022\e[0m"
+    >&2 echo -e "\e[31mPlease consider a upgrade to Docker-Compose v2.\e[0m"
+    >&2 echo
+    >&2 echo
+    >&2 echo -e "\e[33mContinuing...\e[0m"
+    sleep 3
+    COMPOSE_COMMAND="docker-compose"
+
+else
+    >&2 echo -e "\e[31mCannot find Docker-Compose v1 or v2 on your System. Please install Docker-Compose v2 and re-run the Script.\e[0m"
+    exit 1
+fi
 export LC_ALL=C
 DATE=$(date +%Y-%m-%d_%H_%M_%S)
 BRANCH=$(cd ${SCRIPT_DIR}; git rev-parse --abbrev-ref HEAD)

--- a/update.sh
+++ b/update.sh
@@ -44,7 +44,7 @@ for bin in curl docker git awk sha1sum; do
   if [[ -z $(which ${bin}) ]]; then echo "Cannot find ${bin}, exiting..."; exit 1; fi
 done
 
-if docker compose version --short | grep "^2" > /dev/null 2>&1 || docker-compose version --short | grep "^2" > /dev/null 2>&1 
+if docker compose version --short | grep "^2" > /dev/null 2>&1
 then
      COMPOSE_COMMAND="docker compose"
 
@@ -254,9 +254,6 @@ while (($#)); do
       echo -e "\e[32mRunning in forced mode...\e[0m"
       FORCE=y
     ;;
-    --no-update-compose)
-      NO_UPDATE_COMPOSE=y
-    ;;
     --skip-ping-check)
       SKIP_PING_CHECK=y
     ;;
@@ -266,7 +263,6 @@ while (($#)); do
   -c|--check           -   Check for updates and exit (exit codes => 0: update available, 3: no updates)
   --ours               -   Use merge strategy option "ours" to solve conflicts in favor of non-mailcow code (local changes over remote changes), not recommended!
   --gc                 -   Run garbage collector to delete old image tags
-  --no-update-compose  -   Do not update docker-compose
   --prefetch           -   Only prefetch new images and exit (useful to prepare updates)
   --skip-start         -   Do not start mailcow after update
   --skip-ping-check    -   Skip ICMP Check to public DNS resolvers (Use it only if you´ve blocked any ICMP Connections to your mailcow machine).
@@ -283,7 +279,7 @@ source mailcow.conf
 DOTS=${MAILCOW_HOSTNAME//[^.]};
 if [ ${#DOTS} -lt 2 ]; then
   echo "MAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) is not a FQDN!"
-  echo "Please change it to a FQDN and run docker-compose down followed by docker-compose up -d"
+  echo "Please change it to a FQDN and run ${COMPOSE_COMMAND} down followed by ${COMPOSE_COMMAND} up -d"
   exit 1
 fi
 
@@ -597,13 +593,13 @@ if [ ! $FORCE ]; then
 fi
 
 echo -e "\e[32mValidating docker-compose stack configuration...\e[0m"
-if ! docker-compose config -q; then
+if ! ${COMPOSE_COMMAND} config -q; then
   echo -e "\e[31m\nOh no, something went wrong. Please check the error message above.\e[0m"
   exit 1
 fi
 
 echo -e "\e[32mChecking for conflicting bridges...\e[0m"
-MAILCOW_BRIDGE=$(docker-compose config | grep -i com.docker.network.bridge.name | cut -d':' -f2)
+MAILCOW_BRIDGE=$(${COMPOSE_COMMAND} config | grep -i com.docker.network.bridge.name | cut -d':' -f2)
 while read NAT_ID; do
   iptables -t nat -D POSTROUTING $NAT_ID
 done < <(iptables -L -vn -t nat --line-numbers | grep $IPV4_NETWORK | grep -E 'MASQUERADE.*all' | grep -v ${MAILCOW_BRIDGE} | cut -d' ' -f1)
@@ -623,8 +619,8 @@ prefetch_images
 
 echo -e "\e[32mStopping mailcow...\e[0m"
 sleep 2
-MAILCOW_CONTAINERS=($(docker-compose ps -q))
-docker-compose down
+MAILCOW_CONTAINERS=($(${COMPOSE_COMMAND} ps -q))
+${COMPOSE_COMMAND} down
 echo -e "\e[32mChecking for remaining containers...\e[0m"
 sleep 2
 for container in "${MAILCOW_CONTAINERS[@]}"; do
@@ -661,51 +657,16 @@ elif [[ ${MERGE_RETURN} == 1 ]]; then
 elif [[ ${MERGE_RETURN} != 0 ]]; then
   echo -e "\e[31m\nOh no, something went wrong. Please check the error message above.\e[0m"
   echo
-  echo "Run docker-compose up -d to restart your stack without updates or try again after fixing the mentioned errors."
+  echo "Run ${COMPOSE_COMMAND} up -d to restart your stack without updates or try again after fixing the mentioned errors."
   exit 1
 fi
 
-if [[ ${NO_UPDATE_COMPOSE} == "y" ]]; then
-  echo -e "\e[33mNot fetching latest docker-compose, please check for updates manually!\e[0m"
-elif [[ -e /etc/alpine-release ]]; then
-  echo -e "\e[33mNot fetching latest docker-compose, because you are using Alpine Linux without glibc support. Please update docker-compose via apk!\e[0m"
-else
-  echo -e "\e[32mFetching new docker-compose version...\e[0m"
-  echo -e "\e[32mTrying to determine GLIBC version...\e[0m"
-  if ldd --version > /dev/null; then
-    GLIBC_V=$(ldd --version | grep -E '(GLIBC|GNU libc)' | rev | cut -d ' ' -f1 | rev | cut -d '.' -f2)
-    if [ ! -z "${GLIBC_V}" ] && [ ${GLIBC_V} -gt 27 ]; then
-      DC_DL_SUFFIX=
-    else
-      DC_DL_SUFFIX=legacy
-    fi
-  else
-    DC_DL_SUFFIX=legacy
-  fi
-  sleep 1
-  if [[ ! -z $(which pip) && $(pip list --local 2>&1 | grep -v DEPRECATION | grep -c docker-compose) == 1 ]]; then
-    true
-    #prevent breaking a working docker-compose installed with pip
-  elif [[ $(curl -sL -w "%{http_code}" https://www.servercow.de/docker-compose/latest.php?vers=${DC_DL_SUFFIX} -o /dev/null) == "200" ]]; then
-    LATEST_COMPOSE=$(curl -#L https://www.servercow.de/docker-compose/latest.php)
-    COMPOSE_VERSION=$(docker-compose version --short)
-    if [[ "$LATEST_COMPOSE" != "$COMPOSE_VERSION" ]]; then
-      COMPOSE_PATH=$(which docker-compose)
-      if [[ -w ${COMPOSE_PATH} ]]; then
-        curl -#L https://github.com/docker/compose/releases/download/${LATEST_COMPOSE}/docker-compose-$(uname -s)-$(uname -m) > $COMPOSE_PATH
-        chmod +x $COMPOSE_PATH
-      else
-        echo -e "\e[33mWARNING: $COMPOSE_PATH is not writable, but new version $LATEST_COMPOSE is available (installed: $COMPOSE_VERSION)\e[0m"
-      fi
-    fi
-  else
-    echo -e "\e[33mCannot determine latest docker-compose version, skipping...\e[0m"
-  fi
-fi
+echo -e "\e[33mNot fetching latest docker-compose, please check for updates manually!\e[0m"
+sleep 3
 
 echo -e "\e[32mFetching new images, if any...\e[0m"
 sleep 2
-docker-compose pull
+${COMPOSE_COMMAND} pull
 
 # Fix missing SSL, does not overwrite existing files
 [[ ! -d data/assets/ssl ]] && mkdir -p data/assets/ssl
@@ -760,11 +721,11 @@ else
 fi
 
 if [[ ${SKIP_START} == "y" ]]; then
-  echo -e "\e[33mNot starting mailcow, please run \"docker-compose up -d --remove-orphans\" to start mailcow.\e[0m"
+  echo -e "\e[33mNot starting mailcow, please run \"${COMPOSE_COMMAND} up -d --remove-orphans\" to start mailcow.\e[0m"
 else
   echo -e "\e[32mStarting mailcow...\e[0m"
   sleep 2
-  docker-compose up -d --remove-orphans
+  ${COMPOSE_COMMAND} up -d --remove-orphans
 fi
 
 echo -e "\e[32mCollecting garbage...\e[0m"
@@ -779,4 +740,4 @@ fi
 #echo
 #git reflog --color=always | grep "Before update on "
 #echo
-#echo "Use \"git reset --hard hash-on-the-left\" and run docker-compose up -d afterwards."
+#echo "Use \"git reset --hard hash-on-the-left\" and run ${COMPOSE_COMMAND} up -d afterwards."

--- a/update.sh
+++ b/update.sh
@@ -698,9 +698,6 @@ fi
 
 # Checking for old project name bug
 sed -i --follow-symlinks 's#COMPOSEPROJECT_NAME#COMPOSE_PROJECT_NAME#g' mailcow.conf
-# Checking old, wrong bindings
-sed -i --follow-symlinks 's/HTTP_BIND=0.0.0.0/HTTP_BIND=/g' mailcow.conf
-sed -i --follow-symlinks 's/HTTPS_BIND=0.0.0.0/HTTPS_BIND=/g' mailcow.conf
 
 # Fix Rspamd maps
 if [ -f data/conf/rspamd/custom/global_from_blacklist.map ]; then

--- a/update.sh
+++ b/update.sh
@@ -44,7 +44,9 @@ for bin in curl docker git awk sha1sum; do
   if [[ -z $(which ${bin}) ]]; then echo "Cannot find ${bin}, exiting..."; exit 1; fi
 done
 
-if docker compose version --short | grep "^2" > /dev/null 2>&1
+
+echo "checking docker compose version...";
+if docker --help | grep compose
 then
      COMPOSE_COMMAND="docker compose"
 


### PR DESCRIPTION
This PR includes the official Docker Compose v2 Support for the mailcow Stack.

It has been tested but might have some deep dive issues.

The mailcow Stack is also still usable with Compose v1.

**Caution: As a compatibility reason, from 2022-06 until the 2022-12 update, the web interface will only be accessible via v4 (see Changelog from Docker: https://docs.docker.com/engine/release-notes/#20106 ,PR: https://github.com/mailcow/mailcow-dockerized/pull/4531 and Issue: https://github.com/mailcow/mailcow-dockerized/issues/4315) as a temporary workaround, the IPv6 bind must be set in an extra docker-compose.override.yml (see [docs](https://mailcow.github.io/mailcow-dockerized-docs/post_installation/firststeps-ip_bindings/), after 2022-06 release).**

**The other Containers are not affected.**