### PR TITLE
[web] Fix: dns_diagnostics.php SPF DNS lookup loop

### DIFF
--- a/data/web/inc/spf.inc.php
+++ b/data/web/inc/spf.inc.php
@@ -26,7 +26,7 @@ function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false) {
 				$mod = explode('=', $mech);
 				if ($mod[0] == 'redirect') // handle a redirect
 				{
-					array_push($checked_domains, $check_domain);
+					array_push($checked_domains, $mod[1]);
 					$hosts = get_spf_allowed_hosts($mod[1],true);
 					return $hosts;
 				}
@@ -52,7 +52,7 @@ function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false) {
 				$new_hosts = array();
         if ($mech == 'include' && $check_domain != $domain && !in_array($check_domain, $checked_domains)) // handle an inclusion
 				{
-					array_push($checked_domains, $check_domain);
+					array_push($checked_domains, $domain);
 					$new_hosts = get_spf_allowed_hosts($domain);
 				}
 				elseif ($mech == 'a') // handle a mechanism

--- a/data/web/inc/spf.inc.php
+++ b/data/web/inc/spf.inc.php
@@ -1,6 +1,6 @@
 <?php
 error_reporting(0);
-function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false) {
+function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false, $original_domain = "") {
 	$hosts = array();
 	
 	$records = dns_get_record($check_domain, DNS_TXT);
@@ -24,7 +24,7 @@ function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false) {
 				$mod = explode('=', $mech);
 				if ($mod[0] == 'redirect') // handle a redirect
 				{
-					$hosts = get_spf_allowed_hosts($mod[1],true);
+					$hosts = get_spf_allowed_hosts($mod[1],true, $check_domain);
 					return $hosts;
 				}
 			}
@@ -47,9 +47,9 @@ function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false) {
 				}
 				
 				$new_hosts = array();
-        if ($mech == 'include' && $check_domain != $domain) // handle an inclusion
+        if ($mech == 'include' && $check_domain != $domain && $original_domain != $domain) // handle an inclusion
 				{
-					$new_hosts = get_spf_allowed_hosts($domain);
+					$new_hosts = get_spf_allowed_hosts($domain, false, $check_domain);
 				}
 				elseif ($mech == 'a') // handle a mechanism
 				{
@@ -133,7 +133,7 @@ function get_a_hosts($domain)
 function get_outgoing_hosts_best_guess($domain)
 {
 	// try the SPF record to get hosts that are allowed to send outgoing mails for this domain
-	$hosts = get_spf_allowed_hosts($domain);
+	$hosts = get_spf_allowed_hosts($domain, false, $check_domain);
 	if ($hosts) return $hosts;
 	
 	// try the MX record to get mail servers for this domain

--- a/data/web/inc/spf.inc.php
+++ b/data/web/inc/spf.inc.php
@@ -47,7 +47,7 @@ function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false, $original_do
 				}
 				
 				$new_hosts = array();
-        if ($mech == 'include' && $check_domain != $domain && $original_domain != $domain) // handle an inclusion
+				if ($mech == 'include' && $check_domain != $domain && $original_domain != $domain) // handle an inclusion
 				{
 					$new_hosts = get_spf_allowed_hosts($domain, false, $check_domain);
 				}

--- a/data/web/inc/spf.inc.php
+++ b/data/web/inc/spf.inc.php
@@ -1,8 +1,6 @@
 <?php
 error_reporting(0);
-$checked_domains = array();
-function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false) {
-	global $checked_domains;
+function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false, $checked_domains = array()) {
 	$hosts = array();
 	
 	$records = dns_get_record($check_domain, DNS_TXT);
@@ -27,7 +25,7 @@ function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false) {
 				if ($mod[0] == 'redirect' && !in_array($mod[1], $checked_domains)) // handle a redirect
 				{
 					array_push($checked_domains, $mod[1]);
-					$hosts = get_spf_allowed_hosts($mod[1],true);
+					$hosts = get_spf_allowed_hosts($mod[1],true, $checked_domains);
 					return $hosts;
 				}
 			}
@@ -53,7 +51,7 @@ function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false) {
         if ($mech == 'include' && $check_domain != $domain && !in_array($domain, $checked_domains)) // handle an inclusion
 				{
 					array_push($checked_domains, $domain);
-					$new_hosts = get_spf_allowed_hosts($domain);
+					$new_hosts = get_spf_allowed_hosts($domain, false, $checked_domains);
 				}
 				elseif ($mech == 'a') // handle a mechanism
 				{

--- a/data/web/inc/spf.inc.php
+++ b/data/web/inc/spf.inc.php
@@ -24,7 +24,7 @@ function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false) {
 			if (strpos($mech, '=') !== FALSE) // handle a modifier
 			{
 				$mod = explode('=', $mech);
-				if ($mod[0] == 'redirect') // handle a redirect
+				if ($mod[0] == 'redirect' && !in_array($mod[1], $checked_domains)) // handle a redirect
 				{
 					array_push($checked_domains, $mod[1]);
 					$hosts = get_spf_allowed_hosts($mod[1],true);
@@ -50,7 +50,7 @@ function get_spf_allowed_hosts($check_domain, $expand_ipv6 = false) {
 				}
 				
 				$new_hosts = array();
-        if ($mech == 'include' && $check_domain != $domain && !in_array($check_domain, $checked_domains)) // handle an inclusion
+        if ($mech == 'include' && $check_domain != $domain && !in_array($domain, $checked_domains)) // handle an inclusion
 				{
 					array_push($checked_domains, $domain);
 					$new_hosts = get_spf_allowed_hosts($domain);


### PR DESCRIPTION
### Description

### The problem:
When using dns diagnostics to check SPF records, a possible loop can occur.
If the domain has an SPF record pointing to another domain that has an SPF record referencing the original via `include:`.
This causes an infinite stall.

### Example: 
- call dns_diagnostics.php?domain=example.com
- example.com has an SPF record with `include:mail.example.com`
- mail.example.com has an SPF record with `include:example.com`

### The fix:
I appended `, $original_domain = ""` to the `get_spf_allowed_hosts(..` function in `data/web/inc/spf.inc.php` and also set every call within `spf.inc.php` to pass `$check_domain` to this new argument. Then by adding an additional check on line 50 for this original domain ` && $original_domain != $domain` it correctly stops after one loop as we're back on the original domain.

Closes #4715 