### PR TITLE
Unbound base image update

### DIFF
--- a/data/Dockerfiles/unbound/Dockerfile
+++ b/data/Dockerfiles/unbound/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
 
     unbound-mailcow:
-      image: mailcow/unbound:1.15
+      image: mailcow/unbound:1.16
       environment:
         - TZ=${TZ}
       volumes:


### PR DESCRIPTION
Updates Unbound image to Alpine 3.16
**mailcow/unbound:1.16** is available on Docker Hub