### PR TITLE
Update to PHP 8.2

### DIFF
--- a/data/Dockerfiles/phpfpm/Dockerfile
+++ b/data/Dockerfiles/phpfpm/Dockerfile
@@ -12,7 +12,7 @@ ARG MEMCACHED_PECL_VERSION=3.2.0
 # renovate: datasource=github-tags depName=phpredis/phpredis versioning=semver-coerced
 ARG REDIS_PECL_VERSION=5.3.7
 # renovate: datasource=github-tags depName=composer/composer versioning=semver-coerced
-ARG COMPOSER_VERSION=2.5.4
+ARG COMPOSER_VERSION=2.5.5
 
 RUN apk add -U --no-cache autoconf \
   aspell-dev \

--- a/data/Dockerfiles/phpfpm/Dockerfile
+++ b/data/Dockerfiles/phpfpm/Dockerfile
@@ -76,7 +76,7 @@ RUN apk add -U --no-cache autoconf \
     --with-webp \
     --with-xpm \
     --with-avif \
-  && docker-php-ext-install -j 4 exif gd gettext intl ldap opcache pcntl pdo pdo_mysql pspell soap sockets zip bcmath gmp \
+  && docker-php-ext-install -j 4 exif gd gettext intl ldap opcache pcntl pdo pdo_mysql pspell soap sockets sysvsem zip bcmath gmp \
   && docker-php-ext-configure imap --with-imap --with-imap-ssl \
   && docker-php-ext-install -j 4 imap \
   && curl --silent --show-error https://getcomposer.org/installer | php -- --version=${COMPOSER_VERSION} \

--- a/data/Dockerfiles/phpfpm/Dockerfile
+++ b/data/Dockerfiles/phpfpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-alpine3.17
+FROM php:8.2-fpm-alpine3.17
 LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
 # renovate: datasource=github-tags depName=krakjoe/apcu versioning=semver-coerced
@@ -52,6 +52,7 @@ RUN apk add -U --no-cache autoconf \
   libxpm-dev \
   libzip \
   libzip-dev \
+  linux-headers \
   make \
   mysql-client \
   openldap-dev \
@@ -99,6 +100,7 @@ RUN apk add -U --no-cache autoconf \
     libxml2-dev \
     libxpm-dev \
     libzip-dev \
+    linux-headers \
     make \
     openldap-dev \
     pcre-dev \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
             - rspamd
 
     php-fpm-mailcow:
-      image: mailcow/phpfpm:1.82
+      image: mailcow/phpfpm:1.83
       command: "php-fpm -d date.timezone=${TZ} -d expose_php=0"
       depends_on:
         - redis-mailcow


### PR DESCRIPTION
This PR updates the phpfpm container to PHP 8.2
Also fixes [CVE-2023-0567](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0567)

Currently I am testing it on my instance