### PR TITLE
2022-08a

### DIFF
--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -194,6 +194,7 @@ plugin {
   fts_solr = url=http://solr:8983/solr/dovecot-fts/
   quota = dict:Userquota::proxy::sqlquota
   quota_rule2 = Trash:storage=+100%%
+  sieve = /var/vmail/sieve/%u.sieve
   sieve_plugins = sieve_imapsieve sieve_extprograms
   sieve_vacation_send_from_recipient = yes
   sieve_redirect_envelope_from = recipient

--- a/update.sh
+++ b/update.sh
@@ -178,7 +178,7 @@ remove_obsolete_nginx_ports() {
 detect_docker_compose_command(){
 if ! [ "${DOCKER_COMPOSE_VERSION}" == "native" ] && ! [ "${DOCKER_COMPOSE_VERSION}" == "standalone" ]; then
   if docker compose > /dev/null 2>&1; then
-      if docker compose version --short | grep "^2." > /dev/null 2>&1; then
+      if docker compose version --short | grep "2." > /dev/null 2>&1; then
         DOCKER_COMPOSE_VERSION=native
         COMPOSE_COMMAND="docker compose"
         echo -e "\e[31mFound Docker Compose Plugin (native).\e[0m"
@@ -361,14 +361,6 @@ if grep --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusyBox grep 
 # This will also cover sort
 if cp --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusyBox cp detected, please install coreutils, \"apk add --no-cache --upgrade coreutils\""; exit 1; fi
 if sed --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusyBox sed detected, please install gnu sed, \"apk add --no-cache --upgrade sed\""; exit 1; fi
-
-# Check if Docker Compose is older then v2 before continuing
-if ! $COMPOSE_COMMAND version --short | grep "^2." > /dev/null 2>&1; then
-  echo -e "\e[33mYour Docker Compose Version is not up to date!\e[0m"
-  echo -e "\e[33mmailcow needs Docker Compose > 2.X.X!\e[0m"
-  echo -e "\e[33mYour current installed Version: $($COMPOSE_COMMAND version --short)\e[0m"
-  exit 1
-fi
 
 CONFIG_ARRAY=(
   "SKIP_LETS_ENCRYPT"


### PR DESCRIPTION
- Fixes the issue that older v2 Compose Plugin Versions (beginning with v in `docker compose version --short` were not accepted.
- Fixes the Sieve Error that IMAP Clients and SOGo cannot use Sieve Filters anymore.