### PR TITLE
Fix blocking last logins fetching

### DIFF
--- a/data/web/inc/header.inc.php
+++ b/data/web/inc/header.inc.php
@@ -49,7 +49,6 @@ $globalVariables = [
   'app_links' => customize('get', 'app_links'),
   'is_root_uri' => (parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) == '/'),
   'uri' => $_SERVER['REQUEST_URI'],
-  'last_login' => last_login('get', $_SESSION['mailcow_cc_username'], 7, 0)['ui']['time']
 ];
 
 foreach ($globalVariables as $globalVariableName => $globalVariableValue) {

--- a/data/web/js/site/user.js
+++ b/data/web/js/site/user.js
@@ -676,5 +676,5 @@ jQuery(function($){
   onVisible("[id^=wl_policy_mailbox_table]", () => draw_wl_policy_mailbox_table());
   onVisible("[id^=sync_job_table]", () => draw_sync_job_table());
   onVisible("[id^=app_passwd_table]", () => draw_app_passwd_table());
-  last_logins('get');
+  onVisible("[id^=recent-logins]", () => last_logins('get'));
 });

--- a/data/web/templates/base.twig
+++ b/data/web/templates/base.twig
@@ -146,7 +146,6 @@
   var lang_fido2 = {{ lang_fido2|raw }};
   var docker_timeout = {{ docker_timeout|raw }} * 1000;
   var mailcow_cc_role = '{{ mailcow_cc_role }}';
-  var last_login = '{{ last_login }}';
   var mailcow_info = {
     version_tag: '{{ mailcow_info.version_tag }}',
     last_version_tag: '{{ mailcow_info.last_version_tag }}',

--- a/data/web/templates/user/tab-user-auth.twig
+++ b/data/web/templates/user/tab-user-auth.twig
@@ -155,7 +155,7 @@
               <li class="login-history" data-days="31"><a class="dropdown-item" href="#">1 {{ lang.user.month }}</a></li>
             </ul>
           </div>
-          <div class="last-login mt-4"></div>
+          <div class="last-login mt-4" id="recent-logins"></div>
           <span class="clear-last-logins mt-2">
             {{ lang.user.clear_recent_successful_connections }}
           </span>


### PR DESCRIPTION
(Probably)Fixes https://github.com/mailcow/mailcow-dockerized/issues/5645

The problem was that fetching the last logins source IP's country of origin can sometime take a LONG time (up to a few minutes depending on the speed of the requests to `dfdata.bella.network`).

When the country <-> IP relationship isn't cached, this can cause the /user page to take from a few seconds to a few minutes to load for users with a long connection history.

This was caused by a variable declared in `headers.inc.php` that was never used.
Removing this variable solves the issue with loading the `/user` page but when changing tab the user would still be confronted by a long loading time since the background request to `api/v1/get/last-login` would block the loading of other pages.

The second fix is to only load the last logins when the recent logins menu is loaded.

Not sure if this is the issue the original author had, but this fixes the issue discussed on https://github.com/mailcow/mailcow-dockerized/issues/5645  on the last few days

Known issue: When `IP_SHORTCOUNTRY` is not cached, opening the `/user` page, sliding down until the recent logins section is visible, and then opening another tab needing to make an API request will confront the user with a longer than usual waiting time since the request made by the second tab will be blocked by the request to `api/v1/get/last-login`
