### PR TITLE
[Web] Fix BCC validation

### DIFF
--- a/data/web/inc/functions.address_rewriting.inc.php
+++ b/data/web/inc/functions.address_rewriting.inc.php
@@ -49,7 +49,9 @@ function bcc($_action, $_data = null, $_attr = null) {
       }
       elseif (filter_var($local_dest, FILTER_VALIDATE_EMAIL)) {
         $mailbox = mailbox('get', 'mailbox_details', $local_dest);
-        if ($mailbox === false && array_key_exists($local_dest, array_merge($direct_aliases, $shared_aliases)) === false) {
+        $shared_aliases = mailbox('get', 'shared_aliases');
+        $direct_aliases = mailbox('get', 'direct_aliases');
+        if ($mailbox === false && in_array($local_dest, array_merge($direct_aliases, $shared_aliases)) === false) {
           $_SESSION['return'][] = array(
             'type' => 'danger',
             'log' => array(__FUNCTION__, $_action, $_data, $_attr),

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -3965,6 +3965,39 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           }
           return $aliasdomaindata;
         break;
+        case 'shared_aliases':
+          $shared_aliases = array();
+          $stmt = $pdo->query("SELECT `address` FROM `alias`
+            WHERE `goto` REGEXP ','
+            AND `address` NOT LIKE '@%'
+            AND `goto` != `address`");
+          $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+          while($row = array_shift($rows)) {
+            $domain = explode("@", $row['address'])[1];
+            if (hasDomainAccess($_SESSION['mailcow_cc_username'], $_SESSION['mailcow_cc_role'], $domain)) {
+              $shared_aliases[] = $row['address'];
+            }
+          }
+
+          return $shared_aliases;
+        break;
+        case 'direct_aliases':
+          $direct_aliases = array();
+          $stmt = $pdo->query("SELECT `address` FROM `alias`
+            WHERE `goto` NOT LIKE '%,%'
+            AND `address` NOT LIKE '@%'
+            AND `goto` != `address`");
+          $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+          while($row = array_shift($rows)) {
+            $domain = explode("@", $row['address'])[1];
+            if (hasDomainAccess($_SESSION['mailcow_cc_username'], $_SESSION['mailcow_cc_role'], $domain)) {
+              $direct_aliases[] = $row['address'];
+            }
+          }
+
+          return $direct_aliases;
+        break;
         case 'domains':
           $domains = array();
           if ($_SESSION['mailcow_cc_role'] != "admin" && $_SESSION['mailcow_cc_role'] != "domainadmin") {


### PR DESCRIPTION
When setting an alias as local_dest for bcc, the following condition throws errors because $shared_aliases and $direct_aliases were never initialized. 
https://github.com/mailcow/mailcow-dockerized/blob/8f286669162805f74e128ae20fabb15bb49c538d/data/web/inc/functions.address_rewriting.inc.php#L51-L59
I looked at the code to understand what shared_aliases and direct_aliases are, and I added some actions to the mailbox function to retrieve them.

Resolves: https://github.com/mailcow/mailcow-dockerized/issues/5124 https://github.com/mailcow/mailcow-dockerized/issues/5012