### PR TITLE
Improved the FQDN check and Ask before changing Git Repository URL in "update.sh"

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -109,9 +109,24 @@ echo "Press enter to confirm the detected value '[value]' where applicable or en
 while [ -z "${MAILCOW_HOSTNAME}" ]; do
   read -p "Mail server hostname (FQDN) - this is not your mail domain, but your mail servers hostname: " -e MAILCOW_HOSTNAME
   DOTS=${MAILCOW_HOSTNAME//[^.]};
-  if [ ${#DOTS} -lt 2 ] && [ ! -z ${MAILCOW_HOSTNAME} ]; then
-    echo "${MAILCOW_HOSTNAME} is not a FQDN"
-    MAILCOW_HOSTNAME=
+  if [ ${#DOTS} -lt 1 ]; then
+    echo -e "\e[31mMAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) is not a FQDN!\e[0m"
+    sleep 1
+    echo "Please change it to a FQDN and redeploy the stack with docker(-)compose up -d"
+    exit 1
+  elif [[ "${MAILCOW_HOSTNAME: -1}" == "." ]]; then
+    echo "MAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) is ending with a dot. This is not a valid FQDN!"
+    exit 1
+  elif [ ${#DOTS} -eq 1 ]; then
+    echo -e "\e[33mMAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) does not contain a Subdomain. This is not fully tested and may cause issues.\e[0m"
+    echo "Find more information about why this message exists here: https://github.com/mailcow/mailcow-dockerized/issues/1572"
+    read -r -p "Do you want to proceed anyway? [y/N] " response
+    if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+      echo "OK. Procceding."
+    else
+      echo "OK. Exiting."
+      exit 1
+    fi
   fi
 done
 

--- a/update.sh
+++ b/update.sh
@@ -419,14 +419,15 @@ detect_docker_compose_command
 [[ ! -f mailcow.conf ]] && { echo "mailcow.conf is missing! Is mailcow installed?"; exit 1;}
 DOTS=${MAILCOW_HOSTNAME//[^.]};
 if [ ${#DOTS} -lt 1 ]; then
-  echo "MAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) is not a FQDN!"
-  echo "Please change it to a FQDN and run $COMPOSE_COMMAND down followed by $COMPOSE_COMMAND up -d"
+  echo -e "\e[31mMAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) is not a FQDN!\e[0m"
+  sleep 1
+  echo "Please change it to a FQDN and redeploy the stack with $COMPOSE_COMMAND up -d"
   exit 1
 elif [[ "${MAILCOW_HOSTNAME: -1}" == "." ]]; then
   echo "MAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) is ending with a dot. This is not a valid FQDN!"
   exit 1
 elif [ ${#DOTS} -eq 1 ]; then
-  echo "MAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) does not contain a Subdomain. This is not fully tested and may cause issues."
+  echo -e "\e[33mMAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) does not contain a Subdomain. This is not fully tested and may cause issues.\e[0m"
   echo "Find more information about why this message exists here: https://github.com/mailcow/mailcow-dockerized/issues/1572"
   read -r -p "Do you want to proceed anyway? [y/N] " response
   if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then

--- a/update.sh
+++ b/update.sh
@@ -418,10 +418,23 @@ detect_docker_compose_command
 
 [[ ! -f mailcow.conf ]] && { echo "mailcow.conf is missing! Is mailcow installed?"; exit 1;}
 DOTS=${MAILCOW_HOSTNAME//[^.]};
-if [ ${#DOTS} -lt 2 ]; then
+if [ ${#DOTS} -lt 1 ]; then
   echo "MAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) is not a FQDN!"
   echo "Please change it to a FQDN and run $COMPOSE_COMMAND down followed by $COMPOSE_COMMAND up -d"
   exit 1
+elif [[ "${MAILCOW_HOSTNAME: -1}" == "." ]]; then
+  echo "MAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) is ending with a dot. This is not a valid FQDN!"
+  exit 1
+elif [ ${#DOTS} -eq 1 ]; then
+  echo "MAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) does not contain a Subdomain. This is not fully tested and may cause issues."
+  echo "Find more information about why this message exists here: https://github.com/mailcow/mailcow-dockerized/issues/1572"
+  read -r -p "Do you want to proceed anyway? [y/N] " response
+  if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+    echo "OK. Procceding."
+  else
+    echo "OK. Exiting."
+    exit 1
+  fi
 fi
 
 if grep --help 2>&1 | head -n 1 | grep -q -i "busybox"; then echo "BusyBox grep detected, please install gnu grep, \"apk add --no-cache --upgrade grep\""; exit 1; fi

--- a/update.sh
+++ b/update.sh
@@ -893,7 +893,7 @@ done
 
 DEFAULT_REPO=https://github.com/mailcow/mailcow-dockerized
 CURRENT_REPO=$(git remote get-url origin)
-if ["$CURRENT_REPO" != "$DEFAULT_REPO"]; then 
+if [ "$CURRENT_REPO" != "$DEFAULT_REPO" ]; then 
   echo "The Repository currently used is not the default Mailcow Repository."
   echo "Currently Repository: $CURRENT_REPO"
   echo "Default Repository:   $DEFAULT_REPO"

--- a/update.sh
+++ b/update.sh
@@ -893,7 +893,7 @@ done
 
 DEFAULT_REPO=https://github.com/mailcow/mailcow-dockerized
 CURRENT_REPO=$(git remote get-url origin)
-if ["$CURRENT_REPO" != "$DEFAULT_REPO"]
+if ["$CURRENT_REPO" != "$DEFAULT_REPO"]; then 
   echo "The Repository currently used is not the default Mailcow Repository."
   echo "Currently Repository: $CURRENT_REPO"
   echo "Default Repository:   $DEFAULT_REPO"

--- a/update.sh
+++ b/update.sh
@@ -887,8 +887,22 @@ done
 
 [[ -f data/conf/nginx/ZZZ-ejabberd.conf ]] && rm data/conf/nginx/ZZZ-ejabberd.conf
 
+
 # Silently fixing remote url from andryyy to mailcow
 # git remote set-url origin https://github.com/mailcow/mailcow-dockerized
+
+DEFAULT_REPO=https://github.com/mailcow/mailcow-dockerized
+CURRENT_REPO=$(git remote get-url origin)
+if ["$CURRENT_REPO" != "$DEFAULT_REPO"]
+  echo "The Repository currently used is not the default Mailcow Repository."
+  echo "Currently Repository: $CURRENT_REPO"
+  echo "Default Repository:   $DEFAULT_REPO"
+  read -r -p "Should it be changed back to default? [y/N] " repo_response
+  if [[ "$repo_response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+    git remote set-url origin $DEFAULT_REPO
+  fi
+fi
+
 echo -e "\e[32mCommitting current status...\e[0m"
 [[ -z "$(git config user.name)" ]] && git config user.name moo
 [[ -z "$(git config user.email)" ]] && git config user.email moo@cow.moo

--- a/update.sh
+++ b/update.sh
@@ -888,7 +888,7 @@ done
 [[ -f data/conf/nginx/ZZZ-ejabberd.conf ]] && rm data/conf/nginx/ZZZ-ejabberd.conf
 
 # Silently fixing remote url from andryyy to mailcow
-git remote set-url origin https://github.com/mailcow/mailcow-dockerized
+# git remote set-url origin https://github.com/mailcow/mailcow-dockerized
 echo -e "\e[32mCommitting current status...\e[0m"
 [[ -z "$(git config user.name)" ]] && git config user.name moo
 [[ -z "$(git config user.email)" ]] && git config user.email moo@cow.moo


### PR DESCRIPTION
I've added a check for if the last letter in MAILCOW_HOSTNAME is a dot (because if there is one, Postfix doesn't start.

I've also added a bypass if the case in https://github.com/mailcow/mailcow-dockerized/issues/1572 (starting the updater while no subdomain is set eg. "example.org" instead of "mail.example.org") is met. 
The user has to confirm the Message (as seen in the commit) with a link to the issue. 

A better way would be to use a Regex for the check, but as seen here https://stackoverflow.com/a/26618995 , may require a much larger codechange. 