### PR TITLE
[MariaDB] Upgrade to 10.6 (LTS)

### DIFF
--- a/data/Dockerfiles/dockerapi/dockerapi.py
+++ b/data/Dockerfiles/dockerapi/dockerapi.py
@@ -321,7 +321,7 @@ class DockerUtils:
   # api call: container_post - post_action: exec - cmd: system - task: mysql_upgrade
   def container_post__exec__system__mysql_upgrade(self, container_id, request_json):
     for container in self.docker_client.containers.list(filters={"id": container_id}):
-      sql_return = container.exec_run(["/bin/bash", "-c", "/usr/bin/mysql-upgrade -uroot -p'" + os.environ['DBROOT'].replace("'", "'\\''") + "'\n"], user='mysql')
+      sql_return = container.exec_run(["/bin/bash", "-c", "/usr/bin/mysql_upgrade -uroot -p'" + os.environ['DBROOT'].replace("'", "'\\''") + "'\n"], user='mysql')
       if sql_return.exit_code == 0:
         matched = False
         for line in sql_return.output.decode('utf-8').split("\n"):

--- a/data/Dockerfiles/phpfpm/docker-entrypoint.sh
+++ b/data/Dockerfiles/phpfpm/docker-entrypoint.sh
@@ -30,16 +30,16 @@ echo "MySQL @ ${CONTAINER_ID}"
 SQL_LOOP_C=0
 SQL_CHANGED=0
 SQL_TYPE=$(mysqladmin version -u${DBUSER} -p${DBPASS} --socket=/var/run/mysqld/mysqld.sock | grep -o -m 1 -E 'MySQL|MariaDB' | tr '[:upper:]' '[:lower:]')
-if [[ ${SQL_TYPE} == "mariadb" ]]; then
-    SQL_FULL_UPGRADE_RETURN=$(curl --silent --insecure -XPOST https://dockerapi/containers/${CONTAINER_ID}/exec -d '{"cmd":"system", "task":"mariadb_upgrade"}' --silent -H 'Content-type: application/json')
-elif [[ ${SQL_TYPE} == "mysql" ]]; then
-    SQL_FULL_UPGRADE_RETURN=$(curl --silent --insecure -XPOST https://dockerapi/containers/${CONTAINER_ID}/exec -d '{"cmd":"system", "task":"mysql_upgrade"}' --silent -H 'Content-type: application/json')
-fi
 
 until [[ ${SQL_UPGRADE_STATUS} == 'success' ]]; do
   if [ ${SQL_LOOP_C} -gt 4 ]; then
     echo "Tried to upgrade MySQL and failed, giving up after ${SQL_LOOP_C} retries and starting container (oops, not good)"
     break
+  fi
+  if [[ ${SQL_TYPE} == "mariadb" ]]; then
+    SQL_FULL_UPGRADE_RETURN=$(curl --silent --insecure -XPOST https://dockerapi/containers/${CONTAINER_ID}/exec -d '{"cmd":"system", "task":"mariadb_upgrade"}' --silent -H 'Content-type: application/json')
+  elif [[ ${SQL_TYPE} == "mysql" ]]; then
+      SQL_FULL_UPGRADE_RETURN=$(curl --silent --insecure -XPOST https://dockerapi/containers/${CONTAINER_ID}/exec -d '{"cmd":"system", "task":"mysql_upgrade"}' --silent -H 'Content-type: application/json')
   fi
   SQL_UPGRADE_STATUS=$(echo ${SQL_FULL_UPGRADE_RETURN} | jq -r .type)
   SQL_LOOP_C=$((SQL_LOOP_C+1))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
             - rspamd
 
     php-fpm-mailcow:
-      image: mailcow/phpfpm:1.82
+      image: mailcow/phpfpm:1.83
       command: "php-fpm -d date.timezone=${TZ} -d expose_php=0"
       depends_on:
         - redis-mailcow
@@ -510,7 +510,7 @@ services:
             - watchdog
 
     dockerapi-mailcow:
-      image: mailcow/dockerapi:2.01
+      image: mailcow/dockerapi:2.02
       security_opt:
         - label=disable
       restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
             - unbound
 
     mysql-mailcow:
-      image: mariadb:10.5
+      image: mariadb:10.6
       depends_on:
         - unbound-mailcow
       stop_grace_period: 45s


### PR DESCRIPTION
This PR is upgrading MariaDB (finally) to 10.6 LTS.

It also includes the mariadb_upgrade option which gets detected during the mysql upgrade phase.

This change is made since it seems that mysql_upgrade does not upgrade the MariaDB from 10.5 (or lower) to 10.6 properly if there is no --force option appended or if it get upgraded twice. But the upgrade process did not see this as a error.

The current tests applied that the upgrade process runs smoothly.

This issue mention the desired "bug": https://jira.mariadb.org/browse/MDEV-29648?attachmentOrder=desc

Updated Images:
+ mysql-mailcow (mariadb:10.5 -> mariadb:10.6)
+ phpfpm-mailcow (mailcow/phpfpm:1.82 -> mailcow/phpfpm:1.83)
+ dockerapi-mailcow (mailcow/dockerapi:2.01 -> mailcow/dockerapi:2.02)