### PR TITLE
Fixed ports in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -378,8 +378,8 @@ services:
         - ./data/conf/rspamd/meta_exporter:/meta_exporter:ro,z
         - sogo-web-vol-1:/usr/lib/GNUstep/SOGo/
       ports:
-        - "${HTTPS_BIND:-}:${HTTPS_PORT:-443}:${HTTPS_PORT:-443}"
-        - "${HTTP_BIND:-}:${HTTP_PORT:-80}:${HTTP_PORT:-80}"
+        - "${HTTPS_BIND:-}${HTTPS_PORT:-443}:${HTTPS_PORT:-443}"
+        - "${HTTP_BIND:-}${HTTP_PORT:-80}:${HTTP_PORT:-80}"
       restart: always
       networks:
         mailcow-network:


### PR DESCRIPTION
Fixed ports change with HTTP_PORT & HTTPS_PORT in docker-compose file.
One ":" was present which was causing the following error : 

```ERROR: The Compose file './docker-compose.yml' is invalid because:
services.nginx-mailcow.ports is invalid: Invalid port ":444:444", should be [[remote_ip:]remote_port[-remote_port]:]port[/protocol]
services.nginx-mailcow.ports is invalid: Invalid port ":81:81", should be [[remote_ip:]remote_port[-remote_port]:]port[/protocol]```