### PR TITLE
[Mariadb] Update to 10.11 (LTS)

### DIFF
--- a/data/conf/mysql/my.cnf
+++ b/data/conf/mysql/my.cnf
@@ -1,7 +1,7 @@
 [mysqld]
 character-set-client-handshake = FALSE
 character-set-server           = utf8mb4
-collation-server               = utf8mb4_unicode_ci
+collation-server               = utf8mb4_general_ci
 #innodb_file_per_table          = TRUE
 #innodb_file_format             = barracuda
 #innodb_large_prefix            = TRUE

--- a/data/conf/mysql/my.cnf
+++ b/data/conf/mysql/my.cnf
@@ -20,7 +20,7 @@ thread_cache_size       = 8
 query_cache_type        = 0
 query_cache_size        = 0
 max_heap_table_size     = 48M
-thread_stack            = 192K
+thread_stack            = 256K
 skip-host-cache
 skip-name-resolve
 log-warnings            = 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
             - unbound
 
     mysql-mailcow:
-      image: mariadb:10.5
+      image: mariadb:10.11
       depends_on:
         - unbound-mailcow
         - netfilter-mailcow


### PR DESCRIPTION
This PR includes the mariadb upgrade from the current mailcow used version (10.5) to the latest LTS Version from mariadb to 10.11.

It also includes a change in case of thread_stack size value which had to be increased from 128k to 256k due to the mysql_upgrade process.

In some very rare cases the mysql upgrade will fail from 10.5 to 10.11 and needs to be rerun manually from cli (at least it has confirmed for the versions < 10.11 >=10.6 (https://jira.mariadb.org/browse/MDEV-29648?attachmentOrder=desc)