### PR TITLE
[Netfilter] Record IP address in F2B_ACTIVE_BANS instead of the network block

### DIFF
--- a/data/Dockerfiles/netfilter/server.py
+++ b/data/Dockerfiles/netfilter/server.py
@@ -206,7 +206,7 @@ def ban(address):
         rule.target = target
         if rule not in chain.rules:
           chain.insert_rule(rule)
-    r.hset('F2B_ACTIVE_BANS', '%s' % net, cur_time + BAN_TIME)
+    r.hset('F2B_ACTIVE_BANS', '%s' % address, cur_time + BAN_TIME)
   else:
     logWarn('%d more attempts in the next %d seconds until %s is banned' % (MAX_ATTEMPTS - bans[net]['attempts'], RETRY_WINDOW, net))
 
@@ -252,7 +252,7 @@ def permBan(net, unban=False):
       if rule not in chain.rules and not unban:
         logCrit('Add host/network %s to blacklist' % net)
         chain.insert_rule(rule)
-        r.hset('F2B_PERM_BANS', '%s' % net, int(round(time.time()))) 
+        r.hset('F2B_PERM_BANS', '%s' % net, int(round(time.time())))
       elif rule in chain.rules and unban:
         logCrit('Remove host/network %s from blacklist' % net)
         chain.delete_rule(rule)
@@ -267,7 +267,7 @@ def permBan(net, unban=False):
       if rule not in chain.rules and not unban:
         logCrit('Add host/network %s to blacklist' % net)
         chain.insert_rule(rule)
-        r.hset('F2B_PERM_BANS', '%s' % net, int(round(time.time()))) 
+        r.hset('F2B_PERM_BANS', '%s' % net, int(round(time.time())))
       elif rule in chain.rules and unban:
         logCrit('Remove host/network %s from blacklist' % net)
         chain.delete_rule(rule)
@@ -368,7 +368,7 @@ def snat4(snat_target):
           table.commit()
         table.autocommit = True
       except:
-        print('Error running SNAT4, retrying...') 
+        print('Error running SNAT4, retrying...')
 
 def snat6(snat_target):
   global lock
@@ -402,7 +402,7 @@ def snat6(snat_target):
           table.commit()
         table.autocommit = True
       except:
-        print('Error running SNAT6, retrying...') 
+        print('Error running SNAT6, retrying...')
 
 def autopurge():
   while not quit_now:
@@ -468,7 +468,7 @@ def whitelistUpdate():
       if Counter(new_whitelist) != Counter(WHITELIST):
         WHITELIST = new_whitelist
         logInfo('Whitelist was changed, it has %s entries' % len(WHITELIST))
-    time.sleep(60.0 - ((time.time() - start_time) % 60.0)) 
+    time.sleep(60.0 - ((time.time() - start_time) % 60.0))
 
 def blacklistUpdate():
   global quit_now
@@ -479,7 +479,7 @@ def blacklistUpdate():
     new_blacklist = []
     if list:
       new_blacklist = genNetworkList(list)
-    if Counter(new_blacklist) != Counter(BLACKLIST): 
+    if Counter(new_blacklist) != Counter(BLACKLIST):
       addban = set(new_blacklist).difference(BLACKLIST)
       delban = set(BLACKLIST).difference(new_blacklist)
       BLACKLIST = new_blacklist
@@ -490,7 +490,7 @@ def blacklistUpdate():
       if delban:
         for net in delban:
           permBan(net=net, unban=True)
-    time.sleep(60.0 - ((time.time() - start_time) % 60.0)) 
+    time.sleep(60.0 - ((time.time() - start_time) % 60.0))
 
 def initChain():
   # Is called before threads start, no locking


### PR DESCRIPTION
Minor change that can improve the whois output of watchdog's IP ban email in certain cases.

Currently watchdog receives the network block that was banned in the F2B_ACTIVE_BANS message. However a whois lookup of the block can fail to return a result if a larger/smaller block is what's actually registered. Example:

IP that caused the ban: 20.199.179.218
Fail2ban parameter f2b_netban_ipv4: 24
Resulting banned network:  20.199.179.0/24
```
$ whois 20.199.179.0/24
No match found for r + = 20.199.179.0/24.
```

Changing F2B_ACTIVE_BANS to contain the actual IP means watchdog can perform a successful query and include the output in its email:
```
$ whois 20.199.179.218 
<snip>
NetRange:       20.192.0.0 - 20.255.255.255
CIDR:           20.192.0.0/10
NetName:        MSFT
NetHandle:      NET-20-192-0-0-1
Parent:         NET20 (NET-20-0-0-0-0)
NetType:        Direct Allocation
```

Note that the IP is included in the the email subject so in this example it changes from:
`Subject: Wed Sep 21 10:22:36 AEST 2022 - IP ban: 20.199.179.0/24`
to:
`Subject: Wed Sep 21 10:22:36 AEST 2022 - IP ban: 20.199.179.218`

Personally I prefer that because it identifies the actual source of the attempt.

The other changes in the commit simply strip some superfluous whitespace. That was the result of an vim plugin that auto stripped the space. It wasn't an intended change but it cleans it up a bit I guess. :) 

