### PR TITLE
add api get user-acl

### DIFF
--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -688,6 +688,14 @@ if (isset($_GET['query'])) {
             }
           break;
 
+          case "user-acl":
+            switch ($object) {
+              default:
+                process_get_return(acl('get', 'user', $object));
+              break;
+            }
+          break;
+
           case "relayhost":
             switch ($object) {
               case "all":


### PR DESCRIPTION
add api /get/user-acl

A possibility to get user-acl is necessary to integrate a terraform resource user-acl in the [terraform-provider-mailcow](https://registry.terraform.io/providers/l-with/mailcow/).

The implementation is done by adapting the php code for get fail2ban in json_api.php and interpreting the function acl in functions.acl.inc.php

I hope, I produced functional code by this unconventional way adding functionality to the api.
Please give me advice if this is not the case.

I offer to add the API specification in another pull request, therefore I need to try the new endpoint to have a look at the json output.
