### PR TITLE
[Update.sh] User Decision of which Compose Version they want to use (min v2)

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -135,8 +135,6 @@ else
   SKIP_SOLR=n
 fi
 
-if []
-
 [ ! -f ./data/conf/rspamd/override.d/worker-controller-password.inc ] && echo '# Placeholder' > ./data/conf/rspamd/override.d/worker-controller-password.inc
 
 cat << EOF > mailcow.conf

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -16,18 +16,48 @@ if [[ "$(uname -r)" =~ ^4\.4\. ]]; then
   fi
 fi
 
-if grep --help 2>&1 | grep -q -i "busybox"; then
-  echo "BusyBox grep detected, please install gnu grep, \"apk add --no-cache --upgrade grep\""
-  exit 1
-fi
-if cp --help 2>&1 | grep -q -i "busybox"; then
-  echo "BusyBox cp detected, please install coreutils, \"apk add --no-cache --upgrade coreutils\""
-  exit 1
-fi
+if grep --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusyBox grep detected, please install gnu grep, \"apk add --no-cache --upgrade grep\""; exit 1; fi
+# This will also cover sort
+if cp --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusyBox cp detected, please install coreutils, \"apk add --no-cache --upgrade coreutils\""; exit 1; fi
+if sed --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusyBox sed detected, please install gnu sed, \"apk add --no-cache --upgrade sed\""; exit 1; fi
 
-for bin in openssl curl docker docker-compose git awk sha1sum; do
+for bin in openssl curl docker git awk sha1sum; do
   if [[ -z $(which ${bin}) ]]; then echo "Cannot find ${bin}, exiting..."; exit 1; fi
 done
+
+if docker compose > /dev/null 2>&1; then
+    if docker compose version --short | grep "^2." > /dev/null 2>&1; then
+      COMPOSE_VERSION=native
+      echo -e "\e[31mFound Docker Compose Plugin (native).\e[0m"
+      echo -e "\e[31mSetting the DOCKER_COMPOSE_VERSION Variable to native\e[0m"
+      sleep 2
+      echo -e "\e[33mNotice: You´ll have to update this Compose Version via your Package Manager manually!\e[0m"
+    else
+      echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m" 
+      echo -e "\e[31mPlease update it manually regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
+      exit 1
+    fi
+elif docker-compose > /dev/null 2>&1; then
+  if ! [[ $(alias docker-compose 2> /dev/null) ]] ; then
+    if docker-compose version --short | grep "^2." > /dev/null 2>&1; then
+      COMPOSE_VERSION=standalone
+      echo -e "\e[31mFound Docker Compose Standalone.\e[0m"
+      echo -e "\e[31mSetting the DOCKER_COMPOSE_VERSION Variable to standalone\e[0m"
+      sleep 2
+      echo -e "\e[33mNotice: You´ll have to update this Compose Version manually! Please see: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
+    else
+      echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m" 
+      echo -e "\e[31mPlease update manually regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
+      exit 1
+    fi
+  fi
+
+else
+  echo -e "\e[31mCannot find Docker Compose.\e[0m" 
+  echo -e "\e[31mPlease install it regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
+  exit 1
+fi
+    
 
 if [ -f mailcow.conf ]; then
   read -r -p "A config file exists and will be overwritten, are you sure you want to continue? [y/N] " response
@@ -104,6 +134,8 @@ elif [ ${MEM_TOTAL} -le "3670016" ]; then
 else
   SKIP_SOLR=n
 fi
+
+if []
 
 [ ! -f ./data/conf/rspamd/override.d/worker-controller-password.inc ] && echo '# Placeholder' > ./data/conf/rspamd/override.d/worker-controller-password.inc
 
@@ -182,6 +214,12 @@ TZ=${MAILCOW_TZ}
 # Please use lowercase letters only
 
 COMPOSE_PROJECT_NAME=mailcowdockerized
