### PR TITLE
Automatic PR to nightly from 2023-03-06T13:28:02Z

### DIFF
--- a/data/conf/rspamd/local.d/composites.conf
+++ b/data/conf/rspamd/local.d/composites.conf
@@ -8,7 +8,7 @@ VIRUS_FOUND {
 }
 # Bad policy from free mail providers
 FREEMAIL_POLICY_FAILURE {
-  expression = "-g+:policies & !DMARC_POLICY_ALLOW & !MAILLIST & ( FREEMAIL_ENVFROM | FREEMAIL_FROM ) & !WHITELISTED_FWD_HOST";
+  expression = "FREEMAIL_FROM & !DMARC_POLICY_ALLOW & !MAILLIST& !WHITELISTED_FWD_HOST & -g+:policies";
   score = 16.0;
 }
 # Applies to freemail with undisclosed recipients

--- a/data/conf/sogo/sogo.conf
+++ b/data/conf/sogo/sogo.conf
@@ -62,7 +62,7 @@
     SOGoFirstDayOfWeek = "1";
 
     SOGoSieveFolderEncoding = "UTF-8";
-    SOGoPasswordChangeEnabled = YES;
+    SOGoPasswordChangeEnabled = NO;
     SOGoSentFolderName = "Sent";
     SOGoMailShowSubscribedFoldersOnly = NO;
     NGImap4ConnectionStringSeparator = "/";

