### PR TITLE
root@Mail:~/mailcow/mailcow-dockerized# docker-compose pull

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -204,10 +204,10 @@ DBROOT=$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 | head -c 28)
 # For IPv6 see https://mailcow.github.io/mailcow-dockerized-docs/post_installation/firststeps-ip_bindings/
 
 HTTP_PORT=80
-HTTP_BIND=
+HTTP_BIND=0.0.0.0
 
 HTTPS_PORT=443
-HTTPS_BIND=
+HTTPS_BIND=0.0.0.0
 
 # ------------------------------
 # Other bindings


### PR DESCRIPTION
ERROR: The Compose file './docker-compose.yml' is invalid because: services.nginx-mailcow.ports is invalid: Invalid port ":443:443", should be [[remote_ip:]remote_port[-remote_port]:]port[/protocol] services.nginx-mailcow.ports is invalid: Invalid port ":80:80", should be [[remote_ip:]remote_port[-remote_port]:]port[/protocol]

Cant compose without BINDing IPs