### PR TITLE
Dockerapi base image update

### DIFF
--- a/data/Dockerfiles/dockerapi/Dockerfile
+++ b/data/Dockerfiles/dockerapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -507,7 +507,7 @@ services:
             - watchdog
 
     dockerapi-mailcow:
-      image: mailcow/dockerapi:1.41
+      image: mailcow/dockerapi:1.42
       security_opt:
         - label=disable
       restart: always


### PR DESCRIPTION
Updates Dockerapi image to Alpine 3.16
**mailcow/dockerapi:1.42** is available on Docker Hub