### PR TITLE
[Rspamd] Set local_addrs lo mailcow networks

### DIFF
--- a/data/conf/rspamd/local.d/options.inc
+++ b/data/conf/rspamd/local.d/options.inc
@@ -6,3 +6,4 @@ disable_monitoring = true;
 # In case a task times out (like DNS lookup), soft reject the message
 # instead of silently accepting the message without further processing.
 soft_reject_on_timeout = true;
+local_addrs = /etc/rspamd/custom/mailcow_networks.map;


### PR DESCRIPTION
Limit local_addrs to mailcow networks.

This should enable some checkes for non-mailcow networks like https://rspamd.com/doc/tutorials/scanning_outbound.html#scanning-outbound-with-rspamd