### PR TITLE
Refactor: `update.sh` script with `--help` should exit with status code 0

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -409,7 +409,7 @@ while (($#)); do
   -f|--force           -   Force update, do not ask questions
   -d|--dev             -   Enables Developer Mode (No Checkout of update.sh for tests)
 '
-    exit 1
+    exit 0
   esac
   shift
 done


### PR DESCRIPTION
## Modified Files

- update.sh

## Description

Here's the code snippet, as you see after prints the help message then it should return 0 since everything is OK, but instead it returns non-zero code.

```bash
...
    --help|-h)
    echo './update.sh [-c|--check, --ours, --gc, --nightly, --prefetch, --skip-start, --skip-ping-check, --stable, -f|--force, -d|--dev, -h|--help]

  -c|--check           -   Check for updates and exit (exit codes => 0: update available, 3: no updates)
  --ours               -   Use merge strategy option "ours" to solve conflicts in favor of non-mailcow code (local changes over remote changes), not recommended!
  --gc                 -   Run garbage collector to delete old image tags
  --nightly            -   Switch your mailcow updates to the unstable (nightly) branch. FOR TESTING PURPOSES ONLY!!!!
  --prefetch           -   Only prefetch new images and exit (useful to prepare updates)
  --skip-start         -   Do not start mailcow after update
  --skip-ping-check    -   Skip ICMP Check to public DNS resolvers (Use it only if you´ve blocked any ICMP Connections to your mailcow machine)
  --stable             -   Switch your mailcow updates to the stable (master) branch. Default unless you changed it with --nightly.
  -f|--force           -   Force update, do not ask questions
  -d|--dev             -   Enables Developer Mode (No Checkout of update.sh for tests)
'
    exit 1 # <-------- Here it exists with non-zero code
  esac
  shift
done
```