### PR TITLE
[Dovecot] Update to 2.3.19.1

### DIFF
--- a/data/Dockerfiles/dovecot/Dockerfile
+++ b/data/Dockerfiles/dovecot/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bullseye-slim
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG DOVECOT=2.3.18
+ARG DOVECOT=2.3.19.1
 ENV LC_ALL C
 ENV GOSU_VERSION 1.14
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,7 +215,7 @@ services:
             - sogo
 
     dovecot-mailcow:
-      image: mailcow/dovecot:1.162
+      image: mailcow/dovecot:1.17
       depends_on:
         - mysql-mailcow
       dns:


### PR DESCRIPTION
Dockertag will be **mailcow/dovecot:1.17** (already pushed)

Changelog of Dovecot 2.3.19 - 2.3.19.1: https://dovecot.org/doc/NEWS