### PR TITLE
Fix broken dependencies for dovecot image

### DIFF
--- a/data/Dockerfiles/dovecot/Dockerfile
+++ b/data/Dockerfiles/dovecot/Dockerfile
@@ -7,6 +7,9 @@ ARG GOSU_VERSION=1.16
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
+# Add edge repository for perl-lockfile-simple as ARM package is only available there
+RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community/" >>/etc/apk/repositories
+
 # Add groups and users before installing Dovecot to not break compatibility
 RUN addgroup -g 5000 vmail \
   && addgroup -g 401 dovecot \
@@ -62,7 +65,7 @@ RUN addgroup -g 5000 vmail \
   perl-package-stash-xs \
   perl-par-packer \
   perl-parse-recdescent \
-  perl-lockfile-simple --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
+  perl-lockfile-simple@edge-community \
   libproc \
   perl-readonly \
   perl-regexp-common \

--- a/data/Dockerfiles/dovecot/Dockerfile
+++ b/data/Dockerfiles/dovecot/Dockerfile
@@ -107,7 +107,7 @@ RUN addgroup -g 5000 vmail \
   dovecot-pigeonhole-plugin \
   dovecot-pop3d \
   dovecot-fts-solr \
-  && arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
+  && arch=$(arch | sed -e s/armv7l/armhf/ -e s/aarch64/arm64/ -e s/x86_64/amd64/) \
   && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$arch" \
   && chmod +x /usr/local/bin/gosu \
   && gosu nobody true


### PR DESCRIPTION
- Fix python 3.11 vs 3.12 breakage because of edge repository usage
- Fix gosu armhf dependency (@MAGICCC do we even want to support this properly?)
