### PR TITLE
[Dovecot] Update to 2.3.20

### DIFF
--- a/data/Dockerfiles/dovecot/Dockerfile
+++ b/data/Dockerfiles/dovecot/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:bullseye-slim
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
+# renovate: datasource=github-tags depName=dovecot/core versioning=semver-coerced
 ARG DOVECOT=2.3.20
 # renovate: datasource=github-releases depName=tianon/gosu versioning=semver-coerced
 ARG GOSU_VERSION=1.16

--- a/data/Dockerfiles/dovecot/Dockerfile
+++ b/data/Dockerfiles/dovecot/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bullseye-slim
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG DOVECOT=2.3.19.1
+ARG DOVECOT=2.3.20
 # renovate: datasource=github-releases depName=tianon/gosu versioning=semver-coerced
 ARG GOSU_VERSION=1.16
 ENV LC_ALL C

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,7 +216,7 @@ services:
             - sogo
 
     dovecot-mailcow:
-      image: mailcow/dovecot:1.21
+      image: mailcow/dovecot:1.22
       depends_on:
         - mysql-mailcow
       dns:


### PR DESCRIPTION
This PR will bump Dovecot up to Version 2.3.20

Changelog:

https://dovecot.org/pipermail/dovecot-news/2022-December/000479.html