### PR TITLE
Fix: Domain Wide Disclaimer breaks attachments visualization on Gmail and Outlook #5529

### DIFF
--- a/data/conf/rspamd/lua/rspamd.local.lua
+++ b/data/conf/rspamd/lua/rspamd.local.lua
@@ -631,15 +631,19 @@ rspamd_config:register_symbol({
             end
             local out_parts = {}
             for _,o in ipairs(out) do
-               if type(o) ~= 'table' then
-                 out_parts[#out_parts + 1] = o
-                 out_parts[#out_parts + 1] = newline_s
-               else
-                 out_parts[#out_parts + 1] = o[1]
-                 if o[2] then
-                   out_parts[#out_parts + 1] = newline_s
-                 end
-               end
+              if type(o) ~= 'table' then
+                out_parts[#out_parts + 1] = o
+                out_parts[#out_parts + 1] = newline_s
+              else
+                local removePrefix = "--\x0D\x0AContent-Type"
+                if string.lower(string.sub(tostring(o[1]), 1, string.len(removePrefix))) == string.lower(removePrefix) then
+                  o[1] = string.sub(tostring(o[1]), string.len("--\x0D\x0A") + 1)
+                end
+                out_parts[#out_parts + 1] = o[1]
+                if o[2] then
+                  out_parts[#out_parts + 1] = newline_s
+                end
+              end
             end
             task:set_message(out_parts)
           else


### PR DESCRIPTION
When Rspamd function lua_mime.add_text_footer(task, html_footer, text_footer) (https://rspamd.com/doc/lua/lua_mime.html#fa3d82) adds the Domain Wide Disclaimer, it will return new content types for rewriting. These new content types are somehow prefixed with "--\x0D\x0A" which breaks attachments visualization on Gmail and Outlook. 
This PR will remove the prefix before rewriting the content type as a workaround.