### PR TITLE
[Postfix] fix extra.cf updating

### DIFF
--- a/data/Dockerfiles/postfix/postfix.sh
+++ b/data/Dockerfiles/postfix/postfix.sh
@@ -486,7 +486,7 @@ fi
 # Append user overrides
 echo -e "\n# User Overrides" >> /opt/postfix/conf/main.cf
 touch /opt/postfix/conf/extra.cf
-sed -i '/myhostname/d' /opt/postfix/conf/extra.cf
+sed -i '/\$myhostname/! { /myhostname/d }' /opt/postfix/conf/extra.cf
 echo -e "myhostname = ${MAILCOW_HOSTNAME}\n$(cat /opt/postfix/conf/extra.cf)" > /opt/postfix/conf/extra.cf
 cat /opt/postfix/conf/extra.cf >> /opt/postfix/conf/main.cf
 


### PR DESCRIPTION
I was trying to extend the postfix configuration by adding custom directives to extra.cf, and found out that some of them were disappearing on postfix-mailcow restarts. Specifically, this line:
`smtpd_banner = $myhostname ESMTP Postfix`
Same problem is described [here](https://github.com/mailcow/mailcow-dockerized/issues/3167#issuecomment-1639213527).

That happens due to untied `/myhostname/d` sed operation in `data/Dockerfiles/postfix/postfix.sh` - it deletes not only the `myhostname = example.org` line before updating it, but also lines like mentioned above.

This PR fixes the issue by ignoring lines that contain `$myhostname` (variable, not a directive) when cleaning up the `extra.cf`.
