### PR TITLE
Add option to send authorization header to webhook

### DIFF
--- a/data/Dockerfiles/watchdog/watchdog.sh
+++ b/data/Dockerfiles/watchdog/watchdog.sh
@@ -172,8 +172,13 @@ function notify_error() {
     # Replace subject and body placeholders
     WEBHOOK_BODY=$(echo ${WATCHDOG_NOTIFY_WEBHOOK_BODY} | sed "s/\$SUBJECT\|\${SUBJECT}/$SUBJECT/g" | sed "s/\$BODY\|\${BODY}/$BODY/g")
     
+    WEBHOOK_COMMAND="curl -X POST -H \"Content-Type: application/json\" ${CURL_VERBOSE} -d '${WEBHOOK_BODY}' ${WATCHDOG_NOTIFY_WEBHOOK}"
+    if [[ ! -z ${WATCHDOG_NOTIFY_WEBHOOK_AUTH_HEADER} ]]; then
+        WEBHOOK_COMMAND="${WEBHOOK_COMMAND} -H '${WATCHDOG_NOTIFY_WEBHOOK_AUTH_HEADER}'"
+    fi
+
     # POST to webhook
-    curl -X POST -H "Content-Type: application/json" ${CURL_VERBOSE} -d "${WEBHOOK_BODY}" ${WATCHDOG_NOTIFY_WEBHOOK}
+    eval $WEBHOOK_COMMAND
 
     log_msg "Sent notification using webhook"
   fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -460,7 +460,7 @@ services:
         - /lib/modules:/lib/modules:ro
 
     watchdog-mailcow:
-      image: mailcow/watchdog:2.02
+      image: mailcow/watchdog:2.03
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       tmpfs:
@@ -493,6 +493,7 @@ services:
         - WATCHDOG_SUBJECT=${WATCHDOG_SUBJECT:-Watchdog ALERT}
         - WATCHDOG_NOTIFY_WEBHOOK=${WATCHDOG_NOTIFY_WEBHOOK:-}
         - WATCHDOG_NOTIFY_WEBHOOK_BODY=${WATCHDOG_NOTIFY_WEBHOOK_BODY:-}
+        - WATCHDOG_NOTIFY_WEBHOOK_AUTH_HEADER=${WATCHDOG_NOTIFY_WEBHOOK_AUTH_HEADER:-} 
         - WATCHDOG_EXTERNAL_CHECKS=${WATCHDOG_EXTERNAL_CHECKS:-n}
         - WATCHDOG_MYSQL_REPLICATION_CHECKS=${WATCHDOG_MYSQL_REPLICATION_CHECKS:-n}
         - WATCHDOG_VERBOSE=${WATCHDOG_VERBOSE:-n}

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -408,6 +408,8 @@ USE_WATCHDOG=y
 # JSON body included in the webhook POST request. Needs to be in single quotes.
 # Following variables are available: SUBJECT, BODY
 #WATCHDOG_NOTIFY_WEBHOOK_BODY='{"username": "mailcow Watchdog", "content": "**${SUBJECT}**\n${BODY}"}'
+# If the watchdog webhook you are calling needs headers for authentication configure it as follow, putting 'name: value'in quotes:
+#WATCHDOG_NOTIFY_WEBHOOK_AUTH_HEADER='authorization: Bearer allYourTokensAreBelongToUs'
 
 # Notify about banned IP (includes whois lookup)
 WATCHDOG_NOTIFY_BAN=n

--- a/update.sh
+++ b/update.sh
@@ -443,6 +443,7 @@ CONFIG_ARRAY=(
   "WATCHDOG_NOTIFY_EMAIL"
   "WATCHDOG_NOTIFY_WEBHOOK"
   "WATCHDOG_NOTIFY_WEBHOOK_BODY"
+  "WATCHDOG_NOTIFY_WEBHOOK_AUTH_HEADER"
   "WATCHDOG_NOTIFY_BAN"
   "WATCHDOG_NOTIFY_START"
   "WATCHDOG_EXTERNAL_CHECKS"
@@ -642,6 +643,13 @@ for option in ${CONFIG_ARRAY[@]}; do
       echo '# Following variables are available: SUBJECT, BODY' >> mailcow.conf
       WEBHOOK_BODY='{"username": "mailcow Watchdog", "content": "**${SUBJECT}**\n${BODY}"}'
       echo "#WATCHDOG_NOTIFY_WEBHOOK_BODY='${WEBHOOK_BODY}'" >> mailcow.conf
+    fi
+  elif [[ ${option} == "WATCHDOG_NOTIFY_WEBHOOK_AUTH_HEADER" ]]; then
+    if ! grep -q ${option} mailcow.conf; then
+      echo "Adding new option \"${option}\" to mailcow.conf"
+      echo '# If the watchdog webhook you are calling needs headers for authentication configure it as follow, putting 'name: value'in quotes:' >> mailcow.conf
+      WATCHDOG_NOTIFY_WEBHOOK_AUTH_HEADER='authorization: Bearer allYourTokensAreBelongToUs'
+      echo "#WATCHDOG_NOTIFY_WEBHOOK_AUTH_HEADER='${WATCHDOG_NOTIFY_WEBHOOK_AUTH_HEADER}'" >> mailcow.conf
     fi
   elif [[ ${option} == "WATCHDOG_NOTIFY_BAN" ]]; then
     if ! grep -q ${option} mailcow.conf; then


### PR DESCRIPTION
This PR adds a new option `WATCHDOG_NOTIFY_WEBHOOK_AUTH_HEADER` to send an header for authorization when calling watchdog webhook.
This is useful as some webhooks don't accept Basic Authentication that can be put in the URL. I didn't force the header's name as some applications requires fancy header names as `X-API-KEY` for instance. Can be used too to "hide" Basic Authentication in the headers.
I have tested it with a custom image in our production environment and it's working fine.