### PR TITLE
sogo: update to 5.11.0 + Rebase on Bookworm

### DIFF
--- a/data/Dockerfiles/sogo/Dockerfile
+++ b/data/Dockerfiles/sogo/Dockerfile
@@ -1,13 +1,13 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
-LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
+LABEL maintainer="The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG DEBIAN_VERSION=bullseye
+ARG DEBIAN_VERSION=bookworm
 ARG SOGO_DEBIAN_REPOSITORY=http://www.axis.cz/linux/debian
 # renovate: datasource=github-releases depName=tianon/gosu versioning=semver-coerced extractVersion=^(?<version>.*)$
 ARG GOSU_VERSION=1.17
-ENV LC_ALL C
+ENV LC_ALL=C
 
 # Prerequisites
 RUN echo "Building from repository $SOGO_DEBIAN_REPOSITORY" \

--- a/data/Dockerfiles/sogo/syslog-ng-redis_slave.conf
+++ b/data/Dockerfiles/sogo/syslog-ng-redis_slave.conf
@@ -1,4 +1,4 @@
-@version: 3.28
+@version: 3.38
 @include "scl.conf"
 options {
   chain_hostnames(off);

--- a/data/Dockerfiles/sogo/syslog-ng.conf
+++ b/data/Dockerfiles/sogo/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.28
+@version: 3.38
 @include "scl.conf"
 options {
   chain_hostnames(off);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,7 +176,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: mailcow/sogo:1.123
+      image: mailcow/sogo:1.124
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}


### PR DESCRIPTION
This PR upgrades sogo to 5.11.0 and upgrades the base os to bookworm.

Thanks again to Slávek B. for maintaining the SOGo repo we build from ❤️ 

See the Release notes here: https://github.com/Alinto/sogo/releases/tag/SOGo-5.11.0