### PR TITLE
Fix typo in `update.sh`: word Proceeding

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -817,7 +817,7 @@ if ! [ $NEW_BRANCH ]; then
     echo -e "\e[33mTo change that run the update.sh Script one time with the --stable parameter to switch to stable builds.\e[0m"
 
   else
-    echo -e "\e[33mYou are receiving updates from a unsupported branch.\e[0m"
+    echo -e "\e[33mYou are receiving updates from an unsupported branch.\e[0m"
     sleep 1
     echo -e "\e[33mThe mailcow stack might still work but it is recommended to switch to the master branch (stable builds).\e[0m"
     echo -e "\e[33mTo change that run the update.sh Script one time with the --stable parameter to switch to stable builds.\e[0m"

--- a/update.sh
+++ b/update.sh
@@ -828,14 +828,14 @@ elif [ $FORCE ]; then
   echo -e "\e[31mPlease rerun the update.sh Script without the --force/-f parameter.\e[0m"
   sleep 1
 elif [ $NEW_BRANCH == "master" ] && [ $CURRENT_BRANCH != "master" ]; then
-  echo -e "\e[33mYou are about to switch your mailcow Updates to the stable (master) branch.\e[0m"
+  echo -e "\e[33mYou are about to switch your mailcow updates to the stable (master) branch.\e[0m"
   sleep 1
-  echo -e "\e[33mBefore you do: Please take a backup of all components to ensure that no Data is lost...\e[0m"
+  echo -e "\e[33mBefore you do: Please take a backup of all components to ensure that no data is lost...\e[0m"
   sleep 1
-  echo -e "\e[31mWARNING: Please see on GitHub or ask in the communitys if a switch to master is stable or not.
-  In some rear cases a Update back to master can destroy your mailcow configuration in case of Database Upgrades etc.
-  Normally a upgrade back to master should be safe during each full release. 
-  Check GitHub for Database Changes and Update only if there similar to the full release!\e[0m"
+  echo -e "\e[31mWARNING: Please see on GitHub or ask in the community if a switch to master is stable or not.
+  In some rear cases an update back to master can destroy your mailcow configuration such as database upgrade, etc.
+  Normally an upgrade back to master should be safe during each full release.
+  Check GitHub for Database changes and update only if there similar to the full release!\e[0m"
   read -r -p "Are you sure you that want to continue upgrading to the stable (master) branch? [y/N] " response
   if [[ ! "${response}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
     echo "OK. If you prepared yourself for that please run the update.sh Script with the --stable parameter again to trigger this process here."

--- a/update.sh
+++ b/update.sh
@@ -434,7 +434,7 @@ elif [ ${#DOTS} -eq 1 ]; then
   echo "Find more information about why this message exists here: https://github.com/mailcow/mailcow-dockerized/issues/1572"
   read -r -p "Do you want to proceed anyway? [y/N] " response
   if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
-    echo "OK. Procceding."
+    echo "OK. Proceeding."
   else
     echo "OK. Exiting."
     exit 1

--- a/update.sh
+++ b/update.sh
@@ -982,7 +982,7 @@ if [ ! $DEV ]; then
     echo -e "\e[31m\nOh no, what happened?\n=> You most likely added files to your local mailcow instance that were now added to the official mailcow repository. Please move them to another location before updating mailcow.\e[0m"
     exit 1
   elif [[ ${MERGE_RETURN} == 1 ]]; then
-    echo -e "\e[93mPotenial conflict, trying to fix...\e[0m"
+    echo -e "\e[93mPotential conflict, trying to fix...\e[0m"
     git status --porcelain | grep -E "UD|DU" | awk '{print $2}' | xargs rm -v
     git add -A
     git commit -m "After update on ${DATE}" > /dev/null


### PR DESCRIPTION
## Modified Files

- update.sh

## Description

```bash
...
elif [ ${#DOTS} -eq 1 ]; then
  echo -e "\e[33mMAILCOW_HOSTNAME (${MAILCOW_HOSTNAME}) does not contain a Subdomain. This is not fully tested and may cause issues.\e[0m"
  echo "Find more information about why this message exists here: https://github.com/mailcow/mailcow-dockerized/issues/1572"
  read -r -p "Do you want to proceed anyway? [y/N] " response
  if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
    echo "OK. Procceding."   # <--------- Here's typo, right word is: Proceeding
  else
    echo "OK. Exiting."
    exit 1
  fi
fi
...
```

## Update

I'll push all typos in `update.sh` script to this pr, therefore it's not about word `proceeding`.