### PR TITLE
Improve port selection for autoconfig / mobileconfig

### DIFF
--- a/data/web/autoconfig.php
+++ b/data/web/autoconfig.php
@@ -30,6 +30,40 @@ if (isset($_GET['emailaddress'])) {
   }
 }
 
+function autoconfig_service_enabled($_service_type) {
+  global $autodiscover_config;
+  global $domain;
+  $_disabled = FALSE;
+  switch ($_service_type) {
+    // TODO Check autodiscover_config
+    case 'imap':
+      $_disabled = isset($autodiscover_config['imap']['tlsportDisabled']) && $autodiscover_config['imap']['tlsportDisabled'] === TRUE;
+      break;
+    case 'imaps':
+      $_disabled = isset($autodiscover_config['imap']['portDisabled']) && $autodiscover_config['imap']['portDisabled'] === TRUE;
+      break;
+    case 'pop3':
+      $_disabled = isset($autodiscover_config['pop3']['tlsportDisabled']) && $autodiscover_config['pop3']['tlsportDisabled'] === TRUE;
+      break;
+    case 'pop3s':
+      $_disabled = isset($autodiscover_config['pop3']['portDisabled']) && $autodiscover_config['pop3']['portDisabled'] === TRUE;
+      break;
+    case 'smtps':
+      $_disabled = isset($autodiscover_config['smtp']['portDisabled']) && $autodiscover_config['smtp']['portDisabled'] === TRUE;
+      break;
+    case 'submission':
+      $_disabled = isset($autodiscover_config['smtp']['tlsportDisabled']) && $autodiscover_config['smtp']['tlsportDisabled'] === TRUE;
+      break;
+  }
+  // If the port is disabled in the config, do not even bother to check the DNS records.
+  if ($_disabled === TRUE) {
+    return FALSE;
+  }
+  // Check whether the service is announced as "not provided" via a SRV record.
+  $_records = dns_get_record('_' . $_service_type .'._tcp.' . $domain, DNS_SRV);
+  return $_records === FALSE || count($_records) == 0 || $_records[0]['target'] != '';
+}
+
 header('Content-Type: application/xml');
 ?>
 <?= '<?xml version="1.0"?>'; ?>
@@ -39,6 +73,8 @@ header('Content-Type: application/xml');
       <displayName>A mailcow mail server</displayName>
       <displayShortName>mail server</displayShortName>
 
+<?php
+if (autoconfig_service_enabled('imaps')) { ?>
       <incomingServer type="imap">
          <hostname><?=$autodiscover_config['imap']['server']; ?></hostname>
          <port><?=$autodiscover_config['imap']['port']; ?></port>
@@ -46,6 +82,9 @@ header('Content-Type: application/xml');
          <username>%EMAILADDRESS%</username>
          <authentication>password-cleartext</authentication>
       </incomingServer>
+<?php } ?>
+<?php
+if (autoconfig_service_enabled('imap')) { ?>
       <incomingServer type="imap">
          <hostname><?=$autodiscover_config['imap']['server']; ?></hostname>
          <port><?=$autodiscover_config['imap']['tlsport']; ?></port>
@@ -53,10 +92,10 @@ header('Content-Type: application/xml');
          <username>%EMAILADDRESS%</username>
          <authentication>password-cleartext</authentication>
       </incomingServer>
+<?php } ?>
 
 <?php
