### PR TITLE
Update ClamAV to latest LTS version 1.0.3

### DIFF
--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -1,4 +1,4 @@
-FROM clamav/clamav:1.0.1-1_base
+FROM clamav/clamav:1.0.3_base
 
 LABEL maintainer "André Peters <andre.peters@servercow.de>"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,7 +170,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: mailcow/sogo:1.118
+      image: mailcow/sogo:1.119
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
             - redis
 
     clamd-mailcow:
-      image: mailcow/clamd:1.61
+      image: mailcow/clamd:1.62
       restart: always
       depends_on:
         - unbound-mailcow


### PR DESCRIPTION
This PR updates ClamAV to the latest available LTS version 1.0.3 (up from v1.0.1 which is currently used in mailcow-dockerized).

My main reason for this was to fix problems with the [SecuriteInfo databases](https://docs.mailcow.email/manual-guides/ClamAV/u_e-clamav-additional_dbs/) I found in my logs. According to their website (you must sign in):

> "In Basic subscription, versions of ClamAV less than 0.103 are not supported. You will get a 426 HTTP error code if your ClamAV is too old."

v1.0.3 also contains some (security) fixes over v1.0.1, see:
https://blog.clamav.net/2023/08/clamav-120-feature-version-and-111-102.html
https://blog.clamav.net/2023/07/2023-08-16-releases.html

The updated clamd container builds successfully on my mailcow installation and has been running without problems for a couple of hours now, doing its work (I tried sending the EICAR test file).