### PR TITLE
Add raw attribute for lang.admin.hash_remove_info

### DIFF
--- a/data/web/templates/debug.twig
+++ b/data/web/templates/debug.twig
@@ -612,7 +612,7 @@
               <li class="table_collapse_option"><a class="dropdown-item" data-datatables-expand="rl_log" data-table="rl_log" href="#">{{ lang.datatables.expand_all }}</a></li>
               <li class="table_collapse_option"><a class="dropdown-item" data-datatables-collapse="rl_log" data-table="rl_log" href="#">{{ lang.datatables.collapse_all }}</a></li>
             </ul>
-            <p class="text-muted">{{ lang.admin.hash_remove_info }}</p>
+            <p class="text-muted">{{ lang.admin.hash_remove_info|raw }}</p>
             <table id="rl_log" class="table table-striped dt-responsive w-100"></table>
           </div>
         </div>


### PR DESCRIPTION
This PR adds the `raw` attribute for lang.admin.hash_remove_info to allow using HTML tags

Before:
![image](https://user-images.githubusercontent.com/3279213/221949159-2ab9200b-84e5-4f61-94ad-6afcc24aa709.png)

After:
![image](https://user-images.githubusercontent.com/3279213/221949184-f3f87f57-7810-4f1d-948b-c43ac3b4e5de.png)
