### PR TITLE
Update quarantine_notify.py charset

### DIFF
--- a/data/Dockerfiles/dovecot/quarantine_notify.py
+++ b/data/Dockerfiles/dovecot/quarantine_notify.py
@@ -50,7 +50,7 @@ try:
   def query_mysql(query, headers = True, update = False):
     while True:
       try:
-        cnx = mysql.connector.connect(unix_socket = '/var/run/mysqld/mysqld.sock', user=os.environ.get('DBUSER'), passwd=os.environ.get('DBPASS'), database=os.environ.get('DBNAME'), charset="utf8")
+        cnx = mysql.connector.connect(unix_socket = '/var/run/mysqld/mysqld.sock', user=os.environ.get('DBUSER'), passwd=os.environ.get('DBPASS'), database=os.environ.get('DBNAME'), charset="utf8mb4", collation="utf8mb4_general_ci")
       except Exception as ex:
         print('%s - trying again...'  % (ex))
         time.sleep(3)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,7 +215,7 @@ services:
             - sogo
 
     dovecot-mailcow:
-      image: mailcow/dovecot:1.19
+      image: mailcow/dovecot:1.20
       depends_on:
         - mysql-mailcow
       dns:


### PR DESCRIPTION
Updates `quarantine_notify.py` to use utf8mb4 charset and utf8mb4_general_ci collation
Tested on mariadb:10.6 and works.
I sent a bogus mail from a server via telnet which classifies the mail as spam and thus rspamd is putting it in the quarantine. Triggering `quarantine_notify.py` by ofelia will deliver the quarantine mail to the inbox

Fixes https://github.com/mailcow/mailcow-dockerized/issues/4743


New image **mailcow/dovecot:1.20** on Dockerhub available