### PR TITLE
Hash bucket size increased

### DIFF
--- a/data/conf/nginx/site.conf
+++ b/data/conf/nginx/site.conf
@@ -1,5 +1,5 @@
 proxy_cache_path /tmp levels=1:2 keys_zone=sogo:10m inactive=24h  max_size=1g;
-server_names_hash_bucket_size 64;
+server_names_hash_bucket_size 96;
 
 map $http_x_forwarded_proto $client_req_scheme {
      default $scheme;


### PR DESCRIPTION
server_names_hash_bucket_size increased from 64 to 96 since some domains are causing nginx to fail to start.