### PR TITLE
Update composer and allow renovate for updating Dockerfiles

### DIFF
--- a/data/Dockerfiles/phpfpm/Dockerfile
+++ b/data/Dockerfiles/phpfpm/Dockerfile
@@ -1,12 +1,18 @@
 FROM php:8.1-fpm-alpine3.17
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
-ENV APCU_PECL 5.1.22
-ENV IMAGICK_PECL 3.7.0
-ENV MAILPARSE_PECL 3.1.4
-ENV MEMCACHED_PECL 3.2.0
-ENV REDIS_PECL 5.3.7
-ENV COMPOSER 2.4.4
+# renovate: datasource=github-tags depName=krakjoe/apcu versioning=semver-coerced
+ARG APCU_PECL_VERSION=5.1.22
+# renovate: datasource=github-tags depName=Imagick/imagick versioning=semver-coerced
+ARG IMAGICK_PECL_VERSION=3.7.0
+# renovate: datasource=github-tags depName=php/pecl-mail-mailparse versioning=semver-coerced
+ARG MAILPARSE_PECL_VERSION=3.1.4
+# renovate: datasource=github-tags depName=php-memcached-dev/php-memcached versioning=semver-coerced
+ARG MEMCACHED_PECL_VERSION=3.2.0
+# renovate: datasource=github-tags depName=phpredis/phpredis versioning=semver-coerced
+ARG REDIS_PECL_VERSION=5.3.7
+# renovate: datasource=github-tags depName=composer/composer versioning=semver-coerced
+ARG COMPOSER_VERSION=2.5.1
 
 RUN apk add -U --no-cache autoconf \
   aspell-dev \
@@ -55,11 +61,11 @@ RUN apk add -U --no-cache autoconf \
   samba-client \
   zlib-dev \
   tzdata \
-  && pecl install mailparse-${MAILPARSE_PECL} \
-  && pecl install redis-${REDIS_PECL} \
-  && pecl install memcached-${MEMCACHED_PECL} \
-  && pecl install APCu-${APCU_PECL} \
-  && pecl install imagick-${IMAGICK_PECL} \
+  && pecl install APCu-${APCU_PECL_VERSION} \
+  && pecl install imagick-${IMAGICK_PECL_VERSION} \
+  && pecl install mailparse-${MAILPARSE_PECL_VERSION} \
+  && pecl install memcached-${MEMCACHED_PECL_VERSION} \
+  && pecl install redis-${REDIS_PECL_VERSION} \
   && docker-php-ext-enable apcu imagick memcached mailparse redis \
   && pecl clear-cache \
   && docker-php-ext-configure intl \
@@ -72,7 +78,7 @@ RUN apk add -U --no-cache autoconf \
   && docker-php-ext-install -j 4 exif gd gettext intl ldap opcache pcntl pdo pdo_mysql pspell soap sockets zip bcmath gmp \
   && docker-php-ext-configure imap --with-imap --with-imap-ssl \
   && docker-php-ext-install -j 4 imap \
-  && curl --silent --show-error https://getcomposer.org/installer | php -- --version=${COMPOSER} \
+  && curl --silent --show-error https://getcomposer.org/installer | php -- --version=${COMPOSER_VERSION} \
   && mv composer.phar /usr/local/bin/composer \
   && chmod +x /usr/local/bin/composer \
   && apk del --purge autoconf \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
             - rspamd
 
     php-fpm-mailcow:
-      image: mailcow/phpfpm:1.81
+      image: mailcow/phpfpm:1.82
       command: "php-fpm -d date.timezone=${TZ} -d expose_php=0"
       depends_on:
         - redis-mailcow


### PR DESCRIPTION
This PR will do following:
Add matchstrings for extracting gosu versions
Update composer to 2.5.1
Change ENV to ARG since environment variables are only needed during build, and not used in the final image
Reference:
https://docs.docker.com/engine/reference/builder/#env
```
If an environment variable is only needed during build, and not in the final image, consider setting a value for a single command instead:

RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y ...

Or using ARG, which is not persisted in the final image:

ARG DEBIAN_FRONTEND=noninteractive
RUN apt-get update && apt-get install -y ...
```

**Need new image mailcow/phpfpm:1.82 on Dockerhub!**