### PR TITLE
Enable bz2 in php container

### DIFF
--- a/data/Dockerfiles/phpfpm/Dockerfile
+++ b/data/Dockerfiles/phpfpm/Dockerfile
@@ -76,7 +76,7 @@ RUN apk add -U --no-cache autoconf \
     --with-webp \
     --with-xpm \
     --with-avif \
-  && docker-php-ext-install -j 4 exif gd gettext intl ldap opcache pcntl pdo pdo_mysql pspell soap sockets sysvsem zip bcmath gmp \
+  && docker-php-ext-install -j 4 exif gd gettext intl ldap opcache pcntl pdo pdo_mysql pspell soap sockets sysvsem zip bz2 bcmath gmp \
   && docker-php-ext-configure imap --with-imap --with-imap-ssl \
   && docker-php-ext-install -j 4 imap \
   && curl --silent --show-error https://getcomposer.org/installer | php -- --version=${COMPOSER_VERSION} \


### PR DESCRIPTION
Newer Nextcloud version will complain (not too loud, but will) if the php bz2 extension is missing in the  php-fpm container.

It's fairly easy to install after the fact, but with caveats, and seems to go away after an update.

Should not harm normal mailcow behavior and benefits nextcloud users.