### PR TITLE
docker-compose: drop version declaration

### DIFF
--- a/helper-scripts/docker-compose.override.yml.d/BUILD_FLAGS/docker-compose.override.yml
+++ b/helper-scripts/docker-compose.override.yml.d/BUILD_FLAGS/docker-compose.override.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   unbound-mailcow:
     build: ./data/Dockerfiles/unbound

--- a/helper-scripts/docker-compose.override.yml.d/EXTERNAL_DNS/docker-compose.override.yml
+++ b/helper-scripts/docker-compose.override.yml.d/EXTERNAL_DNS/docker-compose.override.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
 
     clamd-mailcow:

--- a/helper-scripts/docker-compose.override.yml.d/EXTERNAL_MYSQL_SOCKET/docker-compose.override.yml
+++ b/helper-scripts/docker-compose.override.yml.d/EXTERNAL_MYSQL_SOCKET/docker-compose.override.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
 
     php-fpm-mailcow:

--- a/helper-scripts/docker-compose.override.yml.d/HAPROXY/docker-compose.override.yml
+++ b/helper-scripts/docker-compose.override.yml.d/HAPROXY/docker-compose.override.yml
@@ -2,7 +2,6 @@
 ## Set haproxy_trusted_networks in Dovecots extra.conf!
 ##
 
-version: '2.1'
 services:
 
     dovecot-mailcow:


### PR DESCRIPTION
Version is informative, not required. Newer versions of compose issue warnings if it's declared. 

Ref https://github.com/docker/compose/issues/11628