### PR TITLE
Add GitHub action update_postscreen_access_list.yml

### DIFF
--- a/.github/workflows/update_postscreen_access_list.yml
+++ b/.github/workflows/update_postscreen_access_list.yml
@@ -1,0 +1,39 @@
+name: Update postscreen_access.cidr
+
+on:
+  schedule:
+    # Monthly
+    - cron: "0 0 1 * *"
+  workflow_dispatch: # Allow to run workflow manually
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+  
+  
+jobs:
+  Update-postscreen_access_cidr:
+   runs-on: ubuntu-latest
+   steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Generate postscreen_access.cidr
+      run: |
+          bash helper-scripts/update_postscreen_whitelist.sh
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.mailcow_action_Update_postscreen_access_cidr_pat }}
+        commit-message: update postscreen_access.cidr
+        committer: milkmaker <milkmaker@mailcow.de>
+        author: milkmaker <milkmaker@mailcow.de>
+        signoff: false
+        branch: update/postscreen_access.cidr
+        base: staging
+        delete-branch: true
+        add-paths: |
+          data/conf/postfix/postscreen_access.cidr
+        title: '[Postfix] update postscreen_access.cidr'
+        body: |
+          This PR updates the postscreen_access.cidr using GitHub Actions and [helper-scripts/update_postscreen_whitelist.sh](https://github.com/mailcow/mailcow-dockerized/blob/master/helper-scripts/update_postscreen_whitelist.sh)

--- a/helper-scripts/update_postscreen_whitelist.sh
+++ b/helper-scripts/update_postscreen_whitelist.sh
@@ -6,7 +6,7 @@ SPFTOOLS_DIR=${WORKING_DIR}/spf-tools
 POSTWHITE_DIR=${WORKING_DIR}/postwhite
 POSTWHITE_CONF=${POSTWHITE_DIR}/postwhite.conf
 
-COSTOM_HOSTS="web.de gmx.net mail.de freenet.de arcor.de unity-mail.de"
+CUSTOM_HOSTS='"web.de gmx.net mail.de freenet.de arcor.de unity-mail.de"'
 STATIC_HOSTS=(
     "194.25.134.0/24 permit # t-online.de"
 )
@@ -19,12 +19,19 @@ function set_config() {
     sudo sed -i "s@^\($1\s*=\s*\).*\$@\1$2@" ${POSTWHITE_CONF}
 }
 
-set_config custom_hosts ${COSTOM_HOSTS}
+set_config custom_hosts "${CUSTOM_HOSTS}"
 set_config reload_postfix no
 set_config postfixpath /.
 set_config spftoolspath ${WORKING_DIR}/spf-tools
 set_config whitelist .${SCRIPT_DIR}/../data/conf/postfix/postscreen_access.cidr
 set_config yahoo_static_hosts ${POSTWHITE_DIR}/yahoo_static_hosts.txt
+
+#Fix URL for Yahoo!: https://github.com/stevejenkins/postwhite/issues/59
+sudo sed -i \
+      -e 's#yahoo_url="https://help.yahoo.com/kb/SLN23997.html"#yahoo_url="https://senders.yahooinc.com/outbound-mail-servers/"#' \
+      -e 's#echo "ipv6:$line";#echo "ipv6:$line" | grep -v "ipv6:::";#' \
+      -e 's#`command -v wget`#`command -v skip-wget`#' \
+      ${POSTWHITE_DIR}/scrape_yahoo
 
 cd ${POSTWHITE_DIR}
 ./postwhite ${POSTWHITE_CONF}


### PR DESCRIPTION
This PR introduces a new GitHub action which updates data/conf/postfix/postscreen_access.cidr every month automatically
Based on the idea of https://github.com/mailcow/mailcow-dockerized/pull/5212

Please contact me via Telegram for the PAT which needs to be added as enviroment variable in the repo