### PR TITLE
Fix SELinux labelling of init_db.inc.php for SOGo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,7 +191,7 @@ services:
       volumes:
         - ./data/hooks/sogo:/hooks:Z
         - ./data/conf/sogo/:/etc/sogo/:z
-        - ./data/web/inc/init_db.inc.php:/init_db.inc.php:Z
+        - ./data/web/inc/init_db.inc.php:/init_db.inc.php:z
         - ./data/conf/sogo/custom-favicon.ico:/usr/lib/GNUstep/SOGo/WebServerResources/img/sogo.ico:z
         - ./data/conf/sogo/custom-theme.js:/usr/lib/GNUstep/SOGo/WebServerResources/js/theme.js:z
         - ./data/conf/sogo/custom-sogo.js:/usr/lib/GNUstep/SOGo/WebServerResources/js/custom-sogo.js:z


### PR DESCRIPTION
init_db.inc.php is currently labelled as exclusive for SOGo while in truth it is shared among containers.
This breaks the admin interface but also any of the DAV features of SOGo.