### PR TITLE
Netfilter Fix os.getenv has no attribute lower

### DIFF
--- a/data/Dockerfiles/netfilter/main.py
+++ b/data/Dockerfiles/netfilter/main.py
@@ -415,7 +415,7 @@ if __name__ == '__main__':
   tables.initChainIPv4()
   tables.initChainIPv6()
 
-  if os.getenv("DISABLE_NETFILTER_ISOLATION_RULE").lower() in ("y", "yes"):
+  if str(os.getenv("DISABLE_NETFILTER_ISOLATION_RULE")).lower() in ("y", "yes"):
     logger.logInfo(f"Skipping {chain_name} isolation")
   else:
     logger.logInfo(f"Setting {chain_name} isolation")


### PR DESCRIPTION
Netfilter crash
```text
netfilter-mailcow-1  | Using IPTables backend
netfilter-mailcow-1  | Clearing all bans
netfilter-mailcow-1  | Initializing mailcow netfilter chain netfilter-mailcow-1  | Traceback (most recent call last):
netfilter-mailcow-1  |   File "/app/main.py", line 418, in <module>
netfilter-mailcow-1  |     if os.getenv("DISABLE_NETFILTER_ISOLATION_RULE").lower() in ("y", "yes"):
netfilter-mailcow-1  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
netfilter-mailcow-1  | AttributeError: 'NoneType' object has no attribute 'lower'
netfilter-mailcow-1 exited with code 1
```
os.getenv has no attribute lower

Fix. Cast to String.