### PR TITLE
.github: Add pull_request_template.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->
+
+## Contribution Guidelines
+
+* [ ] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them
+
+<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->
+
+## What does this PR include?
+
+### Short Description
+
+<!-- Please write a short description, what your PR does here. -->
+
+###  Affected Containers
+
+<!-- Please list all affected Docker containers here, which you commited changes to -->
+
+<!--
+
+Please list them like this:
+
+- container1
+- container2
+- container3
+etc.
+
+-->
+
+## Did you run tests?
+
+### What did you tested?
+
+<!-- Please write shortly, what you've tested (which components etc.). -->
+
+### What were the final results? (Awaited, got)
+
+<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->


### PR DESCRIPTION
This PR adds a PR template to the mailcow Repo, which has to be followed beginning with the 2024-08 update (once this template is in master)