### PR TITLE
Update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
 
     unbound-mailcow:
-      image: mailcow/unbound:1.17
+      image: mailcow/unbound:1.18
       environment:
         - TZ=${TZ}
       volumes:
@@ -17,7 +17,7 @@ services:
             - unbound
 
     mysql-mailcow:
-      image: mariadb:10.5
+      image: mariadb:11.0.2
       depends_on:
         - unbound-mailcow
       stop_grace_period: 45s
@@ -41,7 +41,7 @@ services:
             - mysql
 
     redis-mailcow:
-      image: redis:7-alpine
+      image: redis:7.2-rc2
       volumes:
         - redis-vol-1:/data/
       restart: always
@@ -58,7 +58,7 @@ services:
             - redis
 
     clamd-mailcow:
-      image: mailcow/clamd:1.61
+      image: mailcow/clamd:1.62
       restart: always
       depends_on:
         - unbound-mailcow
@@ -76,7 +76,7 @@ services:
             - clamd
 
     rspamd-mailcow:
-      image: mailcow/rspamd:1.92
+      image: mailcow/rspamd:1.93
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow
@@ -169,7 +169,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: mailcow/sogo:1.117
+      image: mailcow/sogo:1.118
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}
@@ -448,7 +448,7 @@ services:
         - /lib/modules:/lib/modules:ro
 
     watchdog-mailcow:
-      image: mailcow/watchdog:1.97
+      image: mailcow/watchdog:1.98
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       tmpfs:
@@ -563,7 +563,7 @@ services:
             - olefy
 
     ofelia-mailcow:
-      image: mcuadros/ofelia:latest
+      image: mcuadros/ofelia:39bca16
       restart: always
       command: daemon --docker
       environment:


### PR DESCRIPTION
Updated to newest versions:

mailcow/unbound:1.17 -> mailcow/unbound:1.18
mariadb:10.5 -> mariadb:11.0.2
redis:7-alpine -> redis:7.2-rc2
mailcow/clamd:1.61 -> mailcow/clamd:1.62
mailcow/rspamd:1.92 -> mailcow/rspamd:1.93
mailcow/sogo:1.117 -> mailcow/sogo:1.118
mailcow/watchdog:1.97 -> mailcow/watchdog:1.98
mcuadros/ofelia:latest -> mcuadros/ofelia:39bca16