### PR TITLE
Support automatic mariadb-upgrade execution on mariadb upgrades

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
         - MYSQL_USER=${DBUSER}
         - MYSQL_PASSWORD=${DBPASS}
         - MYSQL_INITDB_SKIP_TZINFO=1
+        - MARIADB_AUTO_UPGRADE=1
       restart: always
       ports:
         - "${SQL_PORT:-127.0.0.1:13306}:3306"


### PR DESCRIPTION
To prepare the upgrade to the next mariadb lts version 10.11 I think it makes sense to add the newly available environment variable `MARIADB_AUTO_UPGRADE` which will execute `mariadb-upgrade` in the container, to perform necessary upgrades in the MariaDB system tables if necessary.