### PR TITLE
[Rspamd] add dot-stuffing to bcc forwarding

### DIFF
--- a/data/conf/rspamd/lua/rspamd.local.lua
+++ b/data/conf/rspamd/lua/rspamd.local.lua
@@ -340,6 +340,10 @@ rspamd_config:register_symbol({
       if not bcc_dest then
         return -- stop
       end
+      -- dot stuff content before sending
+      local email_content = tostring(task:get_content())
+      email_content = string.gsub(email_content, "\r\n%.", "\r\n..")
+      -- send mail
       lua_smtp.sendmail({
         task = task,
         host = os.getenv("IPV4_NETWORK") .. '.253',
@@ -347,8 +351,8 @@ rspamd_config:register_symbol({
         from = task:get_from(stp)[1].addr,
         recipients = bcc_dest,
         helo = 'bcc',
-        timeout = 10,
-      }, task:get_content(), sendmail_cb)
+        timeout = 20,
+      }, email_content, sendmail_cb)
     end
 
     -- determine from


### PR DESCRIPTION
If the `BCC` rule finds at least one `bcc_dest`, the rule will retrieve the e-mail's content using `task:get_content()` and forward it via SMTP to the destination. The rule will use the `sendmail` method, which does not perform dot-stuffing. https://datatracker.ietf.org/doc/html/rfc5321#section-4.5.2

If the e-mail contains a new line with a period, it won't be fully forwarded. 
This PR addresses the issue by adding dot-stuffing before forwarding the mail to the `bcc_dest`.
Resolves: https://github.com/mailcow/mailcow-dockerized/issues/5067