### PR TITLE
Fix renovate to allow version extracts for Dockerfiles

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,7 +24,7 @@
     {
       "fileMatch": ["(^|/)Dockerfile[^/]*$"],
       "matchStrings": [
-        "#\\srenovate:\\sdatasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s(ENV|ARG) .*?_VERSION=(?<currentValue>.*)\\s"
+        "#\\srenovate:\\sdatasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?\\s(ENV|ARG) .*?_VERSION=(?<currentValue>.*)\\s"
        ]
     }
   ]

--- a/data/Dockerfiles/dovecot/Dockerfile
+++ b/data/Dockerfiles/dovecot/Dockerfile
@@ -2,9 +2,9 @@ FROM debian:bullseye-slim
 LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
-# renovate: datasource=github-tags depName=dovecot/core versioning=semver-coerced
+# renovate: datasource=github-tags depName=dovecot/core versioning=semver-coerced extractVersion=^v(?<version>.*)$
 ARG DOVECOT=2.3.20
-# renovate: datasource=github-releases depName=tianon/gosu versioning=semver-coerced
+# renovate: datasource=github-releases depName=tianon/gosu versioning=semver-coerced extractVersion=^v(?<version>.*)$
 ARG GOSU_VERSION=1.16
 ENV LC_ALL C
 

--- a/data/Dockerfiles/phpfpm/Dockerfile
+++ b/data/Dockerfiles/phpfpm/Dockerfile
@@ -1,17 +1,17 @@
 FROM php:8.2-fpm-alpine3.17
 LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
 
-# renovate: datasource=github-tags depName=krakjoe/apcu versioning=semver-coerced
+# renovate: datasource=github-tags depName=krakjoe/apcu versioning=semver-coerced extractVersion=^v(?<version>.*)$
 ARG APCU_PECL_VERSION=5.1.22
-# renovate: datasource=github-tags depName=Imagick/imagick versioning=semver-coerced
+# renovate: datasource=github-tags depName=Imagick/imagick versioning=semver-coerced extractVersion=^v(?<version>.*)$
 ARG IMAGICK_PECL_VERSION=3.7.0
-# renovate: datasource=github-tags depName=php/pecl-mail-mailparse versioning=semver-coerced
+# renovate: datasource=github-tags depName=php/pecl-mail-mailparse versioning=semver-coerced extractVersion=^v(?<version>.*)$
 ARG MAILPARSE_PECL_VERSION=3.1.4
-# renovate: datasource=github-tags depName=php-memcached-dev/php-memcached versioning=semver-coerced
+# renovate: datasource=github-tags depName=php-memcached-dev/php-memcached versioning=semver-coerced extractVersion=^v(?<version>.*)$
 ARG MEMCACHED_PECL_VERSION=3.2.0
-# renovate: datasource=github-tags depName=phpredis/phpredis versioning=semver-coerced
+# renovate: datasource=github-tags depName=phpredis/phpredis versioning=semver-coerced extractVersion=^v(?<version>.*)$
 ARG REDIS_PECL_VERSION=5.3.7
-# renovate: datasource=github-tags depName=composer/composer versioning=semver-coerced
+# renovate: datasource=github-tags depName=composer/composer versioning=semver-coerced extractVersion=^v(?<version>.*)$
 ARG COMPOSER_VERSION=2.5.5
 
 RUN apk add -U --no-cache autoconf \

--- a/data/Dockerfiles/sogo/Dockerfile
+++ b/data/Dockerfiles/sogo/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG SOGO_DEBIAN_REPOSITORY=http://packages.sogo.nu/nightly/5/debian/
-# renovate: datasource=github-releases depName=tianon/gosu versioning=semver-coerced
+# renovate: datasource=github-releases depName=tianon/gosu versioning=semver-coerced extractVersion=^v(?<version>.*)$
 ARG GOSU_VERSION=1.16
 ENV LC_ALL C
 

--- a/data/Dockerfiles/solr/Dockerfile
+++ b/data/Dockerfiles/solr/Dockerfile
@@ -2,7 +2,7 @@ FROM solr:7.7-slim
 
 USER root
 
-# renovate: datasource=github-releases depName=tianon/gosu versioning=semver-coerced
+# renovate: datasource=github-releases depName=tianon/gosu versioning=semver-coerced extractVersion=^v(?<version>.*)$
 ARG GOSU_VERSION=1.16
 
 COPY solr.sh /


### PR DESCRIPTION
This PR should fix renovate to allow version extracts for Dockerfiles
Currently if a tag of an upstream contains a v it's not stripped, see https://github.com/mailcow/mailcow-dockerized/pull/5331