### PR TITLE
Olefy base image update

### DIFF
--- a/data/Dockerfiles/olefy/Dockerfile
+++ b/data/Dockerfiles/olefy/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -541,7 +541,7 @@ services:
             - solr
 
     olefy-mailcow:
-      image: mailcow/olefy:1.9
+      image: mailcow/olefy:1.10
       restart: always
       environment:
         - TZ=${TZ}


### PR DESCRIPTION
Updates Dockerapi image to Alpine 3.16
**mailcow/olefy:1.10** is available on Docker Hub