### PR TITLE
[Fix] Watchdog: escape subject and body for webhooks

### DIFF
--- a/data/Dockerfiles/watchdog/watchdog.sh
+++ b/data/Dockerfiles/watchdog/watchdog.sh
@@ -169,9 +169,13 @@ function notify_error() {
       return 1
     fi
 
+    # Escape subject and body (https://stackoverflow.com/a/2705678)
+    ESCAPED_SUBJECT=$(echo ${SUBJECT} | sed -e 's/[\/&]/\\&/g')
+    ESCAPED_BODY=$(echo ${BODY} | sed -e 's/[\/&]/\\&/g')
+
     # Replace subject and body placeholders
-    WEBHOOK_BODY=$(echo ${WATCHDOG_NOTIFY_WEBHOOK_BODY} | sed "s/\$SUBJECT\|\${SUBJECT}/$SUBJECT/g" | sed "s/\$BODY\|\${BODY}/$BODY/g")
-    
+    WEBHOOK_BODY=$(echo ${WATCHDOG_NOTIFY_WEBHOOK_BODY} | sed -e "s/\$SUBJECT\|\${SUBJECT}/$ESCAPED_SUBJECT/g" -e "s/\$BODY\|\${BODY}/$ESCAPED_BODY/g")
+
     # POST to webhook
     curl -X POST -H "Content-Type: application/json" ${CURL_VERBOSE} -d "${WEBHOOK_BODY}" ${WATCHDOG_NOTIFY_WEBHOOK}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -460,7 +460,7 @@ services:
         - /lib/modules:/lib/modules:ro
 
     watchdog-mailcow:
-      image: mailcow/watchdog:2.02
+      image: mailcow/watchdog:2.03
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       tmpfs:
@@ -477,7 +477,6 @@ services:
         - mysql-mailcow
         - acme-mailcow
         - redis-mailcow
-
       environment:
         - IPV6_NETWORK=${IPV6_NETWORK:-fd4d:6169:6c63:6f77::/64}
         - LOG_LINES=${LOG_LINES:-9999}


### PR DESCRIPTION
Proposal for escaping subject and body for webhooks, which fixes #5760. I tried to use a generic approach as mentioned [here](https://stackoverflow.com/a/2705678):

> As Ben Blank said, there are only three characters that need to be escaped in the replacement string (escapes themselves, forward slash for end of statement and & for replace all)

IP ban notifications using Pushover are now working for me:

![grafik](https://github.com/mailcow/mailcow-dockerized/assets/6423849/36dbf19b-8546-4e58-8c78-0b36523c7189)
