### PR TITLE
Improve headers for security

### DIFF
--- a/data/conf/nginx/includes/site-defaults.conf
+++ b/data/conf/nginx/includes/site-defaults.conf
@@ -23,6 +23,9 @@
   add_header Referrer-Policy strict-origin;
   add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), screen-wake-lock=(), serial=(), usb=(), sync-xhr=(), xr-spatial-tracking=()";
   add_header Content-Security-Policy "default-src 'none'; connect-src 'self'; font-src 'self'; img-src * https: data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; block-all-mixed-content; base-uri 'none'";
+  add_header Cross-Origin-Opener-Policy same-origin;
+  add_header Cross-Origin-Embedder-Policy require-corp;
+  add_header Cross-Origin-Resource-Policy same-origin;
 
   index index.php index.html;
 

--- a/data/conf/nginx/includes/site-defaults.conf
+++ b/data/conf/nginx/includes/site-defaults.conf
@@ -22,7 +22,7 @@
   add_header X-Permitted-Cross-Domain-Policies none;
   add_header Referrer-Policy strict-origin;
   add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), screen-wake-lock=(), serial=(), usb=(), sync-xhr=(), xr-spatial-tracking=()";
-  add_header Content-Security-Policy "default-src 'none'; connect-src 'self' https://api.github.com https://www.gravatar.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://www.gravatar.com; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-ancestors 'none'; block-all-mixed-content; base-uri 'none'";
+  add_header Content-Security-Policy "default-src 'none'; connect-src 'self' https://api.github.com https://www.gravatar.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://www.gravatar.com; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content; base-uri 'none'";
   add_header Cross-Origin-Opener-Policy same-origin;
   add_header Cross-Origin-Resource-Policy same-origin;
 

--- a/data/conf/nginx/includes/site-defaults.conf
+++ b/data/conf/nginx/includes/site-defaults.conf
@@ -13,7 +13,7 @@
   ssl_session_timeout 1d;
   ssl_session_tickets off;
 
-  add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
+  add_header Strict-Transport-Security "max-age=15768000; preload";
   add_header X-Content-Type-Options nosniff;
   add_header X-XSS-Protection "0";
   add_header X-Robots-Tag none;

--- a/data/conf/nginx/includes/site-defaults.conf
+++ b/data/conf/nginx/includes/site-defaults.conf
@@ -13,14 +13,16 @@
   ssl_session_timeout 1d;
   ssl_session_tickets off;
 
-  add_header Strict-Transport-Security "max-age=15768000;";
+  add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
   add_header X-Content-Type-Options nosniff;
-  add_header X-XSS-Protection "1; mode=block";
+  add_header X-XSS-Protection "0";
   add_header X-Robots-Tag none;
   add_header X-Download-Options noopen;
   add_header X-Frame-Options "SAMEORIGIN" always;
   add_header X-Permitted-Cross-Domain-Policies none;
   add_header Referrer-Policy strict-origin;
+  add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), screen-wake-lock=(), serial=(), usb=(), sync-xhr=(), xr-spatial-tracking=()";
+  add_header Content-Security-Policy "default-src 'none'; connect-src 'self'; font-src 'self'; img-src * https: data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; block-all-mixed-content; base-uri 'none'";
 
   index index.php index.html;
 

--- a/data/conf/nginx/includes/site-defaults.conf
+++ b/data/conf/nginx/includes/site-defaults.conf
@@ -21,7 +21,7 @@
   add_header X-Frame-Options "SAMEORIGIN" always;
   add_header X-Permitted-Cross-Domain-Policies none;
   add_header Referrer-Policy strict-origin;
-  add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), screen-wake-lock=(), serial=(), usb=(), sync-xhr=(), xr-spatial-tracking=()";
+  add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), browsing-topics=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), screen-wake-lock=(), serial=(), usb=(), sync-xhr=(), xr-spatial-tracking=()";
   add_header Content-Security-Policy "default-src 'none'; connect-src 'self' https://api.github.com https://www.gravatar.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://www.gravatar.com; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content; base-uri 'none'";
   add_header Cross-Origin-Opener-Policy same-origin;
   add_header Cross-Origin-Resource-Policy same-origin;

--- a/data/conf/nginx/includes/site-defaults.conf
+++ b/data/conf/nginx/includes/site-defaults.conf
@@ -22,7 +22,7 @@
   add_header X-Permitted-Cross-Domain-Policies none;
   add_header Referrer-Policy strict-origin;
   add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), screen-wake-lock=(), serial=(), usb=(), sync-xhr=(), xr-spatial-tracking=()";
-  add_header Content-Security-Policy "default-src 'none'; connect-src 'self'; font-src 'self'; img-src * https: data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; block-all-mixed-content; base-uri 'none'";
+  add_header Content-Security-Policy "default-src 'none'; connect-src 'self' https://api.github.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-ancestors 'none'; block-all-mixed-content; base-uri 'none'";
   add_header Cross-Origin-Opener-Policy same-origin;
   add_header Cross-Origin-Embedder-Policy require-corp;
   add_header Cross-Origin-Resource-Policy same-origin;

--- a/data/conf/nginx/includes/site-defaults.conf
+++ b/data/conf/nginx/includes/site-defaults.conf
@@ -22,9 +22,8 @@
   add_header X-Permitted-Cross-Domain-Policies none;
   add_header Referrer-Policy strict-origin;
   add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), screen-wake-lock=(), serial=(), usb=(), sync-xhr=(), xr-spatial-tracking=()";
-  add_header Content-Security-Policy "default-src 'none'; connect-src 'self' https://api.github.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-ancestors 'none'; block-all-mixed-content; base-uri 'none'";
+  add_header Content-Security-Policy "default-src 'none'; connect-src 'self' https://api.github.com https://www.gravatar.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://www.gravatar.com; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-ancestors 'none'; block-all-mixed-content; base-uri 'none'";
   add_header Cross-Origin-Opener-Policy same-origin;
-  add_header Cross-Origin-Embedder-Policy require-corp;
   add_header Cross-Origin-Resource-Policy same-origin;
 
   index index.php index.html;


### PR DESCRIPTION
I added Permissions-Policy and Content-Security-Policy. I have tested these with the admin panel and FIDO2.
XSS filtering should be set to 0 as it could cause issues by itself according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection. 

HSTS should be preloaded and ~~include subdomains~~. I don't see a reason not to.