### PR TITLE
[web] logger pdo exception handling workaround

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -526,8 +526,9 @@ function logger($_data = false) {
           ':remote' => get_remote_ip()
         ));
       }
-      catch (Exception $e) {
-        // Do nothing
+      catch (PDOException $e) {
+        # handle the exception here, as the exception handler function results in a white page
+        error_log($e->getMessage(), 0);
       }
     }
   }


### PR DESCRIPTION
Its more of a workaround then a clean solution, as i was not able to log the error in the frontend, or to to resolve the underlying problem for good.

But as it seems we are trying to log every request, but if the request is longer then about 65000 characters it wont fit the column and therefor results in a SQL Error.

```
SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'call' at row 1
```

It should be fix on API level which would be quite bit of work. As the logging function is not working anyway, i suggest to implement this workaround, so at least the frontend is still working and a error log message in the stdout.

Ref: #5136