### PR TITLE
Netfilter base image update

### DIFF
--- a/data/Dockerfiles/netfilter/Dockerfile
+++ b/data/Dockerfiles/netfilter/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
 ENV XTABLES_LIBDIR /usr/lib/xtables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -422,7 +422,7 @@ services:
             - acme
 
     netfilter-mailcow:
-      image: mailcow/netfilter:1.47
+      image: mailcow/netfilter:1.48
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow


### PR DESCRIPTION
Updates Netfilter image to Alpine 3.16
**mailcow/netfilter:1.48** is available on Docker Hub
