### PR TITLE
Fix Docker Healthcheck for Clamd Container

### DIFF
--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -8,8 +8,14 @@ RUN apk upgrade --no-cache \
   bind-tools \
   bash 
 
-COPY clamd.sh ./
+# init
+COPY clamd.sh /clamd.sh
 RUN chmod +x /sbin/tini
+
+# healthcheck
+COPY healthcheck.sh /healthcheck.sh
+RUN chmod +x /healthcheck.sh
+HEALTHCHECK --start-period=6m CMD "/healthcheck.sh"
 
 ENTRYPOINT []
 CMD ["/sbin/tini", "-g", "--", "/clamd.sh"]

--- a/data/Dockerfiles/clamd/healthcheck.sh
+++ b/data/Dockerfiles/clamd/healthcheck.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ "${SKIP_CLAMD}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+  echo "SKIP_CLAMD=y, skipping ClamAV..."
+  exit 0
+fi
+
+# run clamd healthcheck
+/usr/local/bin/clamdcheck.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
             - redis
 
     clamd-mailcow:
-      image: mailcow/clamd:1.52
+      image: mailcow/clamd:1.53
       restart: always
       depends_on:
         - unbound-mailcow


### PR DESCRIPTION
## Problem

Mailcow uses the Docker image `clamav/clamav:0.105.0_base`, which [includes](https://github.com/Cisco-Talos/clamav/blob/74887875db9a204db8396260b4d075c732a2c6fa/Dockerfile#L115) a health check that verifies that clamd is running. This health check is automatically inherited and is therefore also present in `mailcow/clamd:1.52`.

```shell
$ docker inspect mailcow_clamd-mailcow_1 | grep Healthcheck -A7
            "Healthcheck": {
                "Test": [
                    "CMD-SHELL",
                    "\"clamdcheck.sh\""
                ],
                "StartPeriod": 360000000000
            },
            "Image": "mailcow/clamd:1.52",
```

The problem now is: This health check fails if the user has set `SKIP_CLAMD=y`, because then no clamd is running.

(Takes 6 minutes, because `--start-period=6m` is [set](https://github.com/Cisco-Talos/clamav/blob/74887875db9a204db8396260b4d075c732a2c6fa/Dockerfile#L115)).

```shell
$ docker-compose ps | grep clamd
mailcowdockerized_clamd-mailcow_1       /sbin/tini -g -- /clamd.sh       Up (unhealthy)   3310/tcp, 7357/tcp                                                                                                                                                                                                          
```

See also: #4633

## Solutions

Solutions:

1. Remove health check
2. or include an `exit 0` if `SKIP_CLAMD=y` is set

This pull request contains the second solution.

Code explanations:

```diff
+ # healthcheck
+ COPY healthcheck.sh /healthcheck.sh
+ RUN chmod +x /healthcheck.sh
+ HEALTHCHECK --start-period=6m CMD "/healthcheck.sh"
```

Adds a custom healthcheck bash script to the image.

* The healthcheck fails only after 6 minutes, because clamd needs a while to start
* `healthcheck.sh` checks `SKIP_CLAMD`
  * If `SKIP_CLAMD` is set to `y`: `exit 0`
  * If `SKIP_CLAMD` is set to `n`: runs clamd own health check
* `healthcheck.sh` uses the same mechanism for `SKIP_CLAMD` detection as already used in `clamd.sh`

---

```diff
-COPY clamd.sh ./
+COPY clamd.sh /clamd.sh
```

Use an absolute path. See: [DL3045](https://github.com/hadolint/hadolint/wiki/DL3045) (Best practice, but not necessary for this pull request)

## Tests

- [x] Docker container is healthy if `SKIP_CLAMD` is set to `y`
- [x] Docker container is healthy if `SKIP_CLAMD` is set to `n`

Also manually checked, with `SKIP_CLAMD` set to `y`:

```shell
$ docker exec -it mailcowdockerized_clamd-mailcow_1 sh
/ # /healthcheck.sh
SKIP_CLAMD=y, skipping ClamAV...
/ # echo $?
0
```

and set to `n`:

```shell
# with SKIP_CLAMD set to n
$ docker exec -it mailcowdockerized_clamd-mailcow_1 sh
/ # /healthcheck.sh
Clamd is up
/ # echo $?
0
```