### PR TITLE
optionally allow setting smtp address binds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -319,9 +319,9 @@ services:
       cap_add:
         - NET_BIND_SERVICE
       ports:
-        - "${SMTP_PORT:-25}:25"
-        - "${SMTPS_PORT:-465}:465"
-        - "${SUBMISSION_PORT:-587}:587"
+        - "${SMTP_BIND:-}:${SMTP_PORT:-25}:25"
+        - "${SMTPS_BIND:-}:${SMTPS_PORT:-465}:465"
+        - "${SUBMISSION_BIND:-}:${SUBMISSION_PORT:-587}:587"
       restart: always
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254


### PR DESCRIPTION
if mailcow smtp, smtps and submission should not listen on all addresses, the variables SMTP_BIND, SMTPS_BIND and SUBMISSION_BIND can now be used