### PR TITLE
[Dockerapi] delete vmail_index on maildir cleanup

### DIFF
--- a/data/Dockerfiles/dockerapi/dockerapi.py
+++ b/data/Dockerfiles/dockerapi/dockerapi.py
@@ -380,7 +380,12 @@ class DockerUtils:
     if 'maildir' in request_json:
       for container in self.docker_client.containers.list(filters={"id": container_id}):
         sane_name = re.sub(r'\W+', '', request_json['maildir'])
-        cmd = ["/bin/bash", "-c", "if [[ -d '/var/vmail/" + request_json['maildir'].replace("'", "'\\''") + "' ]]; then /bin/mv '/var/vmail/" + request_json['maildir'].replace("'", "'\\''") + "' '/var/vmail/_garbage/" + str(int(time.time())) + "_" + sane_name + "'; fi"]
+        vmail_name = request_json['maildir'].replace("'", "'\\''")
+        index_name = request_json['maildir'].split("/")
+        index_name = index_name[1].replace("'", "'\\''") + "@" + index_name[0].replace("'", "'\\''")
+        cmd_vmail = "if [[ -d '/var/vmail/" + vmail_name + "' ]]; then /bin/mv '/var/vmail/" + vmail_name + "' '/var/vmail/_garbage/" + str(int(time.time())) + "_" + sane_name + "'; fi"
+        cmd_vmail_index = "if [[ -d '/var/vmail_index/" + index_name + "' ]]; then /bin/mv '/var/vmail_index/" + index_name + "' '/var/vmail/_garbage/" + str(int(time.time())) + "_" + sane_name + "_index'; fi"
+        cmd = ["/bin/bash", "-c", cmd_vmail + " && " + cmd_vmail_index]
         maildir_cleanup = container.exec_run(cmd, user='vmail')
         return exec_run_handler('generic', maildir_cleanup)
   # api call: container_post - post_action: exec - cmd: rspamd - task: worker_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -510,7 +510,7 @@ services:
             - watchdog
 
     dockerapi-mailcow:
-      image: mailcow/dockerapi:2.01
+      image: mailcow/dockerapi:2.02
       security_opt:
         - label=disable
       restart: always


### PR DESCRIPTION
This PR fixes an issue where only the vmail directory was getting deleted during maildir cleanup. With this fix, both the vmail and vmail_index folders will be deleted. 

Resolves https://github.com/mailcow/mailcow-dockerized/issues/5112