### PR TITLE
[Postfix] Upgrade to Deb12 + PF to 3.7.10 & Drop TLS 1.0/1.1 per default

### DIFF
--- a/data/Dockerfiles/postfix/Dockerfile
+++ b/data/Dockerfiles/postfix/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/data/Dockerfiles/postfix/syslog-ng-redis_slave.conf
+++ b/data/Dockerfiles/postfix/syslog-ng-redis_slave.conf
@@ -1,4 +1,4 @@
-@version: 3.28
+@version: 3.38
 @include "scl.conf"
 options {
   chain_hostnames(off);

--- a/data/Dockerfiles/postfix/syslog-ng.conf
+++ b/data/Dockerfiles/postfix/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.28
+@version: 3.38
 @include "scl.conf"
 options {
   chain_hostnames(off);

--- a/data/conf/postfix/anonymize_headers.pcre
+++ b/data/conf/postfix/anonymize_headers.pcre
@@ -1,6 +1,6 @@
 if /^\s*Received:.*Authenticated sender.*\(Postcow\)/
 #/^Received: from .*? \([\w-.]* \[.*?\]\)\s+\(Authenticated sender: (.+)\)\s+by.+\(Postcow\) with (E?SMTPS?A?) id ([A-F0-9]+).+;.*?/
-/^Received: from .*? \([\w-.]* \[.*?\]\)(.*|\n.*)\(Authenticated sender: (.+)\)\s+by.+\(Postcow\) with (.*)/
+/^Received: from .*? \([\w\-.]* \[.*?\]\)(.*|\n.*)\(Authenticated sender: (.+)\)\s+by.+\(Postcow\) with (.*)/
   REPLACE Received: from [127.0.0.1] (localhost [127.0.0.1]) by localhost (Mailerdaemon) with $3
 endif
 if /^\s*Received: from.* \(.*dovecot-mailcow.*mailcow-network.*\).*\(Postcow\)/

--- a/data/conf/postfix/main.cf
+++ b/data/conf/postfix/main.cf
@@ -119,9 +119,9 @@ lmtp_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
 smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
 smtpd_tls_mandatory_ciphers = high
 
-smtp_tls_protocols = !SSLv2, !SSLv3
+smtp_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
 lmtp_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
-smtpd_tls_protocols = !SSLv2, !SSLv3
+smtpd_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
 
 smtpd_tls_security_level = may
 tls_preempt_cipherlist = yes

--- a/data/conf/postfix/main.cf
+++ b/data/conf/postfix/main.cf
@@ -114,14 +114,14 @@ smtpd_tls_loglevel = 1
 
 # Mandatory protocols and ciphers are used when a connections is enforced to use TLS
 # Does _not_ apply to enforced incoming TLS settings per mailbox
-smtp_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
-lmtp_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
-smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
+smtp_tls_mandatory_protocols = >=TLSv1.2
+lmtp_tls_mandatory_protocols = >=TLSv1.2
+smtpd_tls_mandatory_protocols = >=TLSv1.2
 smtpd_tls_mandatory_ciphers = high
 
-smtp_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
-lmtp_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
-smtpd_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
+smtp_tls_protocols = >=TLSv1.2
+lmtp_tls_protocols = >=TLSv1.2
+smtpd_tls_protocols = >=TLSv1.2
 
 smtpd_tls_security_level = may
 tls_preempt_cipherlist = yes
@@ -167,8 +167,8 @@ smtpd_discard_ehlo_keywords = chunking, silent-discard
 compatibility_level = 3.7
 smtputf8_enable = no
 # Define protocols for SMTPS and submission service
-submission_smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
-smtps_smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
+submission_smtpd_tls_mandatory_protocols = >=TLSv1.2
+smtps_smtpd_tls_mandatory_protocols = >=TLSv1.2
 parent_domain_matches_subdomains = debug_peer_list,fast_flush_domains,mynetworks,qmqpd_authorized_clients
 
 # DO NOT EDIT ANYTHING BELOW #

--- a/data/conf/postfix/main.cf
+++ b/data/conf/postfix/main.cf
@@ -164,7 +164,7 @@ transport_maps = pcre:/opt/postfix/conf/custom_transport.pcre,
 smtp_sasl_auth_soft_bounce = no
 postscreen_discard_ehlo_keywords = silent-discard, dsn, chunking
 smtpd_discard_ehlo_keywords = chunking, silent-discard
-compatibility_level = 2
+compatibility_level = 3.7
 smtputf8_enable = no
 # Define protocols for SMTPS and submission service
 submission_smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -304,7 +304,7 @@ services:
             - dovecot
 
     postfix-mailcow:
-      image: mailcow/postfix:1.74
+      image: mailcow/postfix:1.75
       depends_on:
         mysql-mailcow:
           condition: service_started


### PR DESCRIPTION
This PR upgrades Postfix underlaying OS to Debian 12 and updates Postfix to the latest Debian Repo Version.

It also drops TLS1.0 and 1.1 per default now.