### PR TITLE
[Unbound] Added Healthcheck for Unbound (Dockerfile and Compose)

### DIFF
--- a/data/Dockerfiles/unbound/Dockerfile
+++ b/data/Dockerfiles/unbound/Dockerfile
@@ -18,6 +18,11 @@ EXPOSE 53/udp 53/tcp
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
+# healthcheck (nslookup)
+COPY healthcheck.sh /healthcheck.sh
+RUN chmod +x /healthcheck.sh
+HEALTHCHECK --interval=30s --timeout=10s CMD [ "/healthcheck.sh" ]
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 CMD ["/usr/sbin/unbound"]

--- a/data/Dockerfiles/unbound/healthcheck.sh
+++ b/data/Dockerfiles/unbound/healthcheck.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+nslookup mailcow.email 127.0.0.1 1> /dev/null
+
+if [ $? == 0 ]; then
+    echo "DNS resolution is working!"
+    exit 0
+else
+    echo "DNS resolution is not working correctly..."
+    echo "Maybe check your outbound firewall, as it needs to resolve DNS over TCP AND UDP!"
+    exit 1
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,9 @@ services:
       image: mailcow/clamd:1.62
       restart: always
       depends_on:
-        - unbound-mailcow
+        unbound-mailcow:
+          condition: service_healthy
+          restart: true
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       environment:
@@ -299,7 +301,11 @@ services:
     postfix-mailcow:
       image: mailcow/postfix:1.72
       depends_on:
-        - mysql-mailcow
+        mysql-mailcow:
+          condition: service_started
+        unbound-mailcow:
+          condition: service_healthy
+          restart: true
       volumes:
         - ./data/hooks/postfix:/hooks:Z
         - ./data/conf/postfix:/opt/postfix/conf:z
@@ -390,7 +396,10 @@ services:
 
     acme-mailcow:
       depends_on:
-        - nginx-mailcow
+        nginx-mailcow:
+          condition: service_started
+        unbound-mailcow:
+          condition: service_healthy
       image: mailcow/acme:1.85
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
@@ -461,6 +470,13 @@ services:
         - postfix-vol-1:/var/spool/postfix
         - ./data/assets/ssl:/etc/ssl/mail/:ro,z
       restart: always
+      depends_on:
+        - postfix-mailcow
+        - dovecot-mailcow
+        - mysql-mailcow
+        - acme-mailcow
+        - redis-mailcow
+
       environment:
         - IPV6_NETWORK=${IPV6_NETWORK:-fd4d:6169:6c63:6f77::/64}
         - LOG_LINES=${LOG_LINES:-9999}


### PR DESCRIPTION
This PR fixes #5449

It implements a simple nslookup check inside unbound and returns a healthcheck value to work within docker-compose.yml.

Postfix, acme and clamav now needs a healthy unbound to start as otherwise the containers won't boot up.

Unbound is always needed to be correctly so for correctly installed instances it should make no difference at all.