### PR TITLE
Limit quota notifications to once per-user, per-day.

### DIFF
--- a/data/Dockerfiles/dovecot/quota_notify.py
+++ b/data/Dockerfiles/dovecot/quota_notify.py
@@ -2,6 +2,7 @@
 
 import smtplib
 import os
+from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import COMMASPACE, formatdate
@@ -30,6 +31,13 @@ while True:
     time.sleep(3)
   else:
     break
+
+now = datetime.now().toordinal()
+if r.hget('QW_TIME', username):
+  last_notified = int(r.hget('QW_TIME', username))
+  if now - last_notified == 0:
+    print(f"{username} notified recently, not sending notification.")
+    sys.exit(0)
 
 if r.get('QW_HTML'):
   try:
@@ -82,6 +90,8 @@ try:
 except Exception as ex:
   print('Failed to send quota notification: %s' % (ex))
   sys.exit(1)
+
+r.hset("QW_TIME", username, now)
 
 try:
   sys.stdout.close()


### PR DESCRIPTION
This commit uses datetime ordinal dates to create timestamps for comparison. If a quota notification email is sent, another will not be sent within the same day. I created this change due to some users receiving as many as 20 emails within one minute when their inbox begins to fill. 

It may be desirable to have more granular control over quota notification frequency. Ordinal dates were chosen because they make the time math much simpler, but are not useful checking any timestamp difference of less than 1 day. If desired, I can add additional commits to make the limitation configurable via the web UI. 

Testing was done by running a bash shell inside the dovecot container and manually invoking the script. 