### PR TITLE
[Web] Fix sorting mailboxes by in use percent

### DIFF
--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -1114,7 +1114,8 @@ jQuery(function($){
           title: "",
           data: 'in_use.sortBy',
           defaultContent: '',
-          className: "d-none"
+          className: "d-none",
+          type: "num"
         },
       ]
     });


### PR DESCRIPTION
There seems to have been a previous attempt to fix this, but for me the mailboxes are still being sorted alphabetically (in descending order e.g. 90%, 9%, 80%, 8%, etc.). Changing the type of the data column to "num" fixed it for me.

There is now also another issue: mailboxes with infinite quota are sorted arbitrarily because their In use % is not a number but "- ". I propose fixing this by changing the API to return 0 as used percent for such mailboxes, but I have not included the change here because I don't know if it could break something else.