### PR TITLE
[Fix] SOGo Update Fix for 5.8.0 (macOS fix)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,7 +169,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: mailcow/sogo:1.114
+      image: mailcow/sogo:1.115
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}


### PR DESCRIPTION
This PR will hopefully finally fix the annoying macOS bug with caldav from sogo.

As mentioned in the Issue: https://github.com/mailcow/mailcow-dockerized/issues/4897 the problem seems to be resolved now.