### PR TITLE
[Web] Fix deleting sender_acl when mbox is deleted

### DIFF
--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -4956,9 +4956,10 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             $stmt->execute(array(
               ':username' => $username
             ));
-            $stmt = $pdo->prepare("DELETE FROM `sender_acl` WHERE `logged_in_as` = :username");
+            $stmt = $pdo->prepare("DELETE FROM `sender_acl` WHERE `logged_in_as` = :logged_in_as OR `send_as` = :send_as");
             $stmt->execute(array(
-              ':username' => $username
+              ':logged_in_as' => $username,
+              ':send_as' => $username
             ));
             // fk, better safe than sorry
             $stmt = $pdo->prepare("DELETE FROM `user_acl` WHERE `username` = :username");


### PR DESCRIPTION
This PR updates the deletion behavior of `sender_acl` entries when a mailbox is deleted. 
Previously, only entries where the mailbox was listed in `logged_in_as` were deleted. 
With this update, all entries where the mailbox is listed in `send_as` will be deleted as well.

Resolves https://github.com/mailcow/mailcow-dockerized/issues/5055