### PR TITLE
Allow hard-coding IPV4 and IPV6 rather than it being detected

### DIFF
--- a/data/Dockerfiles/acme/acme.sh
+++ b/data/Dockerfiles/acme/acme.sh
@@ -220,14 +220,12 @@ while true; do
   if [ -z "${IPV4}" ]; then
     IPV4=$(get_ipv4)
   else
-    IPV4=${IPV4}
     log_f "Using pre-defined IPV4 address: ${IPV4}"
   fi
 
   if [ -z "${IPV6}" ]; then
     IPV6=$(get_ipv6)
   else
-    IPV6=${IPV6}
     log_f "Using pre-defined IPV6 address: ${IPV6}"
   fi
 

--- a/data/Dockerfiles/acme/acme.sh
+++ b/data/Dockerfiles/acme/acme.sh
@@ -216,8 +216,15 @@ while true; do
   if [[ ${SKIP_IP_CHECK} != "y" ]]; then
   # Start IP detection
   log_f "Detecting IP addresses..."
-  IPV4=$(get_ipv4)
-  IPV6=$(get_ipv6)
+
+  if [ -z "${IPV4}" ]; then
+    IPV4=$(get_ipv4)
+  fi
+
+  if [ -z "${IPV6}" ]; then
+    IPV6=$(get_ipv6)
+  fi
+
   log_f "OK: ${IPV4}, ${IPV6:-"0000:0000:0000:0000:0000:0000:0000:0000"}"
   fi
 

--- a/data/Dockerfiles/acme/acme.sh
+++ b/data/Dockerfiles/acme/acme.sh
@@ -219,10 +219,16 @@ while true; do
 
   if [ -z "${IPV4}" ]; then
     IPV4=$(get_ipv4)
+  else
+    IPV4=${IPV4}
+    log_f "Using pre-defined IPV4 address: ${IPV4}"
   fi
 
   if [ -z "${IPV6}" ]; then
     IPV6=$(get_ipv6)
+  else
+    IPV6=${IPV6}
+    log_f "Using pre-defined IPV6 address: ${IPV6}"
   fi
 
   log_f "OK: ${IPV4}, ${IPV6:-"0000:0000:0000:0000:0000:0000:0000:0000"}"


### PR DESCRIPTION
This allows hardcoding `IPV4` and `IPV6` rather than being automatically detected when renewing SSL certificates.

This is handy in scenarios where outbound traffic comes from a different IP than what would normally be expected.