### PR TITLE
Fix `LABEL` in Dockerfile, should be key=value

### DIFF
--- a/data/Dockerfiles/acme/Dockerfile
+++ b/data/Dockerfiles/acme/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.20
 
-LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
+LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 
 
 RUN apk upgrade --no-cache \

--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.20
 
-LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
+LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 
 RUN apk upgrade --no-cache \
   && apk add --update --no-cache \

--- a/data/Dockerfiles/dockerapi/Dockerfile
+++ b/data/Dockerfiles/dockerapi/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.20
 
-LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
+LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG PIP_BREAK_SYSTEM_PACKAGES=1
 WORKDIR /app

--- a/data/Dockerfiles/dovecot/Dockerfile
+++ b/data/Dockerfiles/dovecot/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.20
-LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
+
+LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 
 # renovate: datasource=github-releases depName=tianon/gosu versioning=semver-coerced extractVersion=^(?<version>.*)$
 ARG GOSU_VERSION=1.16

--- a/data/Dockerfiles/netfilter/Dockerfile
+++ b/data/Dockerfiles/netfilter/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.20
-LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
+
+LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 
 WORKDIR /app
 

--- a/data/Dockerfiles/olefy/Dockerfile
+++ b/data/Dockerfiles/olefy/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.20
-LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
+
+LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG PIP_BREAK_SYSTEM_PACKAGES=1
 WORKDIR /app

--- a/data/Dockerfiles/phpfpm/Dockerfile
+++ b/data/Dockerfiles/phpfpm/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:8.2-fpm-alpine3.18
-LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
+
+LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 
 # renovate: datasource=github-tags depName=krakjoe/apcu versioning=semver-coerced extractVersion=^v(?<version>.*)$
 ARG APCU_PECL_VERSION=5.1.23

--- a/data/Dockerfiles/postfix/Dockerfile
+++ b/data/Dockerfiles/postfix/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian:bookworm-slim
-LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
+
+LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL C

--- a/data/Dockerfiles/rspamd/Dockerfile
+++ b/data/Dockerfiles/rspamd/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian:bullseye-slim
-LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
+
+LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG RSPAMD_VER=rspamd_3.7.5-2~8c86c1676   

--- a/data/Dockerfiles/sogo/Dockerfile
+++ b/data/Dockerfiles/sogo/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian:bullseye-slim
-LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
+
+LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG DEBIAN_VERSION=bullseye

--- a/data/Dockerfiles/unbound/Dockerfile
+++ b/data/Dockerfiles/unbound/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.20
 
-LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
+LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 
 RUN apk add --update --no-cache \
 	curl \

--- a/data/Dockerfiles/watchdog/Dockerfile
+++ b/data/Dockerfiles/watchdog/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.20
-LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
+
+LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 
 # Installation
 RUN apk add --update \


### PR DESCRIPTION
## Modified Files

- data/Dockerfiles/acme/Dockerfile
- data/Dockerfiles/backup/Dockerfile
- data/Dockerfiles/clamd/Dockerfile
- data/Dockerfiles/dockerapi/Dockerfile
- data/Dockerfiles/dovecot/Dockerfile
- data/Dockerfiles/netfilter/Dockerfile
- data/Dockerfiles/olefy/Dockerfile
- data/Dockerfiles/phpfpm/Dockerfile
- data/Dockerfiles/postfix/Dockerfile
- data/Dockerfiles/rspamd/Dockerfile
- data/Dockerfiles/sogo/Dockerfile
- data/Dockerfiles/solr/Dockerfile
- data/Dockerfiles/unbound/Dockerfile
- data/Dockerfiles/watchdog/Dockerfile

## Description

Referring to the [`Official Docker Docs`](https://docs.docker.com/reference/dockerfile/#label), clearly said the format of LABEL is 

```bash
LABEL <key>=<value> <key>=<value> <key>=<value> ...
```

But the mentioned files are written as follows:
```bash
LABEL <value>
``` 

Also in the resource of Docker Docs, there it said:

> The LABEL instruction adds metadata to an image. A LABEL is a `key-value pair`