### PR TITLE
feat(docker): add support for rootless docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,6 @@ services:
         - "${REDIS_PORT:-127.0.0.1:7654}:6379"
       environment:
         - TZ=${TZ}
-      sysctls:
-        - net.core.somaxconn=4096
       networks:
         mailcow-network:
           ipv4_address: ${IPV4_NETWORK:-172.22.1}.249
@@ -284,11 +282,6 @@ services:
         ofelia.job-exec.dovecot_fts.command: "/usr/bin/curl http://solr:8983/solr/dovecot-fts/update?optimize=true"
         ofelia.job-exec.dovecot_repl_health.schedule: "@every 5m"
         ofelia.job-exec.dovecot_repl_health.command: "/bin/bash -c \"/usr/local/bin/gosu vmail /usr/local/bin/repl_health.sh\""
-      ulimits:
-        nproc: 65535
-        nofile:
-          soft: 20000
-          hard: 40000
       networks:
         mailcow-network:
           ipv4_address: ${IPV4_NETWORK:-172.22.1}.250
@@ -434,7 +427,6 @@ services:
         - php-fpm-mailcow
         - redis-mailcow
       restart: always
-      privileged: true
       environment:
         - TZ=${TZ}
         - IPV4_NETWORK=${IPV4_NETWORK:-172.22.1}
@@ -443,7 +435,6 @@ services:
         - SNAT6_TO_SOURCE=${SNAT6_TO_SOURCE:-n}
         - REDIS_SLAVEOF_IP=${REDIS_SLAVEOF_IP:-}
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
-      network_mode: "host"
       volumes:
         - /lib/modules:/lib/modules:ro
 
@@ -522,7 +513,7 @@ services:
         - REDIS_SLAVEOF_IP=${REDIS_SLAVEOF_IP:-}
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
       volumes:
-        - /var/run/docker.sock:/var/run/docker.sock:ro
+        - /run/user/${CURRENT_USER_ID:?}/docker.sock:/var/run/docker.sock:ro
       networks:
         mailcow-network:
           aliases:
@@ -576,7 +567,7 @@ services:
       security_opt:
         - label=disable
       volumes:
-        - /var/run/docker.sock:/var/run/docker.sock:ro
+        - /run/user/${CURRENT_USER_ID:?}/docker.sock:/var/run/docker.sock:ro
       networks:
         mailcow-network:
           aliases:
@@ -606,10 +597,8 @@ services:
       security_opt:
         - label=disable
       restart: always
-      privileged: true
-      network_mode: "host"
       volumes:
-        - /var/run/docker.sock:/var/run/docker.sock:ro
+        - /run/user/${CURRENT_USER_ID:?}/docker.sock:/var/run/docker.sock:ro
         - /lib/modules:/lib/modules:ro
 
 networks:

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -33,7 +33,7 @@ if docker compose > /dev/null 2>&1; then
       sleep 2
       echo -e "\e[33mNotice: You´ll have to update this Compose Version via your Package Manager manually!\e[0m"
     else
-      echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m" 
+      echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m"
       echo -e "\e[31mPlease update/install it manually regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
       exit 1
     fi
@@ -46,14 +46,14 @@ elif docker-compose > /dev/null 2>&1; then
       sleep 2
       echo -e "\e[33mNotice: For an automatic update of docker-compose please use the update_compose.sh scripts located at the helper-scripts folder.\e[0m"
     else
-      echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m" 
+      echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m"
       echo -e "\e[31mPlease update/install manually regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
       exit 1
     fi
   fi
 
 else
-  echo -e "\e[31mCannot find Docker Compose.\e[0m" 
+  echo -e "\e[31mCannot find Docker Compose.\e[0m"
   echo -e "\e[31mPlease install it regarding to this doc site: https://mailcow.github.io/mailcow-dockerized-docs/i_u_m/i_u_m_install/\e[0m"
   exit 1
 fi
@@ -173,7 +173,7 @@ else
   echo -e "\033[31mCould not determine branch input..."
   echo -e "\033[31mExiting."
   exit 1
-fi  
+fi
 
 if [ ! -z "${MAILCOW_BRANCH}" ]; then
   git_branch=${MAILCOW_BRANCH}
@@ -430,6 +430,9 @@ ACME_CONTACT=
 # After setting WEBAUTHN_ONLY_TRUSTED_VENDORS=y only devices from trusted manufacturers are allowed
 # root certificates can be placed for validation under mailcow-dockerized/data/web/inc/lib/WebAuthn/rootCertificates
 WEBAUTHN_ONLY_TRUSTED_VENDORS=n
+
+# To mount rootless docker.sock we need to know current user id
+CURRENT_USER_ID=$UID
 
 EOF
 


### PR DESCRIPTION
As it seems that Rootless Docker is more secure alternative to the regular Docker it would be nice to be able to use Mailcow under the Rootless Docker.

I'm not the expert in the field, just was testing if it is possible to run Mailcow under the Rootless Docker at all.

These changes currently are not supposed to be merged, as it modifies basic `docker-compose.yml` for the purpose to be able to visually show the difference and, if everything's ok, then it can be transferred into new docker compose file or to some other logic.

I didn't do much, just removed unsupported lines and changed path to `docker.sock`. But it actually looks to be working just fine on my test server...

May be `sysctls` and `ulimits` options can be moved to some local docker config, for example under `~/.config`?

Also I had to add `CURRENT_USER_ID` variable as for some reason docker compose wasn't able to use just `$UID` inside `volumes` section, I'm not sure why.

Linux Info:
```bash
uname -a

Linux hostname #66-Ubuntu SMP Fri Jan 20 14:29:49 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
```

Docker Info:
```bash
docker info

Client:
 Context:    rootless
 Debug Mode: false
 Plugins:
  compose: Docker Compose (Docker Inc.)
    Version:  v2.16.0
    Path:     /home/username/.docker/cli-plugins/docker-compose

Server:
 Containers: 20
  Running: 19
  Paused: 0
  Stopped: 1
 Images: 21
 Server Version: 23.0.0
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Using metacopy: false
  Native Overlay Diff: false
  userxattr: true
 Logging Driver: json-file
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 31aa4358a36870b21a992d3ad2bef29e1d693bec
 runc version: v1.1.4-0-g5fd4c4d
 init version: de40ad0
 Security Options:
  seccomp
   Profile: builtin
  rootless
  cgroupns
 Kernel Version: 5.15.0-60-generic
 Operating System: Ubuntu 22.04.1 LTS
 OSType: linux
 Architecture: x86_64
 CPUs: 4
 Total Memory: 7.763GiB
 Name: hostname
 ID: 9b12ef02-ef97-4e74-9cea-0406aba841d0
 Docker Root Dir: /home/username/.local/share/docker
 Debug Mode: false
 Registry: https://index.docker.io/v1/
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false
 Product License: Community Engine

WARNING: No cpu cfs quota support
WARNING: No cpu cfs period support
WARNING: No cpu shares support
WARNING: No cpuset support
WARNING: No io.weight support
WARNING: No io.weight (per device) support
WARNING: No io.max (rbps) support
WARNING: No io.max (wbps) support
WARNING: No io.max (riops) support
WARNING: No io.max (wiops) support
WARNING: bridge-nf-call-iptables is disabled
WARNING: bridge-nf-call-ip6tables is disabled
```