### PR TITLE
[PHP] Update to 8.1

### DIFF
--- a/data/Dockerfiles/phpfpm/Dockerfile
+++ b/data/Dockerfiles/phpfpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-fpm-alpine3.16
+FROM php:8.1-fpm-alpine3.16
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
 ENV APCU_PECL 5.1.21

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
             - rspamd
 
     php-fpm-mailcow:
-      image: mailcow/phpfpm:1.79
+      image: mailcow/phpfpm:1.80
       command: "php-fpm -d date.timezone=${TZ} -d expose_php=0"
       depends_on:
         - redis-mailcow


### PR DESCRIPTION
This PR updates PHP to 8.1.

As mentioned in the Issue: https://github.com/mailcow/mailcow-dockerized/issues/4839 PHP 8.0 runs EOL in a few weeks.

Thanks to @BigMichi1 for mentioning.