### PR TITLE
[Rspamd] Update to 3.7.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
             - clamd
 
     rspamd-mailcow:
-      image: mailcow/rspamd:1.92
+      image: mailcow/rspamd:1.93
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow


### PR DESCRIPTION
This PR includes the update to Rspamd 3.7.3.

The official changelog can be found here:

https://github.com/rspamd/rspamd/releases/tag/3.7.3

No additional changes inside mailcow needed.

---

Tests looking good 👍 