### PR TITLE
Update mime_types.conf configuration

### DIFF
--- a/data/conf/rspamd/local.d/mime_types.conf
+++ b/data/conf/rspamd/local.d/mime_types.conf
@@ -1,27 +1,45 @@
+###############################################################################
+# This list is added/merged with defined defaults in LUA module:
+# https://github.com/rspamd/rspamd/blob/master/src/plugins/lua/mime_types.lua
+###############################################################################
+
 # Extensions that are treated as 'bad'
 # Number is score multiply factor
 bad_extensions = {
-  scr = 20,
-  lnk = 20,
-  exe = 20,
-  msi = 1,
-  msp = 1,
-  msu = 1,
-  jar = 2,
-  com = 20,
-  bat = 4,
-  cmd = 4,
-  ps1 = 4,
-  ace = 4,
-  arj = 4,
+  apk = 4,
+  appx = 4,
+  appxbundle = 4,
+  bat = 8,
   cab = 20,
+  cmd = 8,
+  com = 20,
+  diagcfg = 4,
+  diagpack = 4,
+  dmg = 8,
+  ex = 20,
+  ex_ = 20,
+  exe = 20,
+  img = 4,
+  jar = 8,
+  jnlp = 8,
+  js = 8,
+  jse = 8,
+  lnk = 20,
+  mjs = 8,
+  msi = 4,
+  msix = 4,
+  msixbundle = 4,
+  ps1 = 8,
+  scr = 20,
+  sct = 20,
+  vb = 20,
+  vbe = 20,
   vbs = 20,
-  hta = 4,
-  shs = 4,
-  wsc = 4,
-  wsf = 4,
-  iso = 8,
-  img = 8
+  vhd = 4,
+  py = 4,
+  reg = 8,
+  scf = 8,
+  vhdx = 4,
 };
 
 # Extensions that are particularly penalized for archives
@@ -30,18 +48,14 @@ bad_archive_extensions = {
   docx = 0.5,
   xlsx = 0.5,
   pdf = 1.0,
-  jar = 3,
-  js = 0.5,
-  vbs = 20,
-  exe = 20
+  jar = 12,
+  jnlp = 12,
+  bat = 12,
+  cmd = 12,
 };
 
 # Used to detect another archive in archive
 archive_extensions = {
-  zip = 1,
-  arj = 1,
-  rar = 1,
-  ace = 1,
-  7z = 1,
-  cab = 1
+  tar = 1,
+  ['tar.gz'] = 1,
 };


### PR DESCRIPTION
## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

In the last months and years, the default `mime_types.conf` of rspamd has changed and it might be also useful to make some adjustments to the weight of certain file extensions.

This PR is removing all file extensions from `mime_types.conf` which are already in rspamd's default configuration at [rspamd/src/plugins/lua/mime_types.lua](https://github.com/rspamd/rspamd/blob/master/src/plugins/lua/mime_types.lua). If file extension is not present or has a different score compared to rspamd default, it is still in the list.

There are also a few major differences to certain file extensions, which might be useful to discuss and carefully adjust. For example, `.exe` files are rated very 'badly' due to high chance of being malicious, so are other extensions like `bat`, `cmd`, etc.

Current suggestion:
```lua
# Extensions that are treated as 'bad'
# Number is score multiply factor
bad_extensions = {
  apk = 4,
  appx = 4,
  appxbundle = 4,
  bat = 8,
  cab = 20,
  cmd = 8,
  com = 20,
  diagcfg = 4,
  diagpack = 4,
  dmg = 8,
  ex = 20,
  ex_ = 20,
  exe = 20,
  img = 4,
  jar = 8,
  jnlp = 8,
  js = 8,
  jse = 8,
  lnk = 20,
  mjs = 8,
  msi = 4,
  msix = 4,
  msixbundle = 4,
  ps1 = 8,
  scr = 20,
  sct = 20,
  vb = 20,
  vbe = 20,
  vbs = 20,
  vhd = 4,
  py = 4,
  reg = 8,
  scf = 8,
  vhdx = 4,
};

# Extensions that are particularly penalized for archives
bad_archive_extensions = {
  pptx = 0.5,
  docx = 0.5,
  xlsx = 0.5,
  pdf = 1.0,
  jar = 12,
  jnlp = 12,
  bat = 12,
  cmd = 12,
};

# Used to detect another archive in archive
archive_extensions = {
  tar = 1,
  ['tar.gz'] = 1,
};
```

**As a important reminder**: For all remaining and additional file extensions and score weights, please check above default rspamd configuration!

This is meant as a sort-of open discussion on the weighting, I find a good way to achieve weighting fitting most usecases.

###  Affected Containers

- rspamd