### PR TITLE
dovecot: fix precompiling of sieve scripts

### DIFF
--- a/data/Dockerfiles/dovecot/docker-entrypoint.sh
+++ b/data/Dockerfiles/dovecot/docker-entrypoint.sh
@@ -407,14 +407,6 @@ sievec /var/vmail/sieve/global_sieve_after.sieve
 sievec /usr/lib/dovecot/sieve/report-spam.sieve
 sievec /usr/lib/dovecot/sieve/report-ham.sieve
 
-for file in /var/vmail/*/*/sieve/*.sieve ; do
-  if [[ "$file" == "/var/vmail/*/*/sieve/*.sieve" ]]; then
-    continue
-  fi
-  sievec "$file" "$(dirname "$file")/../.dovecot.svbin"
-  chown vmail:vmail "$(dirname "$file")/../.dovecot.svbin"
-done
-
 # Fix permissions
 chown root:root /etc/dovecot/sql/*.conf
 chown root:dovecot /etc/dovecot/sql/dovecot-dict-sql-sieve* /etc/dovecot/sql/dovecot-dict-sql-quota* /etc/dovecot/lua/passwd-verify.lua

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,7 +221,7 @@ services:
             - sogo
 
     dovecot-mailcow:
-      image: mailcow/dovecot:1.30
+      image: mailcow/dovecot:2.0
       depends_on:
         - mysql-mailcow
         - netfilter-mailcow


### PR DESCRIPTION
This PR includes a change on how dovecot handles the sieve scripts. In 2022 the removed lines had been added to fix the sieve compiler in some rare cases used in replication mode.. however this "fix" broke more than it used.. and after some debugging analysis (sorry took longer than it should) we decided on removing this.


Fixes https://github.com/mailcow/mailcow-dockerized/issues/4770
