### PR TITLE
Allow prompt-less install on low-resource systems

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -147,40 +147,44 @@ done
 
 MEM_TOTAL=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
 
-if [ ${MEM_TOTAL} -le "2621440" ]; then
-  echo "Installed memory is <= 2.5 GiB. It is recommended to disable ClamAV to prevent out-of-memory situations."
-  echo "ClamAV can be re-enabled by setting SKIP_CLAMD=n in mailcow.conf."
-  read -r -p  "Do you want to disable ClamAV now? [Y/n] " response
-  case $response in
-    [nN][oO]|[nN])
-      SKIP_CLAMD=n
+if [ -z "${SKIP_CLAMD}" ]; then
+  if [ ${MEM_TOTAL} -le "2621440" ]; then
+    echo "Installed memory is <= 2.5 GiB. It is recommended to disable ClamAV to prevent out-of-memory situations."
+    echo "ClamAV can be re-enabled by setting SKIP_CLAMD=n in mailcow.conf."
+    read -r -p  "Do you want to disable ClamAV now? [Y/n] " response
+    case $response in
+      [nN][oO]|[nN])
+        SKIP_CLAMD=n
+        ;;
+      *)
+        SKIP_CLAMD=y
       ;;
-    *)
-      SKIP_CLAMD=y
-    ;;
-  esac
-else
-  SKIP_CLAMD=n
+    esac
+  else
+    SKIP_CLAMD=n
+  fi
 fi
 
-if [ ${MEM_TOTAL} -le "2097152" ]; then
-  echo "Disabling Solr on low-memory system."
-  SKIP_SOLR=y
-elif [ ${MEM_TOTAL} -le "3670016" ]; then
-  echo "Installed memory is <= 3.5 GiB. It is recommended to disable Solr to prevent out-of-memory situations."
-  echo "Solr is a prone to run OOM and should be monitored. The default Solr heap size is 1024 MiB and should be set in mailcow.conf according to your expected load."
-  echo "Solr can be re-enabled by setting SKIP_SOLR=n in mailcow.conf but will refuse to start with less than 2 GB total memory."
-  read -r -p  "Do you want to disable Solr now? [Y/n] " response
-  case $response in
-    [nN][oO]|[nN])
-      SKIP_SOLR=n
+if [ -z "${SKIP_SOLR}" ]; then
+  if [ ${MEM_TOTAL} -le "2097152" ]; then
+    echo "Disabling Solr on low-memory system."
+    SKIP_SOLR=y
+  elif [ ${MEM_TOTAL} -le "3670016" ]; then
+    echo "Installed memory is <= 3.5 GiB. It is recommended to disable Solr to prevent out-of-memory situations."
+    echo "Solr is a prone to run OOM and should be monitored. The default Solr heap size is 1024 MiB and should be set in mailcow.conf according to your expected load."
+    echo "Solr can be re-enabled by setting SKIP_SOLR=n in mailcow.conf but will refuse to start with less than 2 GB total memory."
+    read -r -p  "Do you want to disable Solr now? [Y/n] " response
+    case $response in
+      [nN][oO]|[nN])
+        SKIP_SOLR=n
+        ;;
+      *)
+        SKIP_SOLR=y
       ;;
-    *)
-      SKIP_SOLR=y
-    ;;
-  esac
-else
-  SKIP_SOLR=n
+    esac
+  else
+    SKIP_SOLR=n
+  fi
 fi
 
 if [[ ${SKIP_BRANCH} != y ]]; then


### PR DESCRIPTION
Make it possible to generate config unattended on low resource systems by bypassing prompts if `SKIP_SOLR` or `SKIP_CLAMD` is non-empty.
This was tested with the mailcow-ansiblerole repository with the following patch:

```patch
diff --git a/tasks/main.yml b/tasks/main.yml
index a1263f2..bf8825a 100755
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,8 @@
     MAILCOW_HOSTNAME: "{{ mailcow__hostname }}"
     MAILCOW_TZ: "{{ mailcow__timezone }}"
     MAILCOW_BRANCH: "{{ mailcow__git_version }}"
+    SKIP_SOLR: "{{ mailcow__config_skip_solr }}"
+    SKIP_CLAMD: "{{ mailcow__config_skip_clamd }}"
   args:
     executable: /bin/bash
     chdir: "{{ mailcow__install_path }}"
```