### PR TITLE
[Compose] Use new (patched) Netfilter Image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -424,7 +424,7 @@ services:
             - acme
 
     netfilter-mailcow:
-      image: mailcow/netfilter:1.48
+      image: mailcow/netfilter:1.49
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow


### PR DESCRIPTION
This PR uses the correct and patched Netfilter image which hasn´t been included in the 2022-10 Update.