### PR TITLE
Enable posix_getpwuid for the web-worker pool

### DIFF
--- a/data/conf/phpfpm/php-fpm.d/pools.conf
+++ b/data/conf/phpfpm/php-fpm.d/pools.conf
@@ -26,4 +26,4 @@ access.log = /proc/self/fd/2
 clear_env = no
 catch_workers_output = yes
 php_admin_value[memory_limit] = 512M
-php_admin_value[disable_functions] = show_source, highlight_file, apache_child_terminate, apache_get_modules, apache_note, apache_setenv, virtual, dl, disk_total_space, posix_getpwnam, posix_getpwuid, posix_mkfifo, posix_mknod, posix_setpgid, posix_setsid, posix_setuid, posix_uname, proc_nice, openlog, syslog, pfsockopen, system, shell_exec, passthru, popen, proc_open, exec, ini_alter, pcntl_exec, proc_close, proc_get_status, proc_terminate, symlink
+php_admin_value[disable_functions] = show_source, highlight_file, apache_child_terminate, apache_get_modules, apache_note, apache_setenv, virtual, dl, disk_total_space, posix_getpwnam, posix_mkfifo, posix_mknod, posix_setpgid, posix_setsid, posix_setuid, posix_uname, proc_nice, openlog, syslog, pfsockopen, system, shell_exec, passthru, popen, proc_open, exec, ini_alter, pcntl_exec, proc_close, proc_get_status, proc_terminate, symlink


### PR DESCRIPTION
This fixes [issue 5706](https://github.com/mailcow/mailcow-dockerized/issues/5706)
Nextcloud >= 28.0.2 requires posix_getpwuid for their Security & setup warnings panel to function.

As I am not familiar with the php code of mailcow someone would need to give feedback if it safe to just enable posix_getpwuid for all of mailcow.