### PR TITLE
Fixed SQL query for retrieving SSO users.

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -2225,7 +2225,7 @@ function identity_provider($_action, $_data = null, $_extra = null) {
           AND `mailbox`.`active`='1'
           AND `domain`.`active`='1'
           AND `username` = :user
-          AND `authsource`='keycloak' OR `authsource`='generic-oidc'");
+          AND (`authsource`='keycloak' OR `authsource`='generic-oidc')");
       $stmt->execute(array(':user' => $info['email']));
       $row = $stmt->fetch(PDO::FETCH_ASSOC);
       if ($row){


### PR DESCRIPTION
# Issue

When retrieving users via SSO, the as-is query always returns the first user. This results in the problem where only a single mailbox is created (first SSO user), and no mailboxes are created for additional users.

# Resolution

Modified the query so that the last `OR` query is part of the last `AND` statement, otherwise the last `OR` always returns true.