-$records = dns_get_record('_pop3s._tcp.' . $domain, DNS_SRV); // check if POP3 is announced as "not provided" via SRV record
-if ($records === FALSE || count($records) == 0 || $records[0]['target'] != '') { ?>
+if (autoconfig_service_enabled('pop3s')) { ?>
       <incomingServer type="pop3">
          <hostname><?=$autodiscover_config['pop3']['server']; ?></hostname>
          <port><?=$autodiscover_config['pop3']['port']; ?></port>
@@ -66,8 +105,7 @@ if ($records === FALSE || count($records) == 0 || $records[0]['target'] != '') {
       </incomingServer>
 <?php } ?>
 <?php
-$records = dns_get_record('_pop3._tcp.' . $domain, DNS_SRV); // check if POP3 is announced as "not provided" via SRV record
-if ($records === FALSE || count($records) == 0 || $records[0]['target'] != '') { ?>
+if (autoconfig_service_enabled('pop3')) { ?>
       <incomingServer type="pop3">
          <hostname><?=$autodiscover_config['pop3']['server']; ?></hostname>
          <port><?=$autodiscover_config['pop3']['tlsport']; ?></port>
@@ -77,6 +115,8 @@ if ($records === FALSE || count($records) == 0 || $records[0]['target'] != '') {
       </incomingServer>
 <?php } ?>
 
+<?php
+if (autoconfig_service_enabled('smtps')) { ?>
       <outgoingServer type="smtp">
          <hostname><?=$autodiscover_config['smtp']['server']; ?></hostname>
          <port><?=$autodiscover_config['smtp']['port']; ?></port>
@@ -84,6 +124,9 @@ if ($records === FALSE || count($records) == 0 || $records[0]['target'] != '') {
          <username>%EMAILADDRESS%</username>
          <authentication>password-cleartext</authentication>
       </outgoingServer>
+<?php } ?>
+<?php
+if (autoconfig_service_enabled('submission')) { ?>
       <outgoingServer type="smtp">
          <hostname><?=$autodiscover_config['smtp']['server']; ?></hostname>
          <port><?=$autodiscover_config['smtp']['tlsport']; ?></port>
@@ -91,6 +134,7 @@ if ($records === FALSE || count($records) == 0 || $records[0]['target'] != '') {
          <username>%EMAILADDRESS%</username>
          <authentication>password-cleartext</authentication>
       </outgoingServer>
+<?php } ?>
 
       <enable visiturl="https://<?=$mailcow_hostname; ?><?php if ($port != 443) echo ':'.$port; ?>/admin.php">
          <instruction>If you didn't change the password given to you by the administrator or if you didn't change it in a long time, please consider doing that now.</instruction>

--- a/data/web/autoconfig.php
+++ b/data/web/autoconfig.php
@@ -24,10 +24,10 @@ else {
 }
 
 if (isset($_GET['emailaddress'])) {
-   $emailaddress_at = strpos($_GET['emailaddress'], '@');
-   if ($emailaddress_at !== FALSE) {
-      $domain = substr($_GET['emailaddress'], $emailaddress_at + 1);
-   }
+  $emailaddress_at = strpos($_GET['emailaddress'], '@');
+  if ($emailaddress_at !== FALSE) {
+    $domain = substr($_GET['emailaddress'], $emailaddress_at + 1);
+  }
 }
 
 header('Content-Type: application/xml');
@@ -56,7 +56,7 @@ header('Content-Type: application/xml');
 
 <?php
 $records = dns_get_record('_pop3s._tcp.' . $domain, DNS_SRV); // check if POP3 is announced as "not provided" via SRV record
-if (count($records) == 0 || $records[0]['target'] != '') { ?>
+if ($records === FALSE || count($records) == 0 || $records[0]['target'] != '') { ?>
       <incomingServer type="pop3">
          <hostname><?=$autodiscover_config['pop3']['server']; ?></hostname>
          <port><?=$autodiscover_config['pop3']['port']; ?></port>
@@ -67,7 +67,7 @@ if (count($records) == 0 || $records[0]['target'] != '') { ?>
 <?php } ?>
 <?php
 $records = dns_get_record('_pop3._tcp.' . $domain, DNS_SRV); // check if POP3 is announced as "not provided" via SRV record
-if (count($records) == 0 || $records[0]['target'] != '') { ?>
+if ($records === FALSE || count($records) == 0 || $records[0]['target'] != '') { ?>
       <incomingServer type="pop3">
          <hostname><?=$autodiscover_config['pop3']['server']; ?></hostname>
          <port><?=$autodiscover_config['pop3']['tlsport']; ?></port>

--- a/data/web/autoconfig.php
+++ b/data/web/autoconfig.php
@@ -23,6 +23,13 @@ else {
   $port = substr($_SERVER['HTTP_HOST'], $domain_port+1);
 }
 
+if (isset($_GET['emailaddress'])) {
+   $emailaddress_at = strpos($_GET['emailaddress'], '@');
+   if ($emailaddress_at !== FALSE) {
+      $domain = substr($_GET['emailaddress'], $emailaddress_at + 1);
+   }
+}
+
 header('Content-Type: application/xml');
 ?>
 <?= '<?xml version="1.0"?>'; ?>

--- a/data/web/inc/vars.inc.php
+++ b/data/web/inc/vars.inc.php
@@ -43,6 +43,9 @@ $autodiscover_config = array(
   // Please don't use STARTTLS-enabled service ports in the "port" variable.
   // The autodiscover service will always point to SMTPS and IMAPS (TLS-wrapped services).
   // The autoconfig service will additionally announce the STARTTLS-enabled ports, specified in the "tlsport" variable.
+  // In order to disable one of the ports from being presented in the autodiscovery procss, set portDisabled or tlsPortDisabled to true.
+  // For example, in vars.local.inc.php add:
+  // $autodiscover_config['pop3']['tlsportDisabled'] = true;
   'imap' => array(
     'server' => $mailcow_hostname,
     'port' => (int)filter_var(substr(getenv('IMAPS_PORT'), strrpos(getenv('IMAPS_PORT'), ':')), FILTER_SANITIZE_NUMBER_INT),

--- a/data/web/mobileconfig.php
+++ b/data/web/mobileconfig.php
@@ -68,6 +68,24 @@ if (isset($_GET['app_password'])) {
   $app_password = false;
 }
 
+if (isset($autodiscover_config['imap']['portDisabled'])
+  && $autodiscover_config['imap']['portDisabled'] === TRUE
+  && !isset($autodiscover_config['imap']['tlsportDisabled'])
+  || $autodiscover_config['imap']['tlsportDisabled'] !== TRUE) {
+  $imap_port = $autodiscover_config['imap']['tlsport'];
+} else {
+  $imap_port = $autodiscover_config['imap']['port'];
+}
+
+if (isset($autodiscover_config['smtp']['portDisabled'])
+  && $autodiscover_config['smtp']['portDisabled'] === TRUE
+  && !isset($autodiscover_config['smtp']['tlsportDisabled'])
+  || $autodiscover_config['smtp']['tlsportDisabled'] !== TRUE) {
+  $smtp_port = $autodiscover_config['smtp']['tlsport'];
+} else {
+  $smtp_port = $autodiscover_config['smtp']['port'];
+}
+
 echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
 ?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -89,7 +107,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
         <key>IncomingMailServerHostName</key>
         <string><?=$autodiscover_config['imap']['server']?></string>
         <key>IncomingMailServerPortNumber</key>
-        <integer><?=$autodiscover_config['imap']['port']?></integer>
+        <integer><?=$imap_port?></integer>
         <key>IncomingMailServerUseSSL</key>
         <true/>
         <key>IncomingMailServerUsername</key>
@@ -103,7 +121,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
         <key>OutgoingMailServerHostName</key>
         <string><?=$autodiscover_config['smtp']['server']?></string>
         <key>OutgoingMailServerPortNumber</key>
-        <integer><?=$autodiscover_config['smtp']['port']?></integer>
+        <integer><?=$smtp_port?></integer>
         <key>OutgoingMailServerUseSSL</key>
         <true/>
         <key>OutgoingMailServerUsername</key>


### PR DESCRIPTION
In setups where some of the ports are not available (e.g. due to firewall rules, corporate policies, etc.) it is desirable to to not announce these ports as part of the autoconfig / autodiscovery / mobileconfig process. This ensures that clients using the respective process will use the correct ports.

In `autoconfig.php`, this was partially implemented before: For POP3 and POP3S, `autoconfig.php` would look for relevant DNS SRV records and omit the ports from the generated configuration when the SRV record indicated that these services were deliberately not available.

This PR improves on this concept by making the following changes:

- When an e-mail address is provided to `autoconfig.php`, the script will now use the domain from that e-mail address for the DNS lookups instead of using the domain from the server name in the HTTP headers. This has the advantage that the correct domain is going to be selected when the autoconfig URL used by the client is not directly served by mailcow, but is served by a different webserver which proxies the request or redirects the client to the mailcow server. One example where such a setup is necessary is when the DNS name `autoconfig.<mail domain>` is also needed for other services or when corporate policies do not allow adding such a name, but the webserver at `<mail domain>` can be configured to forward requests to `http://<mail domain>/.well-known/autoconfig/mail/config-v1.1.xml` to the mailcow server. In addition to that, I made a small change that makes the DNS lookup fail gracefully (treating a DNS failure like if the requested record did not exist and thus enabling the port).

- Both the `autoconfig.php` and `mobileconfig.php` scripts will now check for a `portDisabled` and `tlsportDisabled` flag in `$autodiscover_config`. This allows administrators to disable the announcement of certain ports as part of autoconfig, even when they cannot add the relevant SRV records to DNS. More importantly, it makes `mobileconfig.php` treat the situation correctly where IMAPS (port 993) or SMTPS (port 465) are not available, but IMAP with STARTTLS (port 143) or SMTP with STARTTLS (port 587) are available.

I tested all changes (`autoconfig.php` with Thunderbird version 102, `mobileconfig.php` with iPad OS 16.7). In particular, I tested that iPad OS can actually handle IMAP with STARTTLS.

I think that in theory, the changes made to `mobileconfig.php` should also be made to `autodiscover.php` to allow for the correct configuration of Microsoft Outlook when IMAP / SMTP is used and IMAPS or SMTPS are disabled. However, I could not make the autodiscover process work at all (I tested with Outlook from the Microsoft 365 client for macOS and for Windows). This was regardless of whether I tested it with the original version of `autodiscover.php` or with my changes and regardless of whether `$autodiscover_config['autodiscoverType']` was set to `activesync` or `imap` and $autodiscover_config['autodiscoverType']['useEASforOutlook'] was set to `yes` or `no`.

I rather believe this to be a problem with Outlook than with `autodiscover.php`, in particular because the Nginx logs show that Outlook is requesting the `autodiscover.xml` file and the server responds with a 200 status code. Due to Outlook being closed source, I don’t really have any idea how I could investigate this further, and as supporting Outlook is not really important for us (IMO it is one of the worse e-mail clients anyway), I did not want to spend more time on this.

Anyway, without being able to test the changes, I did not want to include them in this PR. One of the reasons why I did not want to include the changes without being able to test them is that the `<Encryption>` tag that apparently needs to be used to tell Outlook to use STARTTLS is not part of Microsoft’s official documentation, but there are some sources which claim that it has the desired effect.

If someone has a working autodiscover process for Outlook and is interested in testing these changes, here is the patch:

```patch
diff --git a/data/web/autodiscover.php b/data/web/autodiscover.php
index 992524b3..ec0e8a26 100644
--- a/data/web/autodiscover.php
+++ b/data/web/autodiscover.php
@@ -41,6 +41,28 @@ if (getenv('SKIP_SOGO') == "y") {
   $autodiscover_config['autodiscoverType'] = 'imap';
 }
 
+if (isset($autodiscover_config['imap']['port_disabled'])
+  && $autodiscover_config['imap']['port_disabled'] === TRUE
+  && !isset($autodiscover_config['imap']['tlsport_disabled'])
+  || $autodiscover_config['imap']['tlsport_disabled'] !== TRUE) {
+  $imap_port = $autodiscover_config['imap']['tlsport'];
+  $imap_encryption_line = "<Encryption>TLS</Encryption>";
+} else {
+  $imap_port = $autodiscover_config['imap']['port'];
+  $imap_encryption_line = "<SSL>on</SSL>";
+}
+
+if (isset($autodiscover_config['smtp']['port_disabled'])
+  && $autodiscover_config['smtp']['port_disabled'] === TRUE
+  && !isset($autodiscover_config['smtp']['tlsport_disabled'])
+  || $autodiscover_config['smtp']['tlsport_disabled'] !== TRUE) {
+  $smtp_port = $autodiscover_config['smtp']['tlsport'];
+  $smtp_encryption_line = "<Encryption>TLS</Encryption>";
+} else {
+  $smtp_port = $autodiscover_config['smtp']['port'];
+  $smtp_encryption_line = "<SSL>on</SSL>";
+}
+
 //$dsn = $database_type . ":host=" . $database_host . ";dbname=" . $database_name;
 $dsn = $database_type . ":unix_socket=" . $database_sock . ";dbname=" . $database_name;
 $opt = [
@@ -164,21 +186,21 @@ if ($login_role === "user") {
       <Protocol>
         <Type>IMAP</Type>
         <Server><?=$autodiscover_config['imap']['server'];?></Server>
-        <Port><?=$autodiscover_config['imap']['port'];?></Port>
+        <Port><?=$imap_port;?></Port>
         <DomainRequired>off</DomainRequired>
         <LoginName><?=$email;?></LoginName>
         <SPA>off</SPA>
-        <SSL>on</SSL>
+        <?=$imap_encryption_line;?>
         <AuthRequired>on</AuthRequired>
       </Protocol>
       <Protocol>
         <Type>SMTP</Type>
         <Server><?=$autodiscover_config['smtp']['server'];?></Server>
-        <Port><?=$autodiscover_config['smtp']['port'];?></Port>
+        <Port><?=$smtp_port;?></Port>
         <DomainRequired>off</DomainRequired>
         <LoginName><?=$email;?></LoginName>
         <SPA>off</SPA>
-        <SSL>on</SSL>
+        <?=$smtp_encryption_line;?>
         <AuthRequired>on</AuthRequired>
         <UsePOPAuth>on</UsePOPAuth>
         <SMTPLast>off</SMTPLast>
```

One thing that we might want to think about is disabling the DNS lookups in `autoconfig.php` completely, when `portDisabled` or `tlsportDisabled` are explicitly set to `false` (instead of not being set at all).