### PR TITLE
[Web] fix blank /debug page with invalid timezone

### DIFF
--- a/data/web/debug.php
+++ b/data/web/debug.php
@@ -39,9 +39,13 @@ foreach ($containers as $container => $container_info) {
       $StartedAt['month'],
       $StartedAt['day'],
       $StartedAt['year']));
-    $user_tz = new DateTimeZone(getenv('TZ'));
-    $date->setTimezone($user_tz);
-    $started = $date->format('r');
+    try {
+      $user_tz = new DateTimeZone(getenv('TZ'));
+      $date->setTimezone($user_tz);
+      $started = $date->format('r');
+    } catch(Exception $e) {
+      $started = '?';
+    }
   }
   else {
     $started = '?';


### PR DESCRIPTION
This will fix the debug page to not show a blank page if an invalid timezone is defined in mailcow.conf.