### PR TITLE
Improve send-as behaviour

### DIFF
--- a/.github/workflows/close_old_issues_and_prs.yml
+++ b/.github/workflows/close_old_issues_and_prs.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Mark/Close Stale Issues and Pull Requests 🗑️
-        uses: actions/stale@v5.1.0
+        uses: actions/stale@v5.1.1
         with:
           repo-token: ${{ secrets.STALE_ACTION_PAT }}
           days-before-stale: 60

--- a/data/Dockerfiles/postfix/postfix.sh
+++ b/data/Dockerfiles/postfix/postfix.sh
@@ -323,7 +323,19 @@ hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 # First select queries domain and alias_domain to determine if domains are active.
 query = SELECT goto FROM alias
-  WHERE address='%s'
+  WHERE id IN (
+      SELECT COALESCE (
+        (
+          SELECT id FROM alias
+            WHERE address='%s'
+            AND (active='1' OR active='2')
+        ), (
+          SELECT id FROM alias
+            WHERE address='@%d'
+            AND (active='1' OR active='2')
+        )
+      )
+    )
     AND active='1'
     AND (domain IN
       (SELECT domain FROM domain
@@ -354,7 +366,7 @@ query = SELECT goto FROM alias
     WHERE alias_domain.alias_domain = '%d'
       AND mailbox.username = CONCAT('%u','@',alias_domain.target_domain)
       AND (mailbox.active = '1' OR mailbox.active ='2')
-      AND alias_domain.active='1'
+      AND alias_domain.active='1';
 EOF
 
 # MX based routing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -295,7 +295,7 @@ services:
             - dovecot
 
     postfix-mailcow:
-      image: mailcow/postfix:1.67
+      image: mailcow/postfix:1.68
       depends_on:
         - mysql-mailcow
       volumes:


### PR DESCRIPTION
Receiving mails for wildcard alias addresses is really easy – but sending mails from those any-aliases was not possible at all unless every sender address was added as an explicit alias to the database.

By this change in the database query for allowed sender addresses, the first finding `not NULL` (see [`SELECT COALESCE`](https://www.w3schools.com/sql/func_sqlserver_coalesce.asp) for how it works) – either an exact alias `mailbox@domain.tld` or the wildcard alias `@domain.tld` will be allowed to send mails as the given address ... without the need of explicit definition within the database.

I hope, you find this change useful and consider adding this feature to the official project =)