### PR TITLE
fix blank page on /user when not logged

### DIFF
--- a/data/web/user.php
+++ b/data/web/user.php
@@ -91,8 +91,7 @@ elseif (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == '
     'number_of_app_passwords' => $number_of_app_passwords,
   ];
 }
-
-if (!isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == 'admin') {
+else {
   header('Location: /');
   exit();
 }


### PR DESCRIPTION
the current condition to redirect to / was never matching, so a blank page was displayed on /user when not logged in or when logged in as admin.
this will fix it and always redirect to / if nothing is rendered in the user.php