### PR TITLE
Fix error  "Deprecated: Using ${var} in strings is deprecated, use {$…

### DIFF
--- a/data/web/sogo-auth.php
+++ b/data/web/sogo-auth.php
@@ -60,7 +60,7 @@ elseif (isset($_GET['login'])) {
           ':remote_addr' => ($_SERVER['HTTP_X_REAL_IP'] ?? $_SERVER['REMOTE_ADDR'])
         ));
         // redirect to sogo (sogo will get the correct credentials via nginx auth_request
-        header("Location: /SOGo/so/${login}");
+        header("Location: /SOGo/so/{$login}");
         exit;
       }
     }


### PR DESCRIPTION
On a new installed mailcow I get the error `Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /web/sogo-auth.php on line 63` when I click "**Login to webmail**" in mailcow UI. I fixed this error.