### PR TITLE
New Feature: Quarantine Outgoing Mail

### DIFF
--- a/data/conf/rspamd/meta_exporter/pipe.php
+++ b/data/conf/rspamd/meta_exporter/pipe.php
@@ -90,55 +90,57 @@ catch (RedisException $e) {
   exit;
 }
 
-// If the sender is managed by mailcow, quarantine and skip the rest
-// TODO: check if outgoing quarantine is enabled along with domain map
+// If the sender is managed by mailcow, only if the mail is rejected, quarantine and skip further processing
+// TODO: per domain outgoing quarantine
 try {
-  $domain = parse_email($sender)['domain'];
-  if ($redis->hGet('DOMAIN_MAP', $domain)) {
-    foreach (json_decode($rcpts, true) as $rcpt) {
-      error_log("QUARANTINE: quarantine pipe: processing quarantine message for rcpt " . $rcpt . PHP_EOL);
-      try {
-        $stmt = $pdo->prepare("INSERT INTO `quarantine` (`qid`, `subject`, `score`, `sender`, `rcpt`, `symbols`, `user`, `ip`, `msg`, `action`, `fuzzy_hashes`)
-          VALUES (:qid, :subject, :score, :sender, :rcpt, :symbols, :user, :ip, :msg, :action, :fuzzy_hashes)");
-        $stmt->execute(
-          array(
-            ':qid' => $qid,
-            ':subject' => $subject,
-            ':score' => $score,
-            ':sender' => $sender,
-            ':rcpt' => $rcpt,
-            ':symbols' => $symbols,
-            ':user' => $user,
-            ':ip' => $ip,
-            ':msg' => $raw_data,
-            ':action' => $action,
-            ':fuzzy_hashes' => $fuzzy
-          )
-        );
-        $stmt = $pdo->prepare('DELETE FROM `quarantine` WHERE `rcpt` = :rcpt AND `id` NOT IN (
-          SELECT `id`
-          FROM (
+  if ($redis->Get('Q_OUTGOING_ENABLED') == 'on') {
+    $domain = parse_email($sender)['domain'];
+    if ($redis->hGet('DOMAIN_MAP', $domain) && $action == "reject") {
+      error_log("QUARANTINE: quarantine pipe: processing quarantine message for sender " . $sender . PHP_EOL);
+      foreach (json_decode($rcpts, true) as $rcpt) {
+        try {
+          $stmt = $pdo->prepare("INSERT INTO `quarantine` (`qid`, `subject`, `score`, `sender`, `rcpt`, `symbols`, `user`, `ip`, `msg`, `action`, `fuzzy_hashes`)
+            VALUES (:qid, :subject, :score, :sender, :rcpt, :symbols, :user, :ip, :msg, :action, :fuzzy_hashes)");
+          $stmt->execute(
+            array(
+              ':qid' => $qid,
+              ':subject' => $subject,
+              ':score' => $score,
+              ':sender' => $sender,
+              ':rcpt' => $rcpt,
+              ':symbols' => $symbols,
+              ':user' => $user,
+              ':ip' => $ip,
+              ':msg' => $raw_data,
+              ':action' => $action,
+              ':fuzzy_hashes' => $fuzzy
+            )
+          );
+          $stmt = $pdo->prepare('DELETE FROM `quarantine` WHERE `rcpt` = :rcpt AND `id` NOT IN (
             SELECT `id`
-            FROM `quarantine`
-            WHERE `rcpt` = :rcpt2
-            ORDER BY id DESC
-            LIMIT :retention_size
-          ) x 
-        );');
-        $stmt->execute(
-          array(
-            ':rcpt' => $rcpt,
-            ':rcpt2' => $rcpt,
-            ':retention_size' => $retention_size
-          )
-        );
-      } catch (PDOException $e) {
-        error_log("QUARANTINE: " . $e->getMessage() . PHP_EOL);
-        http_response_code(503);
-        exit;
+            FROM (
+              SELECT `id`
+              FROM `quarantine`
+              WHERE `rcpt` = :rcpt2
+              ORDER BY id DESC
+              LIMIT :retention_size
+            ) x 
+          );');
+          $stmt->execute(
+            array(
+              ':rcpt' => $rcpt,
+              ':rcpt2' => $rcpt,
+              ':retention_size' => $retention_size
+            )
+          );
+        } catch (PDOException $e) {
+          error_log("QUARANTINE: " . $e->getMessage() . PHP_EOL);
+          http_response_code(503);
+          exit;
+        }
       }
+      exit;
     }
-    exit;
   }
 } 
 catch (RedisException $e) {

--- a/data/conf/rspamd/meta_exporter/pipe.php
+++ b/data/conf/rspamd/meta_exporter/pipe.php
@@ -90,8 +90,7 @@ catch (RedisException $e) {
   exit;
 }
 
-// If the sender is managed by mailcow, only if the mail is rejected, quarantine and skip further processing
-// TODO: per domain outgoing quarantine
+// If the sender is a mailcow user and outgoing quarantine is enabled, quarantine the message and skip further processing
 try {
   if ($redis->Get('Q_OUTGOING_ENABLED') == 'on') {
     $domain = parse_email($sender)['domain'];
@@ -139,6 +138,7 @@ try {
           exit;
         }
       }
+      // The sender is a single person, and has been successfully processed, no need to process further
       exit;
     }
   }

--- a/data/web/inc/functions.quarantine.inc.php
+++ b/data/web/inc/functions.quarantine.inc.php
@@ -478,7 +478,6 @@ function quarantine($_action, $_data = null) {
             $parser->setText($row['msg']);
             $subject = $parser->getHeader('subject');
             $text = $parser->getMessageBody('text');
-            // $html = $parser->getMessageBody('html');
             $html = $parser->getMessageBody('htmlEmbedded');
             try {
               $mail = new PHPMailer(true);
@@ -517,7 +516,7 @@ function quarantine($_action, $_data = null) {
                     $dkim_key = $redis->hGet('DKIM_PRIV_KEYS', sprintf("%s.%s", $selector, $sender_domain));
                     $mail->DKIM_copyHeaderFields = false;
                     $mail->DKIM_domain = $sender_domain;
-                    $mail->DKIM_private_string = $dkim_key; // Make sure to protect the key from being publicly accessible!
+                    $mail->DKIM_private_string = $dkim_key;
                     $mail->DKIM_selector = $selector;
                     $mail->DKIM_identity = $mail->From;
                   }

--- a/data/web/inc/functions.quarantine.inc.php
+++ b/data/web/inc/functions.quarantine.inc.php
@@ -314,6 +314,7 @@ function quarantine($_action, $_data = null) {
           $max_score = floatval($_data['max_score']);
         }
         $max_age = intval($_data['max_age']);
+        $outgoing_enabled = $_data['outgoing_enabled'];
         $subject = $_data['subject'];
         if (!filter_var($_data['bcc'], FILTER_VALIDATE_EMAIL)) {
           $bcc = '';
@@ -343,6 +344,7 @@ function quarantine($_action, $_data = null) {
           $redis->Set('Q_MAX_SIZE', intval($max_size));
           $redis->Set('Q_MAX_SCORE', $max_score);
           $redis->Set('Q_MAX_AGE', $max_age);
+          $redis->Set('Q_OUTGOING_ENABLED', $outgoing_enabled);
           $redis->Set('Q_EXCLUDE_DOMAINS', json_encode($exclude_domains));
           $redis->Set('Q_RELEASE_FORMAT', $release_format);
           $redis->Set('Q_SENDER', $sender);
@@ -814,6 +816,7 @@ function quarantine($_action, $_data = null) {
         $settings['max_size'] = $redis->Get('Q_MAX_SIZE');
         $settings['max_score'] = $redis->Get('Q_MAX_SCORE');
         $settings['max_age'] = $redis->Get('Q_MAX_AGE');
+        $settings['outgoing_enabled'] = $redis->Get('Q_OUTGOING_ENABLED');
         $settings['retention_size'] = $redis->Get('Q_RETENTION_SIZE');
         $settings['release_format'] = $redis->Get('Q_RELEASE_FORMAT');
         $settings['subject'] = $redis->Get('Q_SUBJ');

--- a/data/web/lang/lang.en-gb.json
+++ b/data/web/lang/lang.en-gb.json
@@ -262,6 +262,7 @@
         "quarantine_bcc": "Send a copy of all notifications (BCC) to this recipient:<br><small>Leave empty to disable. <b>Unsigned, unchecked mail. Should be delivered internally only.</b></small>",
         "quarantine_exclude_domains": "Exclude domains and alias-domains",
         "quarantine_max_age": "Maximum age in days<br><small>Value must be equal to or greater than 1 day.</small>",
+        "quarantine_outgoing_enabled": "Outgoing quarantine enabled<br><small>Rejected mail sent by authenticated users will be saved for review.</small>",
         "quarantine_max_score": "Discard notification if spam score of a mail is higher than this value:<br><small>Defaults to 9999.0</small>",
         "quarantine_max_size": "Maximum size in MiB (larger elements are discarded):<br><small>0 does <b>not</b> indicate unlimited.</small>",
         "quarantine_notification_html": "Notification email template:<br><small>Leave empty to restore default template.</small>",

--- a/data/web/templates/admin/tab-config-quarantine.twig
+++ b/data/web/templates/admin/tab-config-quarantine.twig
@@ -35,6 +35,12 @@
             <input type="number" class="form-control" id="quarantine_max_age" name="max_age" value="{{ q_data.max_age }}" min="1" required>
           </div>
         </div>
+        <div class="row mb-4">
+          <label class="col-sm-4 control-label text-sm-end" for="quarantine_outgoing_enabled">{{ lang.admin.quarantine_outgoing_enabled|raw }}</label>
+          <div class="col-sm-8">
+            <input type="checkbox" class="form-check-input" id="quarantine_outgoing_enabled" name="outgoing_enabled" {% if q_data.outgoing_enabled == 'on' %} checked{% endif %}>
+          </div>
+        </div>
         <hr>
         <div class="row mb-4">
           <label class="col-sm-4 control-label text-sm-end" for="quarantine_redirect"><i class="bi bi-box-arrow-right"></i> {{ lang.admin.quarantine_redirect|raw }}</label>


### PR DESCRIPTION
I have implemented outbound quarantine scanning for mailcow as an optional feature. The UI and language files have been updated to reflect this feature, and the ability to enable/disable it. 

![image](https://github.com/mailcow/mailcow-dockerized/assets/2219973/2efc081e-8985-42f9-a02d-e3d3656cea39)

The  `data/conf/rspamd/meta_exporter/pipe.php` script will now check if the sender is a mailcow user, and will quarantine a message if the feature is enabled and the action is "reject".

Mail is stored per-recipient, similar to how incoming quarantined mail is processed. If the message being released (not via quick release) from quarantine is from a mailcow sender and a DKIM key exists for that domain, the message  will be signed before being released. I have tested this with various email formats (plain text emails, emails with only html, multipart emails with text and html, emails with inline images and attachments) via a few mail clients (SOGo, BetterBird, Evolution), and all released mail appears to leave in its original state. The already included `PhpMimeMailParser` library was used to load raw message contents, select message body components (text/html/etc). New headers were constructed using the message metadata before signing.

I decided that leveraging the existing PHP tooling in this context made more sense than setting up an additional SMTP port to sign outgoing mail via rspamd being released from quarantine, as the existing quarantine port (590) does not use milters.

Bonus: [Headers signed via PHPMailer with some data redacted](https://pastebin.com/WSmRSxmR)