### PR TITLE
Update SOGo to 5.7.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,7 +168,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: mailcow/sogo:1.108
+      image: mailcow/sogo:1.109
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}


### PR DESCRIPTION
This PR updates SOGo to 5.7.0
Releasenotes: https://github.com/inverse-inc/sogo/releases/tag/SOGo-5.7.0

New image **mailcow/sogo:1.109** on Dockerhub available
