### PR TITLE
Watchdog smarthost and rspamd max_message

### DIFF
--- a/data/Dockerfiles/watchdog/watchdog.sh
+++ b/data/Dockerfiles/watchdog/watchdog.sh
@@ -142,7 +142,12 @@ function mail_error() {
       --to=${rcpt} \
       --from="watchdog@${MAILCOW_HOSTNAME}" \
       --hello-host=${MAILCOW_HOSTNAME} \
-      --ipv4
+      if [[ "${WATCHDOG_SMARTHOST}" == "" ]]; then
+        --ipv4
+      else
+        --ipv4 \
+        --host="${WATCHDOG_SMARTHOST}"
+      fi      
     if [[ $? -eq 1 ]]; then # exit code 1 is fine
       log_msg "Sent notification email to ${rcpt}"
     else

--- a/data/conf/rspamd/local.d/options.inc
+++ b/data/conf/rspamd/local.d/options.inc
@@ -6,3 +6,4 @@ disable_monitoring = true;
 # In case a task times out (like DNS lookup), soft reject the message
 # instead of silently accepting the message without further processing.
 soft_reject_on_timeout = true;
+max_message = 100mb;

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -354,6 +354,9 @@ WATCHDOG_EXTERNAL_CHECKS=n
 # Enable watchdog verbose logging
 WATCHDOG_VERBOSE=n
 
+# Enable watchdog smarthost in format ip_or_hostname[:port] (without authentication)
+#WATCHDOG_SMARTHOST=
+
 # Max log lines per service to keep in Redis logs
 
 LOG_LINES=9999

--- a/update.sh
+++ b/update.sh
@@ -402,6 +402,7 @@ CONFIG_ARRAY=(
   "ACME_CONTACT"
   "WATCHDOG_VERBOSE"
   "WEBAUTHN_ONLY_TRUSTED_VENDORS"
+  "WATCHDOG_SMARTHOST"
 )
 
 sed -i --follow-symlinks '$a\' mailcow.conf
@@ -627,11 +628,16 @@ for option in ${CONFIG_ARRAY[@]}; do
       echo '# root certificates can be placed for validation under mailcow-dockerized/data/web/inc/lib/WebAuthn/rootCertificates' >> mailcow.conf
       echo 'WEBAUTHN_ONLY_TRUSTED_VENDORS=n' >> mailcow.conf
     fi
-elif [[ ${option} == "WATCHDOG_VERBOSE" ]]; then
+  elif [[ ${option} == "WATCHDOG_VERBOSE" ]]; then
     if ! grep -q ${option} mailcow.conf; then
       echo '# Enable watchdog verbose logging' >> mailcow.conf
       echo 'WATCHDOG_VERBOSE=n' >> mailcow.conf
-  fi
+    fi
+  elif [[ ${option} == "WATCHDOG_SMARTHOST" ]]; then
+    if ! grep -q ${option} mailcow.conf; then
+      echo '# Enable watchdog smarthost' >> mailcow.conf
+      echo 'WATCHDOG_SMARTHOST=n' >> mailcow.conf
+    fi
   elif ! grep -q ${option} mailcow.conf; then
     echo "Adding new option \"${option}\" to mailcow.conf"
     echo "${option}=n" >> mailcow.conf


### PR DESCRIPTION
I tried to add a new option for mailcow.conf that adds a smarthost for watchdog. Everybody with a dynamic ip for mailcow using a smarthost to send emails will need this option as watchdog does not use this smarthost and tries to relay emails with the servers dynamic ip and most probably these emails are not transmitted successfully and blocked.

Furthermore I put in a fix for [#4726](https://github.com/mailcow/mailcow-dockerized/issues/4726) - at least it is working for me without any issues. Without an adaption of rspamd´s local.d/options.inc to the max_message size of postfix, the mail transport fails with error 4.7.1 - Service unavailable - try again later.

(Sorry for combining the two items in one pull request. To be honest I have no clue how to split it into two - im an absolute github beginner.)

Hope it helps in any way.
Mario