### PR TITLE
Fix sorting of mail configuration DataTables

### DIFF
--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -623,6 +623,7 @@ jQuery(function($){
       processing: true,
       serverSide: false,
       language: lang_datatables,
+      order:[[2, 'desc']],
       ajax: {
         type: "GET",
         url: "/api/v1/get/domain/template/all",
@@ -1078,6 +1079,7 @@ jQuery(function($){
       processing: true,
       serverSide: false,
       language: lang_datatables,
+      order:[[2, 'desc']],
       ajax: {
         type: "GET",
         url: "/api/v1/get/mailbox/template/all",
@@ -1414,6 +1416,7 @@ jQuery(function($){
       processing: true,
       serverSide: false,
       language: lang_datatables,
+      order:[[2, 'desc']],
       ajax: {
         type: "GET",
         url: "/api/v1/get/bcc/all",
@@ -1510,6 +1513,7 @@ jQuery(function($){
       processing: true,
       serverSide: false,
       language: lang_datatables,
+      order:[[2, 'desc']],
       ajax: {
         type: "GET",
         url: "/api/v1/get/recipient_map/all",
@@ -1593,6 +1597,7 @@ jQuery(function($){
       processing: true,
       serverSide: false,
       language: lang_datatables,
+      order:[[2, 'desc']],
       ajax: {
         type: "GET",
         url: "/api/v1/get/tls-policy-map/all",
@@ -1686,6 +1691,7 @@ jQuery(function($){
       processing: true,
       serverSide: false,
       language: lang_datatables,
+      order:[[2, 'desc']],
       ajax: {
         type: "GET",
         url: "/api/v1/get/alias/all",
@@ -2049,6 +2055,7 @@ jQuery(function($){
       processing: true,
       serverSide: false,
       language: lang_datatables,
+      order:[[2, 'desc']],
       ajax: {
         type: "GET",
         url: "/api/v1/get/filters/all",

--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -1908,6 +1908,7 @@ jQuery(function($){
       processing: true,
       serverSide: false,
       language: lang_datatables,
+      order:[[2, 'desc']],
       ajax: {
         type: "GET",
         url: "/api/v1/get/syncjobs/all/no_log",


### PR DESCRIPTION
I have added a default sorting column to the datatables that have an `ID` column. This ensures logical sorting and removes the additional sort button that could not be used (on the first hidden column).

I have not altered the sorting on the other DataTables that do not have an `ID` column, as I do not know what would be preferred.

Fixes #4942.