### PR TITLE
Add checks to sieve validator (mime and foreverypart)

### DIFF
--- a/data/web/inc/lib/sieve/extensions/foreverypart.xml
+++ b/data/web/inc/lib/sieve/extensions/foreverypart.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' standalone='yes'?>
+
+<extension name="foreverypart">
+
+    <command name="foreverypart">
+
+        <parameter type="block" />
+
+    </command>
+
+</extension>

--- a/data/web/inc/lib/sieve/extensions/mime.xml
+++ b/data/web/inc/lib/sieve/extensions/mime.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' standalone='yes'?>
+
+<extension name="mime">
+
+	<tagged-argument extends="(header)">
+
+		<parameter type="tag" name="mime" regex="mime" occurrence="optional">
+
+			<parameter type="tag" name="anychild" regex="anychild" occurrence="optional"/>
+			<parameter type="tag" name="type" regex="type" occurrence="optional"/>
+			<parameter type="tag" name="subtype" regex="subtype" occurrence="optional"/>
+			<parameter type="tag" name="contenttype" regex="contenttype" occurrence="optional"/>
+			<parameter type="tag" name="param" regex="param" occurrence="optional">
+				<parameter type="string" name="name"/>
+			</parameter>
+
+		</parameter>
+
+	</tagged-argument>
+
+</extension>


### PR DESCRIPTION
Allowing the inclusion of the sieve extensions `mime` and `foreverypart` would allow for additional sieve filter options.
The usecase could be filtering mails by attached filetypes.
e.g. redirecting or blocking mails which have a certain file attached to them.

With the proposed changes I was able to successfully save a sieve filter script with following content:
```
require ["mime", "foreverypart", "copy"];

foreverypart
{
  if header :mime :anychild :param "filename" :matches "Content-Disposition" ["*.pdf"]
  {
    redirect :copy "copycat@example.com";
  }
}
```
This script will forward every mail that has a .pdf file attached to a separate E-Mail address (e.g. dms such as paperless-ngx).

Removing the "filename" string from this example caused the parser to fail - as it should.