### PR TITLE
Bug Fix: Check `mailcow.conf` exists before work with it

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -404,12 +404,13 @@ while (($#)); do
   shift
 done
 
+[[ ! -f mailcow.conf ]] && { echo "mailcow.conf is missing! Is mailcow installed?"; exit 1;}
+
 chmod 600 mailcow.conf
 source mailcow.conf
 
 detect_docker_compose_command
 
-[[ ! -f mailcow.conf ]] && { echo "mailcow.conf is missing! Is mailcow installed?"; exit 1;}
 DOTS=${MAILCOW_HOSTNAME//[^.]};
 if [ ${#DOTS} -lt 1 ]; then
   echo -e "\e[31mMAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) is not a FQDN!\e[0m"

--- a/update.sh
+++ b/update.sh
@@ -404,7 +404,7 @@ while (($#)); do
   shift
 done
 
-[[ ! -f mailcow.conf ]] && { echo "mailcow.conf is missing! Is mailcow installed?"; exit 1;}
+[[ ! -f mailcow.conf ]] && { echo -e "\e[31mmailcow.conf is missing! Is mailcow installed?\e[0m"; exit 1;}
 
 chmod 600 mailcow.conf
 source mailcow.conf


### PR DESCRIPTION
## Modified Files

- `update.sh` script

## Description

In `update.sh` file, there's this part:

```bash
chmod 600 mailcow.conf
source mailcow.conf

detect_docker_compose_command

[[ ! -f mailcow.conf ]] && { echo "mailcow.conf is missing! Is mailcow installed?"; exit 1;}
```

Which as it looks, first chmod, then source the `mailcow.conf`, and then it checks if `mailcow.conf` exists or not.

The modified version is:

```bash
[[ ! -f mailcow.conf ]] && { echo "mailcow.conf is missing! Is mailcow installed?"; exit 1;}

chmod 600 mailcow.conf
source mailcow.conf

detect_docker_compose_command
```

## Test

- I have tested it manually