### PR TITLE
unbound: rewrote of healthcheck

### DIFF
--- a/data/Dockerfiles/unbound/Dockerfile
+++ b/data/Dockerfiles/unbound/Dockerfile
@@ -4,6 +4,8 @@ LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
 
 RUN apk add --update --no-cache \
 	curl \
+	bind-tools \
+	netcat-openbsd \
 	unbound \
 	bash \
 	openssl \
@@ -21,7 +23,7 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 # healthcheck (nslookup)
 COPY healthcheck.sh /healthcheck.sh
 RUN chmod +x /healthcheck.sh
-HEALTHCHECK --interval=30s --timeout=10s CMD [ "/healthcheck.sh" ]
+HEALTHCHECK --interval=5s --timeout=10s CMD [ "/healthcheck.sh" ]
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/data/Dockerfiles/unbound/healthcheck.sh
+++ b/data/Dockerfiles/unbound/healthcheck.sh
@@ -1,12 +1,89 @@
 #!/bin/bash
 
-nslookup mailcow.email 127.0.0.1 1> /dev/null
+# Declare log function for logfile inside container
+function log_to_file() {
+    echo "$(date +"%Y-%m-%d %H:%M:%S"): $1" > /var/log/healthcheck.log
+}
 
-if [ $? == 0 ]; then
-    echo "DNS resolution is working!"
-    exit 0
-else
-    echo "DNS resolution is not working correctly..."
-    echo "Maybe check your outbound firewall, as it needs to resolve DNS over TCP AND UDP!"
+# General Ping function to check general pingability
+function check_ping() {
+    declare -a ipstoping=("1.1.1.1" "8.8.8.8" "9.9.9.9")
+
+    for ip in "${ipstoping[@]}" ; do
+            ping -q -c 3 -w 5 "$ip"
+            if [ $? -ne 0 ]; then
+                log_to_file "Healthcheck: Couldn't ping $ip for 5 seconds... Gave up!"
+                log_to_file "Please check your internet connection or firewall rules to fix this error, because a simple ping test should always go through from the unbound container!"
+                return 1
+            fi
+    done
+
+    log_to_file "Healthcheck: Ping Checks WORKING properly!"
+    return 0
+}
+
+# General DNS Resolve Check against Unbound Resolver himself
+function check_dns() {
+    declare -a domains=("mailcow.email" "github.com" "hub.docker.com")
+
+    for domain in "${domains[@]}" ; do
+        for ((i=1; i<=3; i++)); do
+            dig +short +timeout=2 +tries=1 "$domain" @127.0.0.1 > /dev/null
+        if [ $? -ne 0 ]; then
+            log_to_file "Healthcheck: DNS Resolution Failed on $i attempt! Trying again..."
+            if [ $i -eq 3 ]; then
+                log_to_file "Healthcheck: DNS Resolution not possible after $i attempts... Gave up!"
+                log_to_file "Maybe check your outbound firewall, as it needs to resolve DNS over TCP AND UDP!"
+                return 1
+            fi
+        fi
+        done
+    done
+
+    log_to_file "Healthcheck: DNS Resolver WORKING properly!"
+    return 0
+    
+}
+
+# Simple Netcat Check to connect to common webports
+function check_netcat() {
+    declare -a domains=("mailcow.email" "github.com" "hub.docker.com")
+    declare -a ports=("80" "443")
+
+    for domain in "${domains[@]}" ; do
+        for port in "${ports[@]}" ; do
+            nc -z -w 2 $domain $port
+            if [ $? -ne 0 ]; then
+                log_to_file "Healthcheck: Could not reach $domain on Port $port... Gave up!"
+                log_to_file "Please check your internet connection or firewall rules to fix this error."
+                return 1
+            fi
+        done
+    done
+
+    log_to_file "Healthcheck: Netcat Checks WORKING properly!"
+    return 0
+
+}
+
+# run checks, if check is not returning 0 (return value if check is ok), healthcheck will exit with 1 (marked in docker as unhealthy)
+check_ping
+
+if [ $? -ne 0 ]; then
     exit 1
 fi
+
+check_dns
+
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+
+check_netcat
+
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+
+log_to_file "Healthcheck: ALL CHECKS WERE SUCCESSFUL! Unbound is healthy!"
+exit 0


### PR DESCRIPTION
This PR includes a rewrote of the unbound healthchecks.

Instead of simply checking the DNS Resolution of unbound the check is also checking the ability to ping the hosts which are resolved to test as well as doing a simple 80 443 accessibility check within unbound to ensure a connection can be made.