### PR TITLE
[DB] Update tfa keyHandle max length to 1023

### DIFF
--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -3,7 +3,7 @@ function init_db_schema() {
   try {
     global $pdo;
 
-    $db_version = "13072022_1700";
+    $db_version = "25072022_2300";
 
     $stmt = $pdo->query("SHOW TABLES LIKE 'versions'");
     $num_results = count($stmt->fetchAll(PDO::FETCH_ASSOC));
@@ -738,7 +738,7 @@ function init_db_schema() {
           "username" => "VARCHAR(255) NOT NULL",
           "authmech" => "ENUM('yubi_otp', 'u2f', 'hotp', 'totp', 'webauthn')",
           "secret" => "VARCHAR(255) DEFAULT NULL",
-          "keyHandle" => "VARCHAR(255) DEFAULT NULL",
+          "keyHandle" => "VARCHAR(1023) DEFAULT NULL",
           "publicKey" => "VARCHAR(4096) DEFAULT NULL",
           "counter" => "INT NOT NULL DEFAULT '0'",
           "certificate" => "TEXT",


### PR DESCRIPTION
Recently my [Solo V2](https://www.kickstarter.com/projects/conorpatrick/solo-v2-safety-net-against-phishing) security key arrived.

However, adding it to Mailcow as a 2FA method results in the following error:
> Error code: Error: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'keyHandle' at row 1 - (reload browser if the error persists)

This turned out to be because Mailcow enforces a maximum `keyHandle` size of 255, while the one used by Solo V2 is larger than 255. This apparently also affects other keys, like Nitrokey 3

The WebAuthn specification defines the maximum size as 1023: https://w3c.github.io/webauthn/#credential-id
> Credential ID
> 
> A probabilistically-unique byte sequence identifying a public key credential source and its authentication assertions. At most 1023 bytes long.

This was not always the case, but was changed here: https://github.com/w3c/webauthn/pull/1664
With reasoning here: https://github.com/w3c/webauthn/pull/1664#issuecomment-916089235

See also:
https://github.com/go-gitea/gitea/issues/20457
https://gitlab.com/gitlab-org/gitlab/-/issues/349596

This PR updates the `keyHandle` in `tfa` to support up to 1023 characters, and has been tested on my own instance.
I also took a stab at updating the `$db_version`, please feel free to correct this if it was done wrongly.