### PR TITLE
[web] Fix typo in mobileconfig redirect

### DIFF
--- a/data/web/inc/triggers.inc.php
+++ b/data/web/inc/triggers.inc.php
@@ -63,7 +63,7 @@ if (isset($_POST["login_user"]) && isset($_POST["pass_user"])) {
         unset($_SESSION['index_query_string']);
         if (in_array('mobileconfig', $http_parameters)) {
             if (in_array('only_email', $http_parameters)) {
-                header("Location: /mobileconfig.php?email_only");
+                header("Location: /mobileconfig.php?only_email");
                 die();
             }
             header("Location: /mobileconfig.php");


### PR DESCRIPTION
Fixing typo in mobileconfig redirect, which prevents only_email configuration generation if user is not already logged in.

Fixes https://github.com/mailcow/mailcow-dockerized/issues/5175