### PR TITLE
Feature/enhance backup script

### DIFF
--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -25,7 +25,7 @@ if [[ ${1} == "help" ]]; then
       example: NODATE=1 backup_and_restore.sh backup all
 
       IMPORTANT: If you'd like to restore a NODATE=1 backup, you have to
-      use NODATE=1 for restoring as well! Otherwise, Mailcow will only
+      use NODATE=1 for restoring as well! Otherwise, mailcow will only
       look for timestamped folders, which you will not have.
 
   You can combine the variables as well.

--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -2,12 +2,50 @@
 
 DEBIAN_DOCKER_IMAGE="mailcow/backup:1.0"
 
+if [[ ${1} == "help" ]]; then
+  cat << END_OF_HELP
+  Script usage:
+
+  - Specify 'backup' or 'restore' mode:
+    backup_and_restore.sh backup
+    backup_and_restore.sh restore
+
+  - If you 'backup', you also have to specify what to backup.
+     Use 'backup' to see the backup options you can use.
+
+     backup_and_restore.sh backup
+
+  The script also comes with support for environment variables.
+
+  Available environment variables:
+    THREADS: Allows you to specify how many threads to backup with.
+      example: THREADS=4 backup_and_restore.sh backup all
+
+    NODATE: Allows you to omit the date stamped folder.
+      example: NODATE=1 backup_and_restore.sh backup all
+
+  You can combine the variables as well.
+    example: THREADS=4 NODATE=1 backup_and_restore.sh backup all
+
+  To do a full backup with the script, in an example "/backup/" folder:
+    echo "/backup/" | backup_and_restore.sh backup all
+
+  To do a full backup with 4 threads:
+    echo "/backup/" | THREADS=4 NODATE=1 backup_and_restore.sh backup all
+
+  To do a full backup with all available threads:
+    echo "/backup/" | THREADS=\`getconf _NPROCESSORS_ONLN\` NODATE=1 backup_and_restore.sh backup all
+
+END_OF_HELP
+  exit 0
+fi
+
 if [[ ! -z ${MAILCOW_BACKUP_LOCATION} ]]; then
   BACKUP_LOCATION="${MAILCOW_BACKUP_LOCATION}"
 fi
 
-if [[ ! ${1} =~ (backup|restore) ]]; then
-  echo "First parameter needs to be 'backup' or 'restore'"
+if [[ ! ${1} =~ (backup|restore|help) ]]; then
+  echo "First parameter needs to be 'backup' or 'restore' or 'help'"
   exit 1
 fi
 
@@ -58,7 +96,7 @@ if ! [[ "${THREADS}" =~ ^[1-9]+$ ]] ; then
   echo "Thread input is not a number!"
   exit 1
 elif [[ "${THREADS}" =~ ^[1-9]+$ ]] ; then
-  echo "Using ${THREADS} Thread(s) for this run." 
+  echo "Using ${THREADS} Thread(s) for this run."
   echo "Notice: You can set the Thread count with the THREADS Variable before you run this script."
 fi
 
@@ -190,7 +228,7 @@ function restore() {
 
   elif [ "${DOCKER_COMPOSE_VERSION}" == "standalone" ]; then
     COMPOSE_COMMAND="docker-compose"
-  
+
   else
     echo -e "\e[31mCan not read DOCKER_COMPOSE_VERSION variable from mailcow.conf! Is your mailcow up to date? Exiting...\e[0m"
     exit 1

--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -23,6 +23,10 @@ if [[ ${1} == "help" ]]; then
 
     NODATE: Allows you to omit the date stamped folder.
       example: NODATE=1 backup_and_restore.sh backup all
+      
+      IMPORTANT: If you'd like to restore a NODATE backup, you have to
+      use NODATE=1 for restoring as well! Otherwise, Mailcow will only
+      look for timestamped folders, which you will not have.
 
   You can combine the variables as well.
     example: THREADS=4 NODATE=1 backup_and_restore.sh backup all
@@ -367,10 +371,20 @@ if [[ ${1} == "backup" ]]; then
 elif [[ ${1} == "restore" ]]; then
   i=1
   declare -A FOLDER_SELECTION
-  if [[ $(find ${BACKUP_LOCATION}/mailcow-* -maxdepth 1 -type d 2> /dev/null| wc -l) -lt 1 ]]; then
-    echo "Selected backup location has no subfolders"
-    exit 1
+  
+  if [[ -z "${NODATE}" ]]; then
+    # No NODATE defined so restore normally
+    if [[ $(find ${BACKUP_LOCATION}/mailcow-* -maxdepth 1 -type d 2> /dev/null| wc -l) -lt 1 ]]; then
+      echo "Selected backup location has no timestamped subfolders"
+      exit 1
+    fi
+  else
+    if [[ $(find ${BACKUP_LOCATION}/* -maxdepth 1 -type d 2> /dev/null| wc -l) -lt 1 ]]; then
+      echo "Selected backup location has no subfolders"
+      exit 1
+    fi
   fi
+  
   for folder in $(ls -d ${BACKUP_LOCATION}/mailcow-*/); do
     echo "[ ${i} ] - ${folder}"
     FOLDER_SELECTION[${i}]="${folder}"


### PR DESCRIPTION
Sorry that I make another appearance regarding this script. I use it a lot and the latest THREADS was a great improvement.

This time, I added two things:

- NODATE
This skips the creation of the timestamp folder. Why? If you back up via s3fs, or backblaze/s3 client, you may opt for overwriting your backup files, and store them with the same name. This way, you can use bucket policy to practically never run out of disk space (well, never run out of money) and still have several snapshots available.

Usage: Specifying any value, such as NODATE=1 will work.
- 'help'
Adds a new option the user can call to see what the script can actually do.
It can be called with ".sh help", or if the user simply calls the script without any argument, the script now tells them about this.

**Feel free to change NODATE**'s name, or the text of help, of course. This worked for me, but I'm just a user of this great project. Thank you guys for your continued work on Mailcow!