### PR TITLE
[SOGo] Disable password change option

### DIFF
--- a/data/conf/sogo/sogo.conf
+++ b/data/conf/sogo/sogo.conf
@@ -62,7 +62,7 @@
     SOGoFirstDayOfWeek = "1";
 
     SOGoSieveFolderEncoding = "UTF-8";
-    SOGoPasswordChangeEnabled = YES;
+    SOGoPasswordChangeEnabled = NO;
     SOGoSentFolderName = "Sent";
     SOGoMailShowSubscribedFoldersOnly = NO;
     NGImap4ConnectionStringSeparator = "/";


### PR DESCRIPTION
It doesn't work with ProxyAuth and in general not honor password policy set via mailcow UI. SOGo also do not provide own settings to provide any password policy. Due to this two issues I think that it's better have it disabled by default. People who need it can turn it back easily. We can update https://docs.mailcow.email/manual-guides/SOGo/u_e-sogo/#disable-password-changing to `enable-password-changin` and explanations of reasons why it is disabled.