+
+# Used Docker Compose version
+# Switch here between native (compose plugin) and standalone
+# For more informations take a look at the mailcow docs regarding the configuration options.
+
+DOCKER_COMPOSE_VERSION=${COMPOSE_VERSION}
 
 # Set this to "allow" to enable the anyone pseudo user. Disabled by default.
 # When enabled, ACL can be created, that apply to "All authenticated users"

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -216,6 +216,8 @@ COMPOSE_PROJECT_NAME=mailcowdockerized
 # Used Docker Compose version
 # Switch here between native (compose plugin) and standalone
 # For more informations take a look at the mailcow docs regarding the configuration options.
+# Normally this should be untouched but if you decided to use either of those you can switch it manually here.
+# Please be aware that at least one of those variants should be installed on your maschine or mailcow will fail.
 
 DOCKER_COMPOSE_VERSION=${COMPOSE_VERSION}
 

--- a/helper-scripts/update_compose.sh
+++ b/helper-scripts/update_compose.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source ${SCRIPT_DIR}/../mailcow.conf
+
+if [ "${DOCKER_COMPOSE_VERSION}" == "standalone" ]; then
+LATEST_COMPOSE=$(curl -#L https://www.servercow.de/docker-compose/latest.php)
+COMPOSE_VERSION=$(docker-compose version --short)
+if [[ "$LATEST_COMPOSE" != "$COMPOSE_VERSION" ]]; then
+  echo -e "\e[33mA new docker-compose Version is available: $LATEST_COMPOSE\e[0m"
+  echo -e "\e[33mYour Version is: $COMPOSE_VERSION\e[0m"
+else
+  echo -e "\e[32mYour docker-compose Version is up to date! Not updating it...\e[0m"
+  exit 0 
+fi
+read -r -p "Do you want to update your docker-compose Version? It will automatic upgrade your docker-compose installation (recommended)? [y/N] " updatecomposeresponse 
+    if [[ ! "${updatecomposeresponse}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+      echo "OK, not updating docker-compose."
+      exit 0
+    fi 
+echo -e "\e[32mFetching new docker-compose (standalone) version...\e[0m"
+echo -e "\e[32mTrying to determine GLIBC version...\e[0m"
+    if ldd --version > /dev/null; then
+        GLIBC_V=$(ldd --version | grep -E '(GLIBC|GNU libc)' | rev | cut -d ' ' -f1 | rev | cut -d '.' -f2)
+        if [ ! -z "${GLIBC_V}" ] && [ ${GLIBC_V} -gt 27 ]; then
+        DC_DL_SUFFIX=
+        else
+        DC_DL_SUFFIX=legacy
+        fi
+    else
+        DC_DL_SUFFIX=legacy
+    fi
+    sleep 1
+    if [[ $(command -v pip 2>&1) && $(pip list --local 2>&1 | grep -v DEPRECATION | grep -c docker-compose) == 1 || $(command -v pip3 2>&1) && $(pip3 list --local 2>&1 | grep -v DEPRECATION | grep -c docker-compose) == 1 ]]; then
+        echo -e "\e[33mFound a docker-compose Version installed with pip!\e[0m"
+        echo -e "\e[31mPlease uninstall the pip Version of docker-compose since it doesn´t support Versions higher than 1.29.2.\e[0m"
+        sleep 2
+        echo -e "\e[33mExiting...\e[0m"
+        exit 1
+        #prevent breaking a working docker-compose installed with pip
+    elif [[ $(curl -sL -w "%{http_code}" https://www.servercow.de/docker-compose/latest.php?vers=${DC_DL_SUFFIX} -o /dev/null) == "200" ]]; then
+        LATEST_COMPOSE=$(curl -#L https://www.servercow.de/docker-compose/latest.php)
+        COMPOSE_VERSION=$(docker-compose version --short)
+        if [[ "$LATEST_COMPOSE" != "$COMPOSE_VERSION" ]]; then
+        COMPOSE_PATH=$(command -v docker-compose)
+        if [[ -w ${COMPOSE_PATH} ]]; then
+            curl -#L https://github.com/docker/compose/releases/download/v${LATEST_COMPOSE}/docker-compose-$(uname -s)-$(uname -m) > $COMPOSE_PATH
+            chmod +x $COMPOSE_PATH
+            echo -e "\e[32mYour Docker Compose (standalone) has been updated to: $LATEST_COMPOSE\e[0m"
+            exit 0
+        else
+            echo -e "\e[33mWARNING: $COMPOSE_PATH is not writable, but new version $LATEST_COMPOSE is available (installed: $COMPOSE_VERSION)\e[0m"
+            return 1
+        fi
+        fi
+    else
+        echo -e "\e[33mCannot determine latest docker-compose version, skipping...\e[0m"
+        exit 1
+    fi
+
+elif [ "${DOCKER_COMPOSE_VERSION}" == "native" ]; then
+    echo -e "\e[31mYou are using the native Docker Compose Plugin. This Script is for the standalone Docker Compose Version only.\e[0m"
+    sleep 2
+    echo -e "\e[33mNotice: You´ll have to update this Compose Version via your Package Manager manually!\e[0m"
+    exit 1
+
+else
+    echo -e "\e[31mCan not read DOCKER_COMPOSE_VERSION variable from mailcow.conf! Is your mailcow up to date? Exiting...\e[0m"
+    exit 1
+fi

--- a/update.sh
+++ b/update.sh
@@ -646,16 +646,16 @@ else
    fi
 fi
 
-# echo -e "\e[32mChecking for newer update script...\e[0m"
-# SHA1_1=$(sha1sum update.sh)
-# git fetch origin #${BRANCH}
-# git checkout origin/${BRANCH} update.sh
-# SHA1_2=$(sha1sum update.sh)
-# if [[ ${SHA1_1} != ${SHA1_2} ]]; then
-#   echo "update.sh changed, please run this script again, exiting."
-#   chmod +x update.sh
-#   exit 2
-# fi
+echo -e "\e[32mChecking for newer update script...\e[0m"
+SHA1_1=$(sha1sum update.sh)
+git fetch origin #${BRANCH}
+git checkout origin/${BRANCH} update.sh
+SHA1_2=$(sha1sum update.sh)
+if [[ ${SHA1_1} != ${SHA1_2} ]]; then
+  echo "update.sh changed, please run this script again, exiting."
+  chmod +x update.sh
+  exit 2
+fi
 
 if [ ! $FORCE ]; then
   read -r -p "Are you sure you want to update mailcow: dockerized? All containers will be stopped. [y/N] " response

--- a/update.sh
+++ b/update.sh
@@ -419,6 +419,8 @@ for option in ${CONFIG_ARRAY[@]}; do
       echo "# Used Docker Compose version" >> mailcow.conf
       echo "# Switch here between native (compose plugin) and standalone" >> mailcow.conf
       echo "# For more informations take a look at the mailcow docs regarding the configuration options." >> mailcow.conf
+      echo "# Normally this should be untouched but if you decided to use either of those you can switch it manually here." >> mailcow.conf
+      echo "# Please be aware that at least one of those variants should be installed on your maschine or mailcow will fail." >> mailcow.conf
       echo "" >> mailcow.conf
       echo "DOCKER_COMPOSE_VERSION=${DOCKER_COMPOSE_VERSION}" >> mailcow.conf
     fi


### PR DESCRIPTION
This PR will fix the force of the standalone Version from Docker Compose which has been introduced with 2022-06 (https://github.com/mailcow/mailcow-dockerized/issues/4695).

It´ll read the value from a new Variable inside the mailcow.conf which defines the used Docker Compose Version.

On first run (generate-config) or first update with this change it will automatically detect the available Docker Compose Versions on the Maschine.

**Notice: It will always prefer the native Plugin from Docker itself, not the Standalone Version**

The user is able to change that variable manually to say what mailcow should use internally.