### PR TITLE
[Rspamd] Fixed Ratelimit forced by global ratelimits

### DIFF
--- a/data/conf/rspamd/local.d/ratelimit.conf
+++ b/data/conf/rspamd/local.d/ratelimit.conf
@@ -1,0 +1,9 @@
+# Uncomment below to apply the ratelimits globally. Use Ratelimits inside mailcow UI to overwrite them for a specific domain/mailbox.
+# rates {
+#     # Format: "1 / 1h" or "20 / 1m" etc.
+#     to = "100 / 1s";
+#     to_ip = "100 / 1s";
+#     to_ip_from = "100 / 1s";
+#     bounce_to = "100 / 1h";
+#     bounce_to_ip = "7 / 1m";
+# }

--- a/data/conf/rspamd/override.d/ratelimit.conf
+++ b/data/conf/rspamd/override.d/ratelimit.conf
@@ -1,11 +1,3 @@
-rates {
-    # Format: "1 / 1h" or "20 / 1m" etc. - global ratelimits are disabled by default
-    to = "100 / 1s";
-    to_ip = "100 / 1s";
-    to_ip_from = "100 / 1s";
-    bounce_to = "100 / 1h";
-    bounce_to_ip = "7 / 1m";
-}
 whitelisted_rcpts = "postmaster,mailer-daemon";
 max_rcpt = 25;
 custom_keywords = "/etc/rspamd/lua/ratelimit.lua";


### PR DESCRIPTION
This PR will fix the "bug" which was introduced with 2023-11 which applied the global ratelimits which were meant to be not applied.

You can however setup your own global ratelimits inside the newly added ratelimit.conf in the local.d path of rspamd.