### PR TITLE
Fix CPU load of dockerapi container

### DIFF
--- a/data/Dockerfiles/dockerapi/main.py
+++ b/data/Dockerfiles/dockerapi/main.py
@@ -198,8 +198,8 @@ async def handle_pubsub_messages(channel: aioredis.client.PubSub):
 
   while True:
     try:
-      async with async_timeout.timeout(1):
-        message = await channel.get_message(ignore_subscribe_messages=True)
+      async with async_timeout.timeout(60):
+        message = await channel.get_message(ignore_subscribe_messages=True, timeout=30)
         if message is not None:
           # Parse message
           data_json = json.loads(message['data'].decode('utf-8'))

--- a/data/Dockerfiles/dockerapi/main.py
+++ b/data/Dockerfiles/dockerapi/main.py
@@ -244,7 +244,7 @@ async def handle_pubsub_messages(channel: aioredis.client.PubSub):
           else:
             dockerapi.logger.error("Unknwon PubSub recieved - %s" % json.dumps(data_json))
               
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.0)
     except asyncio.TimeoutError:
       pass
 


### PR DESCRIPTION
Previously the handle_pubsub_messages() loop was executing every 10ms when there was no message available. This creates a constant CPU load of around 6% on my system.

Now reading from the redis network socket will block (the coroutine) for up to 30s before it returns when no message is available. Using channel.listen() would be even better, but it lacks the ignore_subscribe_messages option and I could not figure out how to filter the returned messages.

Note I have a very limited to basically non-existent knowledge of Python, but I read up on asyncio and believe to understand the changes I made. Nonetheless of course this should be cross-checked. I verified that it does not actually block the entire event loop, since HTTP requests to dockerapi are immediately responded to.
