### PR TITLE
refactor: remove 'version' from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
 
     unbound-mailcow:


### PR DESCRIPTION
Remove 'version' from docker-compose.yml since it is obsolete. also when trying to run the compose file, the following warning will appear:

```sh
WARN[0000] /opt/mailcow-dockerized/docker-compose.yml: `version` is obsolete 
```