### PR TITLE
[RSPAMD] Downgrade to 3.2 (stable)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
             - clamd
 
     rspamd-mailcow:
-      image: mailcow/rspamd:1.91
+      image: mailcow/rspamd:1.90
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow


### PR DESCRIPTION
Due to some reports of a corrupt Spamfilter we downgrade the RSPAMD Image to a lower version.

rspamd-mailcow:1.91 --> rspamd-mailcow:1.90

We´ll investigate the issue further.