### PR TITLE
[CI] Added Mailcow tests & image builds

### DIFF
--- a/.github/workflows/image_builds.yml
+++ b/.github/workflows/image_builds.yml
@@ -1,0 +1,41 @@
+name: Build Mailcow Docker Images
+
+on:
+  push:
+    branches: [ "master", "staging" ]
+  workflow_dispatch:
+
+jobs:
+  docker_image_builds:
+    strategy:
+      matrix:
+        images: ["acme-mailcow",
+                 "clamd-mailcow",
+                 "dockerapi-mailcow",
+                 "dovecot-mailcow",
+                 "netfilter-mailcow",
+                 "olefy-mailcow",
+                 "php-fpm-mailcow",
+                 "postfix-mailcow",
+                 "rspamd-mailcow",
+                 "sogo-mailcow",
+                 "solr-mailcow",
+                 "unbound-mailcow",
+                 "watchdog-mailcow"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Docker
+        run: |
+          curl -sSL https://get.docker.com/ | CHANNEL=stable sudo sh
+          sudo service docker start
+          sudo curl -L https://github.com/docker/compose/releases/download/v$(curl -Ls https://www.servercow.de/docker-compose/latest.php)/docker-compose-$(uname -s)-$(uname -m) > /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+      - name: Prepair Image Builds
+        run: |
+          cp helper-scripts/docker-compose.override.yml.d/BUILD_FLAGS/docker-compose.override.yml docker-compose.override.yml
+      - name: Build Docker Images
+        run: |
+          docker-compose build ${image}
+        env:
+          image: ${{ matrix.images }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,60 @@
+name: Mailcow Integration Tests
+
+on:
+  push:
+    branches: [ "master", "staging" ]
+  workflow_dispatch:
+
+jobs:
+  integration_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Ansible
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install python3 python3-pip git
+          sudo pip3 install ansible
+      - name: Prepair Test Environment
+        run: |
+          git clone https://github.com/mailcow/mailcow-integration-tests.git --branch $(curl -sL https://api.github.com/repos/mailcow/mailcow-integration-tests/releases/latest | jq -r '.tag_name') --single-branch .
+          ./fork_check.sh
+          ./ci.sh
+          ./ci-pip-requirements.sh
+        env:
+          VAULT_PW: ${{ secrets.MAILCOW_TESTS_VAULT_PW }}
+          VAULT_FILE: ${{ secrets.MAILCOW_TESTS_VAULT_FILE }}
+      - name: Start Integration Test Server
+        run: |
+          ./fork_check.sh
+          ansible-playbook mailcow-start-server.yml --diff
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          ANSIBLE_HOST_KEY_CHECKING: 'false'
+      - name: Setup Integration Test Server
+        run: |
+          ./fork_check.sh
+          sleep 30
+          ansible-playbook mailcow-setup-server.yml --private-key id_ssh_rsa --diff
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          ANSIBLE_HOST_KEY_CHECKING: 'false'
+      - name: Run Integration Tests
+        run: |
+          ./fork_check.sh
+          ansible-playbook mailcow-integration-tests.yml --private-key id_ssh_rsa --diff
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          ANSIBLE_HOST_KEY_CHECKING: 'false'
+      - name: Delete Integration Test Server
+        if: always()
+        run: |
+          ./fork_check.sh
+          ansible-playbook mailcow-delete-server.yml --diff
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          ANSIBLE_HOST_KEY_CHECKING: 'false'

--- a/.github/workflows/tweet-trigger-publish-release.yml
+++ b/.github/workflows/tweet-trigger-publish-release.yml
@@ -1,4 +1,4 @@
-name: "tweet-trigger-release"
+name: "Tweet trigger release"
 on:
   release:
     types: [published]


### PR DESCRIPTION
This MR adds the mailcow integration tests to run via GitHub CI/CD. It also adds a build for the Docker images on overy push using a matrix build which is quite performant (it takes 5 minutes for all images). The images are not yet pushed anywhere just build.

P.S. I also renamed the twitter job name because it triggered me that it uses dashes instead of spaces like the other ones.