### PR TITLE
[CLAMAV] Update to 1.0.1

### DIFF
--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -1,4 +1,4 @@
-FROM clamav/clamav:1.0_base
+FROM clamav/clamav:1.0.1-1_base
 
 LABEL maintainer "André Peters <andre.peters@servercow.de>"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
             - redis
 
     clamd-mailcow:
-      image: mailcow/clamd:1.60
+      image: mailcow/clamd:1.61
       restart: always
       depends_on:
         - unbound-mailcow


### PR DESCRIPTION
This PR updates mailcow CLAMAV to Version 1.0.1.

It fixes some ClamAV security related issues mentioned here: https://github.com/Cisco-Talos/clamav/releases/tag/clamav-1.0.1