--- a/data/web/js/site/debug.js
+++ b/data/web/js/site/debug.js
@@ -1181,7 +1181,7 @@ jQuery(function($){
 
     if (table = $('#' + log_table).DataTable()) {
       var heading = $('#' + log_table).closest('.card').find('.card-header');
-      var load_rows = (table.page.len() + 1) + '-' + (table.page.len() + new_nrows)
+      var load_rows = (table.data().length + 1) + '-' + (table.data().length + new_nrows)
 
       $.get('/api/v1/get/logs/' + log_url + '/' + load_rows).then(function(data){
         if (data.length === undefined) { mailcow_alert_box(lang.no_new_rows, "info"); return; }

--- a/data/web/lang/lang.da-dk.json
+++ b/data/web/lang/lang.da-dk.json
@@ -83,7 +83,7 @@
         "private_comment": "Privat kommentar",
         "public_comment": "Offentlig kommentar",
         "quota_mb": "Kvota (Mb)",
-        "relay_all": "Send alle modtagere videre",
+        "relay_all": "Besvar alle modtager",
         "relay_all_info": "↪ Hvis du vælger <b> ikke </b> at videresende alle modtagere, skal du tilføje et (\"blind\") postkasse til hver enkelt modtager, der skal videresendes.",
         "relay_domain": "Send dette domæne videre",
         "relay_transport_info": "<div class=\"badge fs-6 bg-info\">Info</div> Du kan definere transportkort til en tilpasset destination for dette domæne. Hvis ikke indstillet, foretages der et MX-opslag.",
@@ -104,7 +104,10 @@
         "timeout2": "Timeout for forbindelse til lokal vært",
         "username": "Brugernavn",
         "validate": "Bekræft",
-        "validation_success": "Valideret med succes"
+        "validation_success": "Valideret med succes",
+        "bcc_dest_format": "BCC-destination skal være en enkelt gyldig e-mail-adresse.<br>Hvis du har brug for at sende en kopi til flere adresser, kan du oprette et alias og bruge det her.",
+        "app_passwd_protocols": "Tilladte protokoller for app adgangskode",
+        "tags": "Tag's"
     },
     "admin": {
         "access": "Adgang",
@@ -313,7 +316,8 @@
         "verify": "Verificere",
         "yes": "&#10003;",
         "ip_check_opt_in": "Opt-In for brug af tredjepartstjeneste <strong>ipv4.mailcow.email</strong> og <strong>ipv6.mailcow.email</strong> til at finde eksterne IP-adresser.",
-        "queue_unban": "unban"
+        "queue_unban": "unban",
+        "admins": "Administratorer"
     },
     "danger": {
         "access_denied": "Adgang nægtet eller ugyldig formular data",

--- a/data/web/lang/lang.fr-fr.json
+++ b/data/web/lang/lang.fr-fr.json
@@ -321,7 +321,9 @@
         "admins": "Administrateurs",
         "api_read_only": "Accès lecture-seule",
         "password_policy_lowerupper": "Doit contenir des caractères minuscules et majuscules",
-        "password_policy_numbers": "Doit contenir au moins un chiffre"
+        "password_policy_numbers": "Doit contenir au moins un chiffre",
+        "ip_check": "Vérification IP",
+        "ip_check_disabled": "La vérification IP est désactivée. Vous pouvez l'activer sous<br> <strong>Système > Configuration > Options > Personnaliser</strong>"
     },
     "danger": {
         "access_denied": "Accès refusé ou données de formulaire non valides",
@@ -440,7 +442,12 @@
         "username_invalid": "Le nom d'utilisateur %s ne peut pas être utilisé",
         "validity_missing": "Veuillez attribuer une période de validité",
         "value_missing": "Veuillez fournir toutes les valeurs",
-        "yotp_verification_failed": "La vérification Yubico OTP a échoué : %s"
+        "yotp_verification_failed": "La vérification Yubico OTP a échoué : %s",
+        "webauthn_authenticator_failed": "L'authentificateur selectionné est introuvable",
+        "demo_mode_enabled": "Le mode de démonstration est activé",
+        "template_exists": "La template %s existe déja",
+        "template_id_invalid": "Le numéro de template %s est invalide",
+        "template_name_invalid": "Le nom de la template est invalide"
     },
     "debug": {
         "chart_this_server": "Graphique (ce serveur)",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,7 +191,7 @@ services:
       volumes:
         - ./data/hooks/sogo:/hooks:Z
         - ./data/conf/sogo/:/etc/sogo/:z
-        - ./data/web/inc/init_db.inc.php:/init_db.inc.php:Z
+        - ./data/web/inc/init_db.inc.php:/init_db.inc.php:z
         - ./data/conf/sogo/custom-favicon.ico:/usr/lib/GNUstep/SOGo/WebServerResources/img/sogo.ico:z
         - ./data/conf/sogo/custom-theme.js:/usr/lib/GNUstep/SOGo/WebServerResources/js/theme.js:z
         - ./data/conf/sogo/custom-sogo.js:/usr/lib/GNUstep/SOGo/WebServerResources/js/custom-sogo.js:z


### PR DESCRIPTION
## :memo:  Brief description
<!-- Diff summary - START -->
Merge pull request #5090 from mailcow/staging
Merge pull request #5106 from mailcow/staging
Fix SELinux labelling of init_db.inc.php for SOGo
[Rspamd] Fix cases of forwarding via freemail
[SOGo] Disable password change option
Translations update from Weblate (#5114)
Merge pull request #5109 from mailcow/dragoangel-patch-2
Fix Bug with button to load more logs
Merge pull request #5119 from bdwebnet:staging
Merge pull request #5108 from mailcow:dragoangel-patch-1
Merge pull request #5107 from kaechele:staging
<!-- Diff summary - END -->


## :computer:  Commits
<!-- Diff commits - START -->
*   7225bd2f - Niklas Meyer - 2023-03-09 14:37:21 
|  Merge pull request #5107 from kaechele:staging
| | Fix SELinux labelling of init_db.inc.php for SOGo
| * 310c01aa - Felix Kaechele - 2023-03-03 22:57:10 
|   Fix SELinux labelling of init_db.inc.php for SOGo
|   init_db.inc.php is currently labelled as exclusive for SOGo while in
|   truth it is shared among containers.
|   This breaks the admin interface but also any of the DAV features of
|   SOGo.
|   
|   Signed-off-by: Felix Kaechele <felix@kaechele.ca>
|   
*   deb2b803 - Niklas Meyer - 2023-03-09 14:33:48 
|  Merge pull request #5108 from mailcow:dragoangel-patch-1
| | [Rspamd] Fix cases of forwarding via freemail
| * 1a9294b5 - Dmitriy Alekseev - 2023-03-04 17:57:52 
| | [Rspamd] Fix cases of forwarding via freemail
| | Excluding FREEMAIL_ENVFROM from the FREEMAIL_POLICY_FAILURE expression will allow forwarding mail via freemail services when the initial sender did not have a DKIM signature.
* |   ad9dee92 - Niklas Meyer - 2023-03-09 14:30:55 
|   Merge pull request #5119 from bdwebnet:staging
| | | Fixes Issue #5118 (Bug with load more logs buttons)
| * | f36bc16c - BD - 2023-03-08 10:35:23 
|/ /  Fix Bug with button to load more logs
| |   
* |   bda5f0ed - Niklas Meyer - 2023-03-07 09:07:45 
|   Merge pull request #5109 from mailcow/dragoangel-patch-2
| | | [SOGo] Disable password change option
| * | 81fcbdd1 - Dmitriy Alekseev - 2023-03-04 18:06:26 
| |/  [SOGo] Disable password change option
| |   It doesn't work with ProxyAuth and in general not honor password policy set via mailcow UI. SOGo also do not provide own settings to provide any password policy. Due to this two issues I think that it's better have it disabled by default. People who need it can turn it back easily. We can update https://docs.mailcow.email/manual-guides/SOGo/u_e-sogo/#disable-password-changing to `enable-password-changin` and explanations of reasons why it is disabled.
| * 229303c1 - Niklas Meyer - 2023-03-03 17:34:24 
|   Merge pull request #5106 from mailcow/staging
|   2023-03
* cbe1c97a - milkmaker - 2023-03-07 05:39:22 
  Translations update from Weblate (#5114)
  * [Web] Updated lang.da-dk.json
  
  [Web] Updated lang.da-dk.json
  
  [Web] Updated lang.da-dk.json
  
  Co-authored-by: Tacaly <frederick@tacaly.com>
  Co-authored-by: milkmaker <milkmaker@mailcow.de>
  
  * [Web] Updated lang.fr-fr.json
  
  Co-authored-by: Matthieu Leboeuf <contact@matthieul.dev>
  Co-authored-by: milkmaker <milkmaker@mailcow.de>
  
  ---------
  
  Co-authored-by: Tacaly <frederick@tacaly.com>
  Co-authored-by: Matthieu Leboeuf <contact@matthieul.dev>
* 2db82c1f - Niklas Meyer - 2023-03-03 16:09:28 
  Merge pull request #5090 from mailcow/staging
  Automatic PR to nightly from 2023-02-23T19:21:31Z
<!-- Diff commits - END -->


## :file_folder:  Modified files
<!-- Diff files - START -->
 data/conf/rspamd/local.d/composites.conf |  2 +-
 data/conf/sogo/sogo.conf                 |  2 +-
 data/web/js/site/debug.js                |  2 +-
 data/web/lang/lang.da-dk.json            | 10 +++++++---
 data/web/lang/lang.fr-fr.json            | 11 +++++++++--
 docker-compose.yml                       |  2 +-
 6 files changed, 20 insertions(+), 9 deletions(-)
<!-- Diff files - END -->
