### PR TITLE
Watchdog base image update

### DIFF
--- a/data/Dockerfiles/watchdog/Dockerfile
+++ b/data/Dockerfiles/watchdog/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 LABEL maintainer "André Peters <andre.peters@servercow.de>"
 
 # Installation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -445,7 +445,7 @@ services:
         - /lib/modules:/lib/modules:ro
 
     watchdog-mailcow:
-      image: mailcow/watchdog:1.96
+      image: mailcow/watchdog:1.97
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       tmpfs:


### PR DESCRIPTION
Updates Watchdog image to Alpine 3.16
**mailcow/watchdog:1.97** is available on Docker Hub