### PR TITLE
Greek names of dovecot folders

### DIFF
--- a/data/conf/dovecot/dovecot.folders.conf
+++ b/data/conf/dovecot/dovecot.folders.conf
@@ -289,5 +289,20 @@ namespace inbox {
   mailbox "Kladde" {
     special_use = \Drafts
   }
+  mailbox "Πρόχειρα" {
+    special_use = \Drafts
+  }
+  mailbox "Απεσταλμένα" {
+    special_use = \Sent
+  }
+  mailbox "Κάδος απορριμάτων" {
+    special_use = \Trash
+  }
+  mailbox "Ανεπιθύμητα" {
+    special_use = \Junk
+  }
+  mailbox "Αρχειοθετημένα" {
+    special_use = \Archive
+  }
   prefix =
 }


### PR DESCRIPTION
Names taken from MSO 2016.

It should help keeping folders in sync for Greek users migrating to mailcow or changing from POP3 to IMAP.