### PR TITLE
Add Date header to messages if it's missing

### DIFF
--- a/data/conf/dovecot/global_sieve_before
+++ b/data/conf/dovecot/global_sieve_before
@@ -1,7 +1,13 @@
 # global_sieve_before script
 # global_sieve_before -> user sieve_before (mailcow UI) -> user sieve_after (mailcow UI) -> global_sieve_after
 
-require ["mailbox", "fileinto"];
+require ["mailbox", "fileinto", "date", "editheader", "variables"];
+
+if not exists "Date" {
+  if date :matches "received" "std11" "*" {
+    addheader :last "Date" "${1}";
+  }
+}
 
 if header :contains ["Chat-Version"] [""] {
   if mailboxexists "DeltaChat" {


### PR DESCRIPTION
I am fully aware that adding a `date` header to e-mail is responsibility of the sender's client. However, there is also no reason known to me to not have this header automatically added on recipient's side when it is missing.

Not having date header creates problems in EAS clients like Android's Gmail app - it assigns the date of sync to the e-mails and therefore ordering is wrong. Furthermore, when trying to manipulate such messages (like moving or deleting them) it sometimes crashes the app. Of course, all of this is the app's fault, but Google won't be fixing this for people using 3rd party mail services based on my experience dealing with them.

`Received` headers should always be available and are the most reliable reference for setting the `Date` header.

I also believe that Dovecot Sieve is the correct place to handle this, as spam filters before it could increase spam score based on this header missing, which is a legitimate behavior.

In the past, I had very weird problems with EAS clients on my phone and while I did not test this back then, presence of such messages in my inbox might have been the culprit. I did observe Gmail app crashing when manipulating these messages and can reproduce this behavior reliably.