### PR TITLE
fix: rollback curl bug

### DIFF
--- a/data/Dockerfiles/acme/Dockerfile
+++ b/data/Dockerfiles/acme/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.18
 
 LABEL maintainer "The Infrastructure Company GmbH GmbH <info@servercow.de>"
 

--- a/data/Dockerfiles/phpfpm/Dockerfile
+++ b/data/Dockerfiles/phpfpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-alpine3.19
+FROM php:8.2-fpm-alpine3.18
 LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
 
 # renovate: datasource=github-tags depName=krakjoe/apcu versioning=semver-coerced extractVersion=^v(?<version>.*)$

--- a/data/Dockerfiles/unbound/Dockerfile
+++ b/data/Dockerfiles/unbound/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.18
 
 LABEL maintainer "The Infrastructure Company GmbH GmbH <info@servercow.de>"
 

--- a/data/Dockerfiles/watchdog/Dockerfile
+++ b/data/Dockerfiles/watchdog/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.18
 LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
 
 # Installation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
             - rspamd
 
     php-fpm-mailcow:
-      image: mailcow/phpfpm:1.86
+      image: mailcow/phpfpm:1.87
       command: "php-fpm -d date.timezone=${TZ} -d expose_php=0"
       depends_on:
         - redis-mailcow
@@ -399,7 +399,7 @@ services:
           condition: service_started
         unbound-mailcow:
           condition: service_healthy
-      image: mailcow/acme:1.86
+      image: mailcow/acme:1.87
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       environment:


### PR DESCRIPTION
This PR rollsback the effected Alpine Images which cause trouble for some users.

Dovecot however cannot be rolled back due to the Alpine 3.19 dependency.

But Dovecot only uses curl to Download things from the internet which still works even in the affected images.