### PR TITLE
[Update.sh] Nightly Version Switch implementation + Composev2 User Decision

### DIFF
--- a/data/web/inc/footer.inc.php
+++ b/data/web/inc/footer.inc.php
@@ -48,7 +48,14 @@ if (isset($pending_tfa_authmechs['u2f'])) {
 $globalVariables = [
   'mailcow_info' => array(
     'version_tag' => $GLOBALS['MAILCOW_GIT_VERSION'],
-    'git_project_url' => $GLOBALS['MAILCOW_GIT_URL']
+    'last_version_tag' => $GLOBALS['MAILCOW_LAST_GIT_VERSION'],
+    'git_owner' => $GLOBALS['MAILCOW_GIT_OWNER'],
+    'git_repo' => $GLOBALS['MAILCOW_GIT_REPO'],
+    'git_project_url' => $GLOBALS['MAILCOW_GIT_URL'],
+    'git_commit' => $GLOBALS['MAILCOW_GIT_COMMIT'],
+    'git_commit_date' => $GLOBALS['MAILCOW_GIT_COMMIT_DATE'],
+    'mailcow_branch' => $GLOBALS['MAILCOW_BRANCH'],
+    'updated_at' => $GLOBALS['MAILCOW_UPDATEDAT']
   ),
   'js_path' => '/cache/'.basename($JSPath),
   'pending_tfa_methods' => @$_SESSION['pending_tfa_methods'],

--- a/data/web/templates/base.twig
+++ b/data/web/templates/base.twig
@@ -484,7 +484,7 @@ function recursiveBase64StrToArrayBuffer(obj) {
     </a>
   </span>
   {% endif %}  
-  {% if mailcow_cc_username and mailcow_info.mailcow_branch|lower == "origin/feature/nightly-editions" and mailcow_info.version_tag|default %}
+  {% if mailcow_cc_username and mailcow_info.mailcow_branch|lower == "nightly" and mailcow_info.version_tag|default %}
   <span class="version">
     🛠️🐮 + 🐋 = 💕
         Nightly: <a href="{{ mailcow_info.git_project_url }}/commit/{{ mailcow_info.git_commit }}" target="_blank">{{ mailcow_info.version_tag }}

--- a/data/web/templates/base.twig
+++ b/data/web/templates/base.twig
@@ -477,14 +477,14 @@ function recursiveBase64StrToArrayBuffer(obj) {
   {% if ui_texts.ui_footer %}
   <hr><span class="rot-enc">{{ ui_texts.ui_footer|rot13|raw }}</span>
   {% endif %}
-  {% if mailcow_cc_username and mailcow_info.mailcow_build|lower == "stable" and mailcow_info.version_tag|default %}
+  {% if mailcow_cc_username and mailcow_info.mailcow_branch|lower == "master" and mailcow_info.version_tag|default %}
   <span class="version">
     🐮 + 🐋 = 💕
         Version: <a href="{{ mailcow_info.git_project_url }}/releases/tag/{{ mailcow_info.version_tag }}" target="_blank">{{ mailcow_info.version_tag }}
     </a>
   </span>
   {% endif %}  
-  {% if mailcow_cc_username and mailcow_info.mailcow_build|lower == "nightly" and mailcow_info.version_tag|default %}
+  {% if mailcow_cc_username and mailcow_info.mailcow_branch|lower == "origin/feature/nightly-editions" and mailcow_info.version_tag|default %}
   <span class="version">
     🛠️🐮 + 🐋 = 💕
         Nightly: <a href="{{ mailcow_info.git_project_url }}/commit/{{ mailcow_info.git_commit }}" target="_blank">{{ mailcow_info.version_tag }}

--- a/data/web/templates/base.twig
+++ b/data/web/templates/base.twig
@@ -477,12 +477,19 @@ function recursiveBase64StrToArrayBuffer(obj) {
   {% if ui_texts.ui_footer %}
   <hr><span class="rot-enc">{{ ui_texts.ui_footer|rot13|raw }}</span>
   {% endif %}
-  {% if mailcow_cc_username and mailcow_info.version_tag|default %}
+  {% if mailcow_cc_username and mailcow_info.mailcow_build|lower == "stable" and mailcow_info.version_tag|default %}
   <span class="version">
     🐮 + 🐋 = 💕
-    <a href="{{ mailcow_info.git_project_url }}/releases/tag/{{ mailcow_info.version_tag }}" target="_blank">
-        Version: {{ mailcow_info.version_tag }}
+        Version: <a href="{{ mailcow_info.git_project_url }}/releases/tag/{{ mailcow_info.version_tag }}" target="_blank">{{ mailcow_info.version_tag }}
     </a>
+  </span>
+  {% endif %}  
+  {% if mailcow_cc_username and mailcow_info.mailcow_build|lower == "nightly" and mailcow_info.version_tag|default %}
+  <span class="version">
+    🛠️🐮 + 🐋 = 💕
+        Nightly: <a href="{{ mailcow_info.git_project_url }}/commit/{{ mailcow_info.git_commit }}" target="_blank">{{ mailcow_info.version_tag }}
+    </a><br>
+    <span style="text-align:right;display:block;">Build: {{ mailcow_info.git_commit_date }}</span>
   </span>
   {% endif %}
 </div>

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -420,16 +420,42 @@ echo "Copying snake-oil certificate..."
 cp -n -d data/assets/ssl-example/*.pem data/assets/ssl/
 
 # Set app_info.inc.php
-mailcow_git_version=$(git describe --tags `git rev-list --tags --max-count=1`)
+if [ ${git_branch} == "master" ]; then
+  mailcow_git_version=$(git describe --tags `git rev-list --tags --max-count=1`)
+elif [ ${git_branch} == "nightly" ]; then
+  mailcow_git_version=$(git rev-parse --short $(git rev-parse @{upstream}))
+  mailcow_last_git_version=""
+else
+  mailcow_git_version=$(git rev-parse --short HEAD)
+  mailcow_last_git_version=""
+fi
+
+mailcow_git_commit=$(git rev-parse origin/${git_branch})
+mailcow_git_commit_date=$(git log -1 --format=%ci @{upstream} )
+
 if [ $? -eq 0 ]; then
   echo '<?php' > data/web/inc/app_info.inc.php
   echo '  $MAILCOW_GIT_VERSION="'$mailcow_git_version'";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_LAST_GIT_VERSION="";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_GIT_OWNER="mailcow";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_GIT_REPO="mailcow-dockerized";' >> data/web/inc/app_info.inc.php
   echo '  $MAILCOW_GIT_URL="https://github.com/mailcow/mailcow-dockerized";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_GIT_COMMIT="'$mailcow_git_commit'";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_GIT_COMMIT_DATE="'$mailcow_git_commit_date'";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_BRANCH="'$BRANCH'";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_UPDATEDAT='$(date +%s)';' >> data/web/inc/app_info.inc.php
   echo '?>' >> data/web/inc/app_info.inc.php
 else
   echo '<?php' > data/web/inc/app_info.inc.php
-  echo '  $MAILCOW_GIT_VERSION="";' >> data/web/inc/app_info.inc.php
-  echo '  $MAILCOW_GIT_URL="";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_GIT_VERSION="'$mailcow_git_version'";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_LAST_GIT_VERSION="";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_GIT_OWNER="mailcow";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_GIT_REPO="mailcow-dockerized";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_GIT_URL="https://github.com/mailcow/mailcow-dockerized";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_GIT_COMMIT="";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_GIT_COMMIT_DATE="";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_BRANCH="'$BRANCH'";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_UPDATEDAT='$(date +%s)';' >> data/web/inc/app_info.inc.php
   echo '?>' >> data/web/inc/app_info.inc.php
   echo -e "\e[33mCannot determine current git repository version...\e[0m"
 fi

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -442,7 +442,7 @@ if [ $? -eq 0 ]; then
   echo '  $MAILCOW_GIT_URL="https://github.com/mailcow/mailcow-dockerized";' >> data/web/inc/app_info.inc.php
   echo '  $MAILCOW_GIT_COMMIT="'$mailcow_git_commit'";' >> data/web/inc/app_info.inc.php
   echo '  $MAILCOW_GIT_COMMIT_DATE="'$mailcow_git_commit_date'";' >> data/web/inc/app_info.inc.php
-  echo '  $MAILCOW_BRANCH="'$BRANCH'";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_BRANCH="'$git_branch'";' >> data/web/inc/app_info.inc.php
   echo '  $MAILCOW_UPDATEDAT='$(date +%s)';' >> data/web/inc/app_info.inc.php
   echo '?>' >> data/web/inc/app_info.inc.php
 else
@@ -454,7 +454,7 @@ else
   echo '  $MAILCOW_GIT_URL="https://github.com/mailcow/mailcow-dockerized";' >> data/web/inc/app_info.inc.php
   echo '  $MAILCOW_GIT_COMMIT="";' >> data/web/inc/app_info.inc.php
   echo '  $MAILCOW_GIT_COMMIT_DATE="";' >> data/web/inc/app_info.inc.php
-  echo '  $MAILCOW_BRANCH="'$BRANCH'";' >> data/web/inc/app_info.inc.php
+  echo '  $MAILCOW_BRANCH="'$git_branch'";' >> data/web/inc/app_info.inc.php
   echo '  $MAILCOW_UPDATEDAT='$(date +%s)';' >> data/web/inc/app_info.inc.php
   echo '?>' >> data/web/inc/app_info.inc.php
   echo -e "\e[33mCannot determine current git repository version...\e[0m"

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -135,6 +135,25 @@ else
   SKIP_SOLR=n
 fi
 
+echo "Which branch of mailcow do you want to use?"
+echo ""
+echo "Available Branches:"
+echo "- master branch (stable updates) | default, recommended [1]"
+echo "- nightly branch (unstable updates, testing) | not-production ready [2]"
+sleep 1
+read -r -p  "Choose the Branch with it´s number [1/2] " branch
+  case $branch in
+    [2])
+      git_branch="nightly"
+      ;;
+    *)
+      git_branch="master"
+    ;;
+  esac
+
+git fetch --all
+git checkout -f $git_branch
+
 [ ! -f ./data/conf/rspamd/override.d/worker-controller-password.inc ] && echo '# Placeholder' > ./data/conf/rspamd/override.d/worker-controller-password.inc
 
 cat << EOF > mailcow.conf

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -135,8 +135,6 @@ else
   SKIP_SOLR=n
 fi
 
-if []
-
 [ ! -f ./data/conf/rspamd/override.d/worker-controller-password.inc ] && echo '# Placeholder' > ./data/conf/rspamd/override.d/worker-controller-password.inc
 
 cat << EOF > mailcow.conf

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -34,7 +34,7 @@ if docker compose > /dev/null 2>&1; then
       echo -e "\e[33mNotice: You´ll have to update this Compose Version via your Package Manager manually!\e[0m"
     else
       echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m" 
-      echo -e "\e[31mPlease update it manually regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
+      echo -e "\e[31mPlease update/install it manually regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
       exit 1
     fi
 elif docker-compose > /dev/null 2>&1; then
@@ -44,10 +44,10 @@ elif docker-compose > /dev/null 2>&1; then
       echo -e "\e[31mFound Docker Compose Standalone.\e[0m"
       echo -e "\e[31mSetting the DOCKER_COMPOSE_VERSION Variable to standalone\e[0m"
       sleep 2
-      echo -e "\e[33mNotice: You´ll have to update this Compose Version manually! Please see: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
+      echo -e "\e[33mNotice: For an automatic update of docker-compose please use the update_compose.sh scripts located at the helper-scripts folder.\e[0m"
     else
       echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m" 
-      echo -e "\e[31mPlease update manually regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
+      echo -e "\e[31mPlease update/install manually regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
       exit 1
     fi
   fi

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -16,18 +16,48 @@ if [[ "$(uname -r)" =~ ^4\.4\. ]]; then
   fi
 fi
 
-if grep --help 2>&1 | grep -q -i "busybox"; then
-  echo "BusyBox grep detected, please install gnu grep, \"apk add --no-cache --upgrade grep\""
-  exit 1
-fi
-if cp --help 2>&1 | grep -q -i "busybox"; then
-  echo "BusyBox cp detected, please install coreutils, \"apk add --no-cache --upgrade coreutils\""
-  exit 1
-fi
+if grep --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusyBox grep detected, please install gnu grep, \"apk add --no-cache --upgrade grep\""; exit 1; fi
+# This will also cover sort
+if cp --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusyBox cp detected, please install coreutils, \"apk add --no-cache --upgrade coreutils\""; exit 1; fi
+if sed --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusyBox sed detected, please install gnu sed, \"apk add --no-cache --upgrade sed\""; exit 1; fi
 
-for bin in openssl curl docker docker-compose git awk sha1sum; do
+for bin in openssl curl docker git awk sha1sum; do
   if [[ -z $(which ${bin}) ]]; then echo "Cannot find ${bin}, exiting..."; exit 1; fi
 done
+
+if docker compose > /dev/null 2>&1; then
+    if docker compose version --short | grep "^2." > /dev/null 2>&1; then
+      COMPOSE_VERSION=native
+      echo -e "\e[31mFound Docker Compose Plugin (native).\e[0m"
+      echo -e "\e[31mSetting the DOCKER_COMPOSE_VERSION Variable to native\e[0m"
+      sleep 2
+      echo -e "\e[33mNotice: You´ll have to update this Compose Version via your Package Manager manually!\e[0m"
+    else
+      echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m" 
+      echo -e "\e[31mPlease update it manually regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
+      exit 1
+    fi
+elif docker-compose > /dev/null 2>&1; then
+  if ! [[ $(alias docker-compose 2> /dev/null) ]] ; then
+    if docker-compose version --short | grep "^2." > /dev/null 2>&1; then
+      COMPOSE_VERSION=standalone
+      echo -e "\e[31mFound Docker Compose Standalone.\e[0m"
+      echo -e "\e[31mSetting the DOCKER_COMPOSE_VERSION Variable to standalone\e[0m"
+      sleep 2
+      echo -e "\e[33mNotice: You´ll have to update this Compose Version manually! Please see: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
+    else
+      echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m" 
+      echo -e "\e[31mPlease update manually regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
+      exit 1
+    fi
+  fi
+
+else
+  echo -e "\e[31mCannot find Docker Compose.\e[0m" 
+  echo -e "\e[31mPlease install it regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
+  exit 1
+fi
+    
 
 if [ -f mailcow.conf ]; then
   read -r -p "A config file exists and will be overwritten, are you sure you want to continue? [y/N] " response
@@ -104,6 +134,8 @@ elif [ ${MEM_TOTAL} -le "3670016" ]; then
 else
   SKIP_SOLR=n
 fi
+
+if []
 
 [ ! -f ./data/conf/rspamd/override.d/worker-controller-password.inc ] && echo '# Placeholder' > ./data/conf/rspamd/override.d/worker-controller-password.inc
 
@@ -182,6 +214,12 @@ TZ=${MAILCOW_TZ}
 # Please use lowercase letters only
 
 COMPOSE_PROJECT_NAME=mailcowdockerized
+
+# Used Docker Compose version
+# Switch here between native (compose plugin) and standalone
+# For more informations take a look at the mailcow docs regarding the configuration options.
+
+DOCKER_COMPOSE_VERSION=${COMPOSE_VERSION}
 
 # Set this to "allow" to enable the anyone pseudo user. Disabled by default.
 # When enabled, ACL can be created, that apply to "All authenticated users"

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -216,6 +216,8 @@ COMPOSE_PROJECT_NAME=mailcowdockerized
 # Used Docker Compose version
 # Switch here between native (compose plugin) and standalone
 # For more informations take a look at the mailcow docs regarding the configuration options.
+# Normally this should be untouched but if you decided to use either of those you can switch it manually here.
+# Please be aware that at least one of those variants should be installed on your maschine or mailcow will fail.
 
 DOCKER_COMPOSE_VERSION=${COMPOSE_VERSION}
 

--- a/helper-scripts/update_compose.sh
+++ b/helper-scripts/update_compose.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source ${SCRIPT_DIR}/../mailcow.conf
+
+if [ "${DOCKER_COMPOSE_VERSION}" == "standalone" ]; then
+LATEST_COMPOSE=$(curl -#L https://www.servercow.de/docker-compose/latest.php)
+COMPOSE_VERSION=$(docker-compose version --short)
+if [[ "$LATEST_COMPOSE" != "$COMPOSE_VERSION" ]]; then
+  echo -e "\e[33mA new docker-compose Version is available: $LATEST_COMPOSE\e[0m"
+  echo -e "\e[33mYour Version is: $COMPOSE_VERSION\e[0m"
+else
+  echo -e "\e[32mYour docker-compose Version is up to date! Not updating it...\e[0m"
+  exit 0 
+fi
+read -r -p "Do you want to update your docker-compose Version? It will automatic upgrade your docker-compose installation (recommended)? [y/N] " updatecomposeresponse 
+    if [[ ! "${updatecomposeresponse}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+      echo "OK, not updating docker-compose."
+      exit 0
+    fi 
+echo -e "\e[32mFetching new docker-compose (standalone) version...\e[0m"
+echo -e "\e[32mTrying to determine GLIBC version...\e[0m"
+    if ldd --version > /dev/null; then
+        GLIBC_V=$(ldd --version | grep -E '(GLIBC|GNU libc)' | rev | cut -d ' ' -f1 | rev | cut -d '.' -f2)
+        if [ ! -z "${GLIBC_V}" ] && [ ${GLIBC_V} -gt 27 ]; then
+        DC_DL_SUFFIX=
+        else
+        DC_DL_SUFFIX=legacy
+        fi
+    else
+        DC_DL_SUFFIX=legacy
+    fi
+    sleep 1
+    if [[ $(command -v pip 2>&1) && $(pip list --local 2>&1 | grep -v DEPRECATION | grep -c docker-compose) == 1 || $(command -v pip3 2>&1) && $(pip3 list --local 2>&1 | grep -v DEPRECATION | grep -c docker-compose) == 1 ]]; then
+        echo -e "\e[33mFound a docker-compose Version installed with pip!\e[0m"
+        echo -e "\e[31mPlease uninstall the pip Version of docker-compose since it doesn´t support Versions higher than 1.29.2.\e[0m"
+        sleep 2
+        echo -e "\e[33mExiting...\e[0m"
+        exit 1
+        #prevent breaking a working docker-compose installed with pip
+    elif [[ $(curl -sL -w "%{http_code}" https://www.servercow.de/docker-compose/latest.php?vers=${DC_DL_SUFFIX} -o /dev/null) == "200" ]]; then
+        LATEST_COMPOSE=$(curl -#L https://www.servercow.de/docker-compose/latest.php)
+        COMPOSE_VERSION=$(docker-compose version --short)
+        if [[ "$LATEST_COMPOSE" != "$COMPOSE_VERSION" ]]; then
+        COMPOSE_PATH=$(command -v docker-compose)
+        if [[ -w ${COMPOSE_PATH} ]]; then
+            curl -#L https://github.com/docker/compose/releases/download/v${LATEST_COMPOSE}/docker-compose-$(uname -s)-$(uname -m) > $COMPOSE_PATH
+            chmod +x $COMPOSE_PATH
+            echo -e "\e[32mYour Docker Compose (standalone) has been updated to: $LATEST_COMPOSE\e[0m"
+            exit 0
+        else
+            echo -e "\e[33mWARNING: $COMPOSE_PATH is not writable, but new version $LATEST_COMPOSE is available (installed: $COMPOSE_VERSION)\e[0m"
+            return 1
+        fi
+        fi
+    else
+        echo -e "\e[33mCannot determine latest docker-compose version, skipping...\e[0m"
+        exit 1
+    fi
+
+elif [ "${DOCKER_COMPOSE_VERSION}" == "native" ]; then
+    echo -e "\e[31mYou are using the native Docker Compose Plugin. This Script is for the standalone Docker Compose Version only.\e[0m"
+    sleep 2
+    echo -e "\e[33mNotice: You´ll have to update this Compose Version via your Package Manager manually!\e[0m"
+    exit 1
+
+else
+    echo -e "\e[31mCan not read DOCKER_COMPOSE_VERSION variable from mailcow.conf! Is your mailcow up to date? Exiting...\e[0m"
+    exit 1
+fi

--- a/update.sh
+++ b/update.sh
@@ -695,8 +695,7 @@ elif [ $NEW_BRANCH == "master" ] && [ $CURRENT_BRANCH != "master" ]; then
     echo "OK. If you prepared yourself for that please run the update.sh Script with the --stable parameter again to trigger this process here."
     exit 0
   fi
-
-  BRANCH = NEW_BRANCH
+  BRANCH=$NEW_BRANCH
   DIFF_DIRECTORY=update_diffs
   DIFF_FILE=${DIFF_DIRECTORY}/diff_before_upgrade_to_master_$(date +"%Y-%m-%d-%H-%M-%S")
   mv diff_before_upgrade* ${DIFF_DIRECTORY}/ 2> /dev/null
@@ -708,7 +707,7 @@ elif [ $NEW_BRANCH == "master" ] && [ $CURRENT_BRANCH != "master" ]; then
   fi
   echo -e "\e[32mSwitching Branch to ${BRANCH}...\e[0m"
   git fetch origin --all
-  git checkout -f origin/${BRANCH}
+  git checkout -f ${BRANCH}
 
 elif [ $NEW_BRANCH == "nightly" ] && [ $CURRENT_BRANCH != "nightly" ]; then
   echo -e "\e[33mYou are about to switch your mailcow Updates to the unstable (nightly) branch.\e[0m"
@@ -721,8 +720,7 @@ elif [ $NEW_BRANCH == "nightly" ] && [ $CURRENT_BRANCH != "nightly" ]; then
     echo "OK. If you prepared yourself for that please run the update.sh Script with the --nightly parameter again to trigger this process here."
     exit 0
   fi
-
-  BRANCH = NEW_BRANCH
+  BRANCH=$NEW_BRANCH
   DIFF_DIRECTORY=update_diffs
   DIFF_FILE=${DIFF_DIRECTORY}/diff_before_upgrade_to_nightly_$(date +"%Y-%m-%d-%H-%M-%S")
   mv diff_before_upgrade* ${DIFF_DIRECTORY}/ 2> /dev/null
@@ -732,10 +730,8 @@ elif [ $NEW_BRANCH == "nightly" ] && [ $CURRENT_BRANCH != "nightly" ]; then
     git diff ${BRANCH} --stat > ${DIFF_FILE}
     git diff ${BRANCH} >> ${DIFF_FILE}
   fi
-
   git fetch origin --all
-  git checkout -f origin/${BRANCH}
-
+  git checkout -f ${BRANCH}
 fi
 
 echo -e "\e[32mChecking for newer update script...\e[0m"
@@ -932,8 +928,8 @@ if [ -f "${SCRIPT_DIR}/post_update_hook.sh" ]; then
   bash "${SCRIPT_DIR}/post_update_hook.sh"
 fi
 
-# echo "In case you encounter any problem, hard-reset to a state before updating mailcow:"
-# echo
-# git reflog --color=always | grep "Before update on "
-# echo
-# echo "Use \"git reset --hard hash-on-the-left\" and run $COMPOSE_COMMAND up -d afterwards."
+echo "In case you encounter any problem, hard-reset to a state before updating mailcow:"
+echo
+git reflog --color=always | grep "Before update on "
+echo
+echo "Use \"git reset --hard hash-on-the-left\" and run $COMPOSE_COMMAND up -d afterwards."

--- a/update.sh
+++ b/update.sh
@@ -658,7 +658,7 @@ else
    fi
 fi
 
-if [ $NEW_BRANCH != "master" ] || [ $NEW_BRANCH != "nightly"]
+if [ $NEW_BRANCH != "master" ] || [ $NEW_BRANCH != "nightly"]; then
   echo -e "\e[33mDetecting which build your mailcow runs on...\e[0m"
   sleep 1
   if [ ${BRANCH} == "master" ]; then
@@ -676,7 +676,7 @@ if [ $NEW_BRANCH != "master" ] || [ $NEW_BRANCH != "nightly"]
     echo -e "\e[33mThe mailcow stack might still work but it is recommended to switch to the master branch (stable builds).\e[0m"
     echo -e "\e[33mTo change that run the update.sh Script one time with the --stable parameter to switch to stable builds.\e[0m"
   fi
-elif [ $NEW_BRANCH == "master" ] && [ $CURRENT_BRANCH != "master" ]
+elif [ $NEW_BRANCH == "master" ] && [ $CURRENT_BRANCH != "master" ]; then
   echo -e "\e[33mYou are about to switch your mailcow Updates to the stable (master) branch.\e[0m"
   sleep 1
   echo -e "\e[33mBefore you do: Please take a backup of all components to ensure that no Data is lost...\e[0m"
@@ -704,7 +704,7 @@ elif [ $NEW_BRANCH == "master" ] && [ $CURRENT_BRANCH != "master" ]
   git fetch origin --all
   git checkout -f origin/${BRANCH}
 
-elif [ $NEW_BRANCH == "nightly" ] && [ $CURRENT_BRANCH != "nightly" ]
+elif [ $NEW_BRANCH == "nightly" ] && [ $CURRENT_BRANCH != "nightly" ]; then
   echo -e "\e[33mYou are about to switch your mailcow Updates to the unstable (nightly) branch.\e[0m"
   sleep 1
   echo -e "\e[33mBefore you do: Please take a backup of all components to ensure that no Data is lost...\e[0m"

--- a/update.sh
+++ b/update.sh
@@ -646,16 +646,16 @@ else
    fi
 fi
 
-# echo -e "\e[32mChecking for newer update script...\e[0m"
-# SHA1_1=$(sha1sum update.sh)
-# git fetch origin #${BRANCH}
-# git checkout origin/${BRANCH} update.sh
-# SHA1_2=$(sha1sum update.sh)
-# if [[ ${SHA1_1} != ${SHA1_2} ]]; then
-#   echo "update.sh changed, please run this script again, exiting."
-#   chmod +x update.sh
-#   exit 2
-# fi
+echo -e "\e[32mChecking for newer update script...\e[0m"
+SHA1_1=$(sha1sum update.sh)
+git fetch origin #${BRANCH}
+git checkout origin/${BRANCH} update.sh
+SHA1_2=$(sha1sum update.sh)
+if [[ ${SHA1_1} != ${SHA1_2} ]]; then
+  echo "update.sh changed, please run this script again, exiting."
+  chmod +x update.sh
+  exit 2
+fi
 
 if [ ! $FORCE ]; then
   read -r -p "Are you sure you want to update mailcow: dockerized? All containers will be stopped. [y/N] " response

--- a/update.sh
+++ b/update.sh
@@ -872,7 +872,7 @@ fi
 if [ ${BRANCH} == "master" ]; then
   mailcow_git_version=$(git describe --tags `git rev-list --tags --max-count=1`)
 elif [ ${BRANCH} == "nightly" ]; then
-  mailcow_git_version=$(git rev-parse origin/${BRANCH} --short HEAD | head -2 | tail -1)
+  mailcow_git_version=$(git rev-parse --short $(git rev-parse @{upstream}))
   mailcow_last_git_version=""
 else
   mailcow_git_version=$(git rev-parse --short HEAD)
@@ -928,8 +928,8 @@ if [ -f "${SCRIPT_DIR}/post_update_hook.sh" ]; then
   bash "${SCRIPT_DIR}/post_update_hook.sh"
 fi
 
-echo "In case you encounter any problem, hard-reset to a state before updating mailcow:"
-echo
-git reflog --color=always | grep "Before update on "
-echo
-echo "Use \"git reset --hard hash-on-the-left\" and run $COMPOSE_COMMAND up -d afterwards."
+# echo "In case you encounter any problem, hard-reset to a state before updating mailcow:"
+# echo
+# git reflog --color=always | grep "Before update on "
+# echo
+# echo "Use \"git reset --hard hash-on-the-left\" and run $COMPOSE_COMMAND up -d afterwards."

--- a/update.sh
+++ b/update.sh
@@ -344,11 +344,12 @@ while (($#)); do
   shift
 done
 
+chmod 600 mailcow.conf
+source mailcow.conf
+
 detect_docker_compose_command
 
 [[ ! -f mailcow.conf ]] && { echo "mailcow.conf is missing! Is mailcow installed?"; exit 1;}
-chmod 600 mailcow.conf
-source mailcow.conf
 DOTS=${MAILCOW_HOSTNAME//[^.]};
 if [ ${#DOTS} -lt 2 ]; then
   echo "MAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) is not a FQDN!"
@@ -734,16 +735,16 @@ elif [ $NEW_BRANCH == "nightly" ] && [ $CURRENT_BRANCH != "nightly" ]; then
   git checkout -f ${BRANCH}
 fi
 
-echo -e "\e[32mChecking for newer update script...\e[0m"
-SHA1_1=$(sha1sum update.sh)
-git fetch origin #${BRANCH}
-git checkout origin/${BRANCH} update.sh
-SHA1_2=$(sha1sum update.sh)
-if [[ ${SHA1_1} != ${SHA1_2} ]]; then
-  echo "update.sh changed, please run this script again, exiting."
-  chmod +x update.sh
-  exit 2
-fi
+# echo -e "\e[32mChecking for newer update script...\e[0m"
+# SHA1_1=$(sha1sum update.sh)
+# git fetch origin #${BRANCH}
+# git checkout origin/${BRANCH} update.sh
+# SHA1_2=$(sha1sum update.sh)
+# if [[ ${SHA1_1} != ${SHA1_2} ]]; then
+#   echo "update.sh changed, please run this script again, exiting."
+#   chmod +x update.sh
+#   exit 2
+# fi
 
 if [ ! $FORCE ]; then
   read -r -p "Are you sure you want to update mailcow: dockerized? All containers will be stopped. [y/N] " response

--- a/update.sh
+++ b/update.sh
@@ -730,7 +730,7 @@ elif [ $NEW_BRANCH == "nightly" ] && [ $CURRENT_BRANCH != "nightly" ]; then
     git diff ${BRANCH} --stat > ${DIFF_FILE}
     git diff ${BRANCH} >> ${DIFF_FILE}
   fi
-  git fetch origin --all
+  git fetch origin
   git checkout -f ${BRANCH}
 fi
 
@@ -928,8 +928,8 @@ if [ -f "${SCRIPT_DIR}/post_update_hook.sh" ]; then
   bash "${SCRIPT_DIR}/post_update_hook.sh"
 fi
 
-echo "In case you encounter any problem, hard-reset to a state before updating mailcow:"
-echo
-git reflog --color=always | grep "Before update on "
-echo
-echo "Use \"git reset --hard hash-on-the-left\" and run $COMPOSE_COMMAND up -d afterwards."
+# echo "In case you encounter any problem, hard-reset to a state before updating mailcow:"
+# echo
+# git reflog --color=always | grep "Before update on "
+# echo
+# echo "Use \"git reset --hard hash-on-the-left\" and run $COMPOSE_COMMAND up -d afterwards."

--- a/update.sh
+++ b/update.sh
@@ -706,7 +706,7 @@ elif [ $NEW_BRANCH == "master" ] && [ $CURRENT_BRANCH != "master" ]; then
     git diff ${BRANCH} >> ${DIFF_FILE}
   fi
   echo -e "\e[32mSwitching Branch to ${BRANCH}...\e[0m"
-  git fetch origin --all
+  git fetch origin
   git checkout -f ${BRANCH}
 
 elif [ $NEW_BRANCH == "nightly" ] && [ $CURRENT_BRANCH != "nightly" ]; then
@@ -730,7 +730,7 @@ elif [ $NEW_BRANCH == "nightly" ] && [ $CURRENT_BRANCH != "nightly" ]; then
     git diff ${BRANCH} --stat > ${DIFF_FILE}
     git diff ${BRANCH} >> ${DIFF_FILE}
   fi
-  git fetch origin --all
+  git fetch origin
   git checkout -f ${BRANCH}
 fi
 

--- a/update.sh
+++ b/update.sh
@@ -880,7 +880,7 @@ else
 fi
 
 mailcow_git_commit=$(git rev-parse origin/${BRANCH})
-mailcow_git_commit_date=$(git show -s --format=%cd --date=format:'%Y-%m-%d %H:%M')
+mailcow_git_commit_date=$(git log -1 --format=%ci @{upstream} )
 
 if [ $? -eq 0 ]; then
   echo '<?php' > data/web/inc/app_info.inc.php

--- a/update.sh
+++ b/update.sh
@@ -184,10 +184,10 @@ if ! [ "${DOCKER_COMPOSE_VERSION}" == "native" ] && ! [ "${DOCKER_COMPOSE_VERSIO
         echo -e "\e[31mFound Docker Compose Plugin (native).\e[0m"
         echo -e "\e[31mSetting the DOCKER_COMPOSE_VERSION Variable to native\e[0m"
         sleep 2
-        echo -e "\e[33mNotice: You´ll have to update this Compose Version via your Package Manager manually!\e[0m"
+        echo -e "\e[33mNotice: You'll have to update this Compose Version via your Package Manager manually!\e[0m"
       else
         echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m" 
-        echo -e "\e[31mPlease update it manually regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
+        echo -e "\e[31mPlease update/install it manually regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
         exit 1
       fi
   elif docker-compose > /dev/null 2>&1; then
@@ -198,10 +198,10 @@ if ! [ "${DOCKER_COMPOSE_VERSION}" == "native" ] && ! [ "${DOCKER_COMPOSE_VERSIO
         echo -e "\e[31mFound Docker Compose Standalone.\e[0m"
         echo -e "\e[31mSetting the DOCKER_COMPOSE_VERSION Variable to standalone\e[0m"
         sleep 2
-        echo -e "\e[33mNotice: You´ll have to update this Compose Version manually! Please see: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
+        echo -e "\e[33mNotice: For an automatic update of docker-compose please use the update_compose.sh scripts located at the helper-scripts folder.[0m"
       else
         echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m" 
-        echo -e "\e[31mPlease update manually regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
+        echo -e "\e[31mPlease update/install regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
         exit 1
       fi
     fi
@@ -735,16 +735,16 @@ elif [ $NEW_BRANCH == "nightly" ] && [ $CURRENT_BRANCH != "nightly" ]; then
   git checkout -f ${BRANCH}
 fi
 
-# echo -e "\e[32mChecking for newer update script...\e[0m"
-# SHA1_1=$(sha1sum update.sh)
-# git fetch origin #${BRANCH}
-# git checkout origin/${BRANCH} update.sh
-# SHA1_2=$(sha1sum update.sh)
-# if [[ ${SHA1_1} != ${SHA1_2} ]]; then
-#   echo "update.sh changed, please run this script again, exiting."
-#   chmod +x update.sh
-#   exit 2
-# fi
+echo -e "\e[32mChecking for newer update script...\e[0m"
+SHA1_1=$(sha1sum update.sh)
+git fetch origin #${BRANCH}
+git checkout origin/${BRANCH} update.sh
+SHA1_2=$(sha1sum update.sh)
+if [[ ${SHA1_1} != ${SHA1_2} ]]; then
+  echo "update.sh changed, please run this script again, exiting."
+  chmod +x update.sh
+  exit 2
+fi
 
 if [ ! $FORCE ]; then
   read -r -p "Are you sure you want to update mailcow: dockerized? All containers will be stopped. [y/N] " response

--- a/update.sh
+++ b/update.sh
@@ -873,11 +873,12 @@ fi
 # Set app_info.inc.php
 if [ ${BRANCH} == "master" ]; then
   mailcow_git_version=$(git describe --tags `git rev-list --tags --max-count=1`)
-  mailcow_last_git_version=""
 elif [ ${BRANCH} == "nightly" ]; then
   mailcow_git_version=$(git rev-parse --short HEAD)
+  mailcow_last_git_version=""
 else
   mailcow_git_version=$(git rev-parse --short HEAD)
+  mailcow_last_git_version=""
 fi
 
 mailcow_git_commit=$(git rev-parse HEAD)

--- a/update.sh
+++ b/update.sh
@@ -419,6 +419,8 @@ for option in ${CONFIG_ARRAY[@]}; do
       echo "# Used Docker Compose version" >> mailcow.conf
       echo "# Switch here between native (compose plugin) and standalone" >> mailcow.conf
       echo "# For more informations take a look at the mailcow docs regarding the configuration options." >> mailcow.conf
+      echo "# Normally this should be untouched but if you decided to use either of those you can switch it manually here." >> mailcow.conf
+      echo "# Please be aware that at least one of those variants should be installed on your maschine or mailcow will fail." >> mailcow.conf
       echo "" >> mailcow.conf
       echo "DOCKER_COMPOSE_VERSION=${DOCKER_COMPOSE_VERSION}" >> mailcow.conf
     fi

--- a/update.sh
+++ b/update.sh
@@ -730,7 +730,7 @@ elif [ $NEW_BRANCH == "nightly" ] && [ $CURRENT_BRANCH != "nightly" ]; then
     git diff ${BRANCH} --stat > ${DIFF_FILE}
     git diff ${BRANCH} >> ${DIFF_FILE}
   fi
-  git fetch origin
+  git fetch origin --all
   git checkout -f ${BRANCH}
 fi
 
@@ -872,14 +872,14 @@ fi
 if [ ${BRANCH} == "master" ]; then
   mailcow_git_version=$(git describe --tags `git rev-list --tags --max-count=1`)
 elif [ ${BRANCH} == "nightly" ]; then
-  mailcow_git_version=$(git rev-parse --short HEAD)
+  mailcow_git_version=$(git rev-parse origin/${BRANCH} --short HEAD | head -2 | tail -1)
   mailcow_last_git_version=""
 else
   mailcow_git_version=$(git rev-parse --short HEAD)
   mailcow_last_git_version=""
 fi
 
-mailcow_git_commit=$(git rev-parse HEAD)
+mailcow_git_commit=$(git rev-parse origin/${BRANCH})
 mailcow_git_commit_date=$(git show -s --format=%cd --date=format:'%Y-%m-%d %H:%M')
 
 if [ $? -eq 0 ]; then
@@ -928,8 +928,8 @@ if [ -f "${SCRIPT_DIR}/post_update_hook.sh" ]; then
   bash "${SCRIPT_DIR}/post_update_hook.sh"
 fi
 
-# echo "In case you encounter any problem, hard-reset to a state before updating mailcow:"
-# echo
-# git reflog --color=always | grep "Before update on "
-# echo
-# echo "Use \"git reset --hard hash-on-the-left\" and run $COMPOSE_COMMAND up -d afterwards."
+echo "In case you encounter any problem, hard-reset to a state before updating mailcow:"
+echo
+git reflog --color=always | grep "Before update on "
+echo
+echo "Use \"git reset --hard hash-on-the-left\" and run $COMPOSE_COMMAND up -d afterwards."

--- a/update.sh
+++ b/update.sh
@@ -658,7 +658,7 @@ else
    fi
 fi
 
-if [ $NEW_BRANCH != "master" ] || [ $NEW_BRANCH != "nightly"]; then
+if ! [ $NEW_BRANCH ]; then
   echo -e "\e[33mDetecting which build your mailcow runs on...\e[0m"
   sleep 1
   if [ ${BRANCH} == "master" ]; then
@@ -676,6 +676,11 @@ if [ $NEW_BRANCH != "master" ] || [ $NEW_BRANCH != "nightly"]; then
     echo -e "\e[33mThe mailcow stack might still work but it is recommended to switch to the master branch (stable builds).\e[0m"
     echo -e "\e[33mTo change that run the update.sh Script one time with the --stable parameter to switch to stable builds.\e[0m"
   fi
+elif [ $FORCE = "y" ]; then
+  echo -e "\e[31mYou are running in forced mode!\e[0m"
+  echo -e "\e[31mA Branch Switch can only be performed manually (monitored).\e[0m"
+  echo -e "\e[31mPlease rerun the update.sh Script without the --force/-f parameter.\e[0m"
+  sleep 1
 elif [ $NEW_BRANCH == "master" ] && [ $CURRENT_BRANCH != "master" ]; then
   echo -e "\e[33mYou are about to switch your mailcow Updates to the stable (master) branch.\e[0m"
   sleep 1
@@ -683,7 +688,8 @@ elif [ $NEW_BRANCH == "master" ] && [ $CURRENT_BRANCH != "master" ]; then
   sleep 1
   echo -e "\e[31mWARNING: Please see on GitHub or ask in the communitys if a switch to master is stable or not.
   In some rear cases a Update back to master can destroy your mailcow configuration in case of Database Upgrades etc.
-  Normally a upgrade back to master should be safe during each full release. Check GitHub for Database Changes and Update only if there similar to the full release!\e[0m"
+  Normally a upgrade back to master should be safe during each full release. 
+  Check GitHub for Database Changes and Update only if there similar to the full release!\e[0m"
   read -r -p "Are you sure you that want to continue upgrading to the stable (master) branch? [y/N] " response
   if [[ ! "${response}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
     echo "OK. If you prepared yourself for that please run the update.sh Script with the --stable parameter again to trigger this process here."
@@ -709,7 +715,7 @@ elif [ $NEW_BRANCH == "nightly" ] && [ $CURRENT_BRANCH != "nightly" ]; then
   sleep 1
   echo -e "\e[33mBefore you do: Please take a backup of all components to ensure that no Data is lost...\e[0m"
   sleep 1
-  echo -e "\e[31mWARNING: A switch to nightly is possible any time. But a switch back (to master) not.\e[0m"
+  echo -e "\e[31mWARNING: A switch to nightly is possible any time. But a switch back (to master) isn't.\e[0m"
   read -r -p "Are you sure you that want to continue upgrading to the unstable (nightly) branch? [y/N] " response
   if [[ ! "${response}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
     echo "OK. If you prepared yourself for that please run the update.sh Script with the --nightly parameter again to trigger this process here."
@@ -730,10 +736,6 @@ elif [ $NEW_BRANCH == "nightly" ] && [ $CURRENT_BRANCH != "nightly" ]; then
   git fetch origin --all
   git checkout -f origin/${BRANCH}
 
-elif [ $FORCE ]; then
-  echo -e "\e[31mYou are running in forced mode!\e[0m"
-  echo -e "\e[31mA Branch Switch can only be performed manually (monitored).\e[0m"
-  echo -e "\e[31mPlease rerun the update.sh Script without the --force/-f parameter.\e[0m"
 fi
 
 echo -e "\e[32mChecking for newer update script...\e[0m"

--- a/update.sh
+++ b/update.sh
@@ -676,7 +676,7 @@ if ! [ $NEW_BRANCH ]; then
     echo -e "\e[33mThe mailcow stack might still work but it is recommended to switch to the master branch (stable builds).\e[0m"
     echo -e "\e[33mTo change that run the update.sh Script one time with the --stable parameter to switch to stable builds.\e[0m"
   fi
-elif [ $FORCE = "y" ]; then
+elif [ $FORCE ]; then
   echo -e "\e[31mYou are running in forced mode!\e[0m"
   echo -e "\e[31mA Branch Switch can only be performed manually (monitored).\e[0m"
   echo -e "\e[31mPlease rerun the update.sh Script without the --force/-f parameter.\e[0m"

--- a/update.sh
+++ b/update.sh
@@ -344,6 +344,8 @@ while (($#)); do
   shift
 done
 
+detect_docker_compose_command
+
 [[ ! -f mailcow.conf ]] && { echo "mailcow.conf is missing! Is mailcow installed?"; exit 1;}
 chmod 600 mailcow.conf
 source mailcow.conf
@@ -353,8 +355,6 @@ if [ ${#DOTS} -lt 2 ]; then
   echo "Please change it to a FQDN and run $COMPOSE_COMMAND down followed by $COMPOSE_COMMAND up -d"
   exit 1
 fi
-
-detect_docker_compose_command
 
 if grep --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusyBox grep detected, please install gnu grep, \"apk add --no-cache --upgrade grep\""; exit 1; fi
 # This will also cover sort


### PR DESCRIPTION
This PR adds a nightly Version Switch for the update.sh

It implements two new flags:
+ --nightly (switch the Repo to the nightly repo)
+ --stable (switch the Repo to the master repo)

Per default (no new flag given) the update.sh Script runs like normal but with the note from which branch you currently getting updates.

(Looks like this for nightly):
![image](https://user-images.githubusercontent.com/62480600/186613713-cbc1328e-6ed4-4d02-89c4-def047ac6f5d.png)

The update.sh warns you if you want to switch a branch. Especially the switch between nightly and master:
![image](https://user-images.githubusercontent.com/62480600/186613939-ef291653-4b31-4793-a92d-d00a5d2e9144.png)

To prevent an unmonitored branch switch the update.sh detects if the user enabled forced mode and skip the branch switching:
![image](https://user-images.githubusercontent.com/62480600/186616614-cce2e138-0a25-47a4-8814-ef7ad1049481.png)

With that change a new Version Footer come into place, which contains a link to the latest commit on the upstream repo (GitHub):
![image](https://user-images.githubusercontent.com/62480600/186614297-4e1bf973-1bc6-4f98-84ff-872c8f772e9d.png)

It also combines the changes implemented with:

PR: https://github.com/mailcow/mailcow-dockerized/pull/4723
