### PR TITLE
Do not add MAILCOW_WHITE on failed DMARC

### DIFF
--- a/data/conf/rspamd/local.d/composites.conf
+++ b/data/conf/rspamd/local.d/composites.conf
@@ -21,6 +21,10 @@ FREEMAIL_TO_UNDISC_RCPT {
 SOGO_CONTACT_EXCLUDE {
   expression = "(-WHITELISTED_FWD_HOST | -g+:policies) & ^SOGO_CONTACT & !DMARC_POLICY_ALLOW";
 }
+# Remove MAILCOW_WHITE symbol for senders with broken policy recieved not from fwd hosts
+MAILCOW_WHITE_EXCLUDE {
+  expression = "^MAILCOW_WHITE & (-DMARC_POLICY_REJECT | -DMARC_POLICY_QUARANTINE | -R_SPF_PERMFAIL) & !WHITELISTED_FWD_HOST";
+}
 # Spoofed header from and broken policy (excluding sieve host, rspamd host, whitelisted senders, authenticated senders and forward hosts)
 SPOOFED_UNAUTH {
   expression = "!MAILCOW_AUTH & !MAILCOW_WHITE & !RSPAMD_HOST & !SIEVE_HOST & MAILCOW_DOMAIN_HEADER_FROM & !WHITELISTED_FWD_HOST & -g+:policies";


### PR DESCRIPTION
We should not allow spoofing for whitelisted domains, especially when whitelists are controlled by user who usually not deep in emails authorizations mechanisms.