### PR TITLE
Feature: Catch-All on user level

### DIFF
--- a/data/Dockerfiles/postfix/postfix.sh
+++ b/data/Dockerfiles/postfix/postfix.sh
@@ -244,7 +244,12 @@ password = ${DBPASS}
 hosts = unix:/var/run/mysqld/mysqld.sock
 dbname = ${DBNAME}
 query = SELECT goto FROM alias
-  WHERE address='%s'
+  WHERE
+    (
+      address = SUBSTR( '%s', INSTR('%s', ".") )
+      OR
+      address = '%s'
+    )
     AND (active='1' OR active='2');
 EOF
 

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -821,7 +821,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               );
               continue;
             }
-            if ((!filter_var($address, FILTER_VALIDATE_EMAIL) === true) && !empty($local_part)) {
+            if ((!filter_var(ltrim($address, '.'), FILTER_VALIDATE_EMAIL) === true) && !empty($local_part)) {
               $_SESSION['return'][] = array(
                 'type' => 'danger',
                 'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
@@ -839,7 +839,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             }
             $stmt = $pdo->prepare("INSERT INTO `alias` (`address`, `public_comment`, `private_comment`, `goto`, `domain`, `sogo_visible`, `active`)
               VALUES (:address, :public_comment, :private_comment, :goto, :domain, :sogo_visible, :active)");
-            if (!filter_var($address, FILTER_VALIDATE_EMAIL) === true) {
+            if (!filter_var(ltrim($address, '.'), FILTER_VALIDATE_EMAIL) === true) {
               $stmt->execute(array(
                 ':address' => '@'.$domain,
                 ':public_comment' => $public_comment,
@@ -2398,7 +2398,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                 );
                 continue;
               }
-              if ((!filter_var($address, FILTER_VALIDATE_EMAIL) === true) && !empty($local_part)) {
+              if ((!filter_var(ltrim($address, '.'), FILTER_VALIDATE_EMAIL) === true) && !empty($local_part)) {
                 $_SESSION['return'][] = array(
                   'type' => 'danger',
                   'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),

--- a/data/web/lang/lang.de-de.json
+++ b/data/web/lang/lang.de-de.json
@@ -37,7 +37,7 @@
         "add_domain_only": "Nur Domain hinzufügen",
         "add_domain_restart": "Domain hinzufügen und SOGo neustarten",
         "alias_address": "Alias-Adresse(n)",
-        "alias_address_info": "<small>Vollständige E-Mail-Adresse(n) eintragen oder @example.com, um alle Nachrichten einer Domain weiterzuleiten. Getrennt durch Komma. <b>Nur eigene Domains</b>.</small>",
+        "alias_address_info": "<small>Vollständige E-Mail-Adresse(n) eintragen oder @example.com, um alle Nachrichten einer Domain weiterzuleiten. Getrennt durch Komma. Wenn die E-Mail-Adresse mit einem Punkt startet (z.B. <i>.user@example.org</i>), werden alle E-Mails an <i>*.user@example.org</i> weitergeleitet. <b>Nur eigene Domains</b>.</small>",
         "alias_domain": "Alias-Domain",
         "alias_domain_info": "<small>Nur gültige Domains. Getrennt durch Komma.</small>",
         "app_name": "App-Name",

--- a/data/web/lang/lang.en-gb.json
+++ b/data/web/lang/lang.en-gb.json
@@ -37,7 +37,7 @@
         "add_domain_only": "Add domain only",
         "add_domain_restart": "Add domain and restart SOGo",
         "alias_address": "Alias address/es",
-        "alias_address_info": "<small>Full email address/es or @example.com, to catch all messages for a domain (comma-separated). <b>mailcow domains only</b>.</small>",
+        "alias_address_info": "<small>Full email address/es or @example.com, to catch all messages for a domain (comma-separated). If the e-mail address starts with a dot (e.g. <i>.user@example.org</i>), all e-mails are forwarded to <i>*.user@example.org</i>. <b>mailcow domains only</b>.</small>",
         "alias_domain": "Alias domain",
         "alias_domain_info": "<small>Valid domain names only (comma-separated).</small>",
         "app_name": "App name",


### PR DESCRIPTION
Use Catch All with wildcard within the local part of the e-mail address.
With this pull request you can add an user-level catch-all.

E.g.: When you add the alias `.user@example.org` all emails to `*.user@example.org` will be forwared to the goto-address.

See https://github.com/mailcow/mailcow-dockerized/issues/2077