### PR TITLE
Update SOGo to 5.8.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,7 +169,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: mailcow/sogo:1.117
+      image: mailcow/sogo:1.118
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}


### PR DESCRIPTION
This PR updates SOGO to 5.8.4 with latest Build Date (31th Juli 2023)

Full Changelogs from SOGo can be found here:

https://github.com/Alinto/sogo/releases/tag/SOGo-5.8.4
