### PR TITLE
[Rspamd] Update to 3.4 (fix of 3.3 Bug)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
             - clamd
 
     rspamd-mailcow:
-      image: mailcow/rspamd:1.90
+      image: mailcow/rspamd:1.91
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow


### PR DESCRIPTION
This PR will reintroduce the newest Rspamd Version after the breaking bug which has introduced in 2022-10.

2022-10a removed the newest Rspamd Version due to a bug with BCC Maps which now have fixed in Rspamd 3.4

The Changelog of Rspamd 3.4 can be found here: https://github.com/rspamd/rspamd/releases/tag/3.4