### PR TITLE
Update sieve extension rules

### DIFF
--- a/data/web/inc/lib/sieve/extensions/copy.xml
+++ b/data/web/inc/lib/sieve/extensions/copy.xml
@@ -2,7 +2,7 @@
 
 <extension name="copy">
 
-	<tagged-argument extends="(fileinto|redirect)">
+	<tagged-argument extends="(fileinto|redirect|pipe)">
 		<parameter type="tag" name="copy" regex="copy" occurrence="optional" />
 	</tagged-argument>
 

--- a/data/web/inc/lib/sieve/extensions/duplicate.xml
+++ b/data/web/inc/lib/sieve/extensions/duplicate.xml
@@ -3,7 +3,16 @@
 <extension name="duplicate">
 
 	<test name="duplicate">
-
+		<parameter type="tag" name="header" regex="(header|uniqueid)" occurrence="optional">
+			<parameter type="string" name="value" />
+		</parameter>
+		<parameter type="tag" name="handle" regex="handle" occurrence="optional">
+			<parameter type="string" name="handle" />
+		</parameter>
+		<parameter type="tag" name="seconds" regex="seconds" occurrence="optional">
+			<parameter type="number" name="timeout" />
+		</parameter>
+		<parameter type="tag" name="last" regex="last" occurrence="optional" />
 	</test>
 
 </extension>

--- a/data/web/inc/lib/sieve/extensions/fileinto.xml
+++ b/data/web/inc/lib/sieve/extensions/fileinto.xml
@@ -3,7 +3,7 @@
 <extension name="fileinto">
 
 	<command name="fileinto">
-    <parameter type="tag" name="create" regex="create" occurrence="optional" />
+		<parameter type="tag" name="create" regex="create" occurrence="optional" />
 		<parameter type="string" name="folder" />
 	</command>
 

--- a/data/web/inc/lib/sieve/extensions/variables.xml
+++ b/data/web/inc/lib/sieve/extensions/variables.xml
@@ -18,4 +18,10 @@
 		<parameter type="stringlist" name="key list" />
 	</test>
 
+	<tagged-argument extends="execute">
+		<parameter type="tag" name="output" regex="output" occurrence="optional">
+			<parameter type="string" name="varname" />
+		</parameter>
+	</tagged-argument>
+
 </extension>

--- a/data/web/inc/lib/sieve/extensions/vnd.dovecot.execute.xml
+++ b/data/web/inc/lib/sieve/extensions/vnd.dovecot.execute.xml
@@ -3,13 +3,17 @@
 <extension name="vnd.dovecot.execute">
 
 	<test name="execute">
-		<parameter type="tag" name="pipe" regex="pipe" occurrence="optional"/>
+		<parameter type="tag" name="pipe" regex="(pipe|input)" occurrence="optional">
+			<parameter type="string" name="input-data" follows="input" />
+		</parameter>
 		<parameter type="string" name="program-name"/>
 		<parameter type="stringlist" name="arguments" occurrence="optional"/>
 	</test>
 
 	<command name="execute">
-		<parameter type="tag" name="pipe" regex="pipe" occurrence="optional"/>
+		<parameter type="tag" name="pipe" regex="(pipe|input)" occurrence="optional">
+			<parameter type="string" name="input-data" follows="input" />
+		</parameter>
 		<parameter type="string" name="program-name"/>
 		<parameter type="stringlist" name="arguments" occurrence="optional"/>
 	</command>


### PR DESCRIPTION
Updated the following extensions according to their RFC specs:

- [duplicate](https://www.rfc-editor.org/rfc/rfc7352.html)
    - `:handle <handle: string>`
    - `:header <header-name: string>` or `:uniqueid <value: string>`
    - `:seconds <timeout: number>`
    - `:last`
- [execute](https://github.com/dovecot/pigeonhole/blob/main/doc/rfc/spec-bosch-sieve-extprograms.txt)
    - `:input <input-data: string>`
    - `:output <varname: string>` if using the variables extension
- [pipe](https://github.com/dovecot/pigeonhole/blob/main/doc/rfc/spec-bosch-sieve-extprograms.txt)
    - `:copy` if using the copy extension