### PR TITLE
[Rspamd] Native mailcow Support for Securite ClamAV Signatures

### DIFF
--- a/data/conf/rspamd/local.d/composites.conf
+++ b/data/conf/rspamd/local.d/composites.conf
@@ -68,3 +68,33 @@ WL_FWD_HOST {
 ENCRYPTED_CHAT {
   expression = "CHAT_VERSION_HEADER & ENCRYPTED_PGP";
 }
+
+CLAMD_SPAM_FOUND {
+  expression = "CLAM_SECI_SPAM & !MAILCOW_WHITE";
+  description = "Probably Spam, Securite Spam Flag set through ClamAV";
+  weight = 4.5;
+}
+
+CLAMD_BAD_PDF {
+  expression = "CLAM_SECI_PDF & !MAILCOW_WHITE";
+  description = "Bad PDF Found, Securite bad PDF Flag set through ClamAV";
+  score = 6;
+}
+
+CLAMD_BAD_JPG {
+  expression = "CLAM_SECI_JPG & !MAILCOW_WHITE";
+  description = "Bad JPG Found, Securite bad JPG Flag set through ClamAV";
+  score = 3;
+}
+
+CLAMD_BAD_HTML {
+  expression = "CLAM_SECI_HTML & !MAILCOW_WHITE";
+  description = "Bad HTML Found, Securite bad HTML Flag set through ClamAV";
+  score = 8;
+}
+
+CLAMD_BAD_JS {
+  expression = "CLAM_SECI_JS & !MAILCOW_WHITE";
+  description = "Bad JS Found, Securite bad JS Flag set through ClamAV";
+  score = 8;
+}

--- a/data/conf/rspamd/local.d/composites.conf
+++ b/data/conf/rspamd/local.d/composites.conf
@@ -78,23 +78,29 @@ CLAMD_SPAM_FOUND {
 CLAMD_BAD_PDF {
   expression = "CLAM_SECI_PDF & !MAILCOW_WHITE";
   description = "Bad PDF Found, Securite bad PDF Flag set through ClamAV";
-  score = 6;
+  score = 8;
 }
 
 CLAMD_BAD_JPG {
   expression = "CLAM_SECI_JPG & !MAILCOW_WHITE";
   description = "Bad JPG Found, Securite bad JPG Flag set through ClamAV";
-  score = 3;
-}
-
-CLAMD_BAD_HTML {
-  expression = "CLAM_SECI_HTML & !MAILCOW_WHITE";
-  description = "Bad HTML Found, Securite bad HTML Flag set through ClamAV";
   score = 8;
 }
 
-CLAMD_BAD_JS {
+CLAMD_ASCII_MALWARE {
+  expression = "CLAM_SECI_ASCII & !MAILCOW_WHITE";
+  description = "ASCII malware found, Securite ASCII malware Flag set through ClamAV";
+  score = 8;
+}
+
+CLAMD_HTML_MALWARE {
+  expression = "CLAM_SECI_HTML & !MAILCOW_WHITE";
+  description = "HTML malware found, Securite HTML malware Flag set through ClamAV";
+  score = 8;
+}
+
+CLAMD_JS_MALWARE {
   expression = "CLAM_SECI_JS & !MAILCOW_WHITE";
-  description = "Bad JS Found, Securite bad JS Flag set through ClamAV";
+  description = "JS malware found, Securite JS malware Flag set through ClamAV";
   score = 8;
 }

--- a/data/conf/rspamd/local.d/composites.conf
+++ b/data/conf/rspamd/local.d/composites.conf
@@ -72,7 +72,7 @@ ENCRYPTED_CHAT {
 CLAMD_SPAM_FOUND {
   expression = "CLAM_SECI_SPAM & !MAILCOW_WHITE";
   description = "Probably Spam, Securite Spam Flag set through ClamAV";
-  weight = 4.5;
+  score = 5;
 }
 
 CLAMD_BAD_PDF {


### PR DESCRIPTION
This PR includes the support for Securite.com Signatures for ClamAV as they would previously always marked as a Virus with the Score weight of 2000. That caused some false positives or non Virus Signatures to be marked as a Virus and therefore rejected from the E-Mail Server.

This new scores (later tweaking may occur) will only be used if the user Setup the Securite Lists recording the Docs Page: https://docs.mailcow.email/manual-guides/ClamAV/u_e-clamav-additional_dbs/?h=clamav#enable-securiteinfo-databases

mailcow will then use the predefined Scores if it detects a spam message via ClamAV (or other).