### PR TITLE
SORBS was decommissioned on June 5, 2024 - remove it from RBLs in use by Mailcow

### DIFF
--- a/data/Dockerfiles/postfix/postfix.sh
+++ b/data/Dockerfiles/postfix/postfix.sh
@@ -415,12 +415,6 @@ postscreen_dnsbl_sites = wl.mailspike.net=127.0.0.[18;19;20]*-2
   b.barracudacentral.org=127.0.0.2*7
   bl.mailspike.net=127.0.0.2*5
   bl.mailspike.net=127.0.0.[10;11;12]*4
-  dnsbl.sorbs.net=127.0.0.10*8
-  dnsbl.sorbs.net=127.0.0.5*6
-  dnsbl.sorbs.net=127.0.0.7*3
-  dnsbl.sorbs.net=127.0.0.8*2
-  dnsbl.sorbs.net=127.0.0.6*2
-  dnsbl.sorbs.net=127.0.0.9*2
 EOF
 fi
 DNSBL_CONFIG=$(grep -v '^#' /opt/postfix/conf/dns_blocklists.cf | grep '\S')

--- a/data/conf/rspamd/local.d/rbl.conf
+++ b/data/conf/rspamd/local.d/rbl.conf
@@ -1,20 +1,4 @@
 rbls {
-  sorbs { 
-    symbol = "RBL_SORBS"; 
-    rbl = "dnsbl.sorbs.net";  
-    returncodes { 
-      # http:// www.sorbs.net/general/using.shtml 
-      RBL_SORBS_HTTP = "127.0.0.2"; 
-      RBL_SORBS_SOCKS = "127.0.0.3";  
-      RBL_SORBS_MISC = "127.0.0.4"; 
-      RBL_SORBS_SMTP = "127.0.0.5"; 
-      RBL_SORBS_RECENT = "127.0.0.6"; 
-      RBL_SORBS_WEB = "127.0.0.7";  
-      RBL_SORBS_DUL = "127.0.0.10"; 
-      RBL_SORBS_BLOCK = "127.0.0.8";  
-      RBL_SORBS_ZOMBIE = "127.0.0.9"; 
-    } 
-  }
   interserver_ip {
     symbol = "RBL_INTERSERVER_IP";
     rbl = "rbl.interserver.net";

--- a/data/conf/rspamd/local.d/rbl_group.conf
+++ b/data/conf/rspamd/local.d/rbl_group.conf
@@ -5,46 +5,6 @@ symbols = {
   "RBL_UCEPROTECT_LEVEL2" {
     score = 1.5;
   }
-  "RBL_SORBS" { 
-    score = 0.0;  
-    description = "Unrecognised result from SORBS RBL"; 
-  } 
-  "RBL_SORBS_HTTP" {  
-    score = 2.5;  
-    description = "List of Open HTTP Proxy Servers."; 
-  } 
-  "RBL_SORBS_SOCKS" { 
-    score = 2.5;  
-    description = "List of Open SOCKS Proxy Servers.";  
-  } 
-  "RBL_SORBS_MISC" {  
-    score = 1.0;  
-    description = "List of open Proxy Servers not listed in the SOCKS or HTTP lists.";  
-  } 
-  "RBL_SORBS_SMTP" {  
-    score = 4.0;  
-    description = "List of Open SMTP relay servers."; 
-  } 
-  "RBL_SORBS_RECENT" {  
-    score = 2.0;  
-    description = "List of hosts that have been noted as sending spam/UCE/UBE to the admins of SORBS within the last 28 days (includes new.spam.dnsbl.sorbs.net)."; 
-  } 
-  "RBL_SORBS_WEB" { 
-    score = 2.0;  
-    description = "List of web (WWW) servers which have spammer abusable vulnerabilities (e.g. FormMail scripts)";  
-  } 
-  "RBL_SORBS_DUL" { 
-    score = 2.0;  
-    description = "Dynamic IP Address ranges (NOT a Dial Up list!)";  
-  } 
-  "RBL_SORBS_BLOCK" { 
-    score = 0.5;  
-    description = "List of hosts demanding that they never be tested by SORBS.";  
-  } 
-  "RBL_SORBS_ZOMBIE" {  
-    score = 2.0;  
-    description = "List of networks hijacked from their original owners, some of which have already used for spamming.";  
-  }
   "RECEIVED_SPAMHAUS_XBL" {
     weight = 0.0;
     description = "Received address is listed in ZEN XBL";


### PR DESCRIPTION
Spam and Open Relay Blocking System (SORBS) was decommissioned on June 5, 2024 - remove it from RBLs in use by Mailcow:

* http://www.sorbs.net/sitedown.shtml
* https://www.theregister.com/2024/06/07/sorbs_closed/