### PR TITLE
Expose the same protocols in autoconfig and autodiscover

### DIFF
--- a/data/web/autoconfig.php
+++ b/data/web/autoconfig.php
@@ -39,17 +39,6 @@ header('Content-Type: application/xml');
          <username>%EMAILADDRESS%</username>
          <authentication>password-cleartext</authentication>
       </incomingServer>
-      <incomingServer type="imap">
-         <hostname><?=$autodiscover_config['imap']['server']; ?></hostname>
-         <port><?=$autodiscover_config['imap']['tlsport']; ?></port>
-         <socketType>STARTTLS</socketType>
-         <username>%EMAILADDRESS%</username>
-         <authentication>password-cleartext</authentication>
-      </incomingServer>
-
-<?php
-$records = dns_get_record('_pop3s._tcp.' . $domain, DNS_SRV); // check if POP3 is announced as "not provided" via SRV record
-if (count($records) == 0 || $records[0]['target'] != '') { ?>
       <incomingServer type="pop3">
          <hostname><?=$autodiscover_config['pop3']['server']; ?></hostname>
          <port><?=$autodiscover_config['pop3']['port']; ?></port>
@@ -57,30 +46,10 @@ if (count($records) == 0 || $records[0]['target'] != '') { ?>
          <username>%EMAILADDRESS%</username>
          <authentication>password-cleartext</authentication>
       </incomingServer>
-<?php } ?>
-<?php
-$records = dns_get_record('_pop3._tcp.' . $domain, DNS_SRV); // check if POP3 is announced as "not provided" via SRV record
-if (count($records) == 0 || $records[0]['target'] != '') { ?>
-      <incomingServer type="pop3">
-         <hostname><?=$autodiscover_config['pop3']['server']; ?></hostname>
-         <port><?=$autodiscover_config['pop3']['tlsport']; ?></port>
-         <socketType>STARTTLS</socketType>
-         <username>%EMAILADDRESS%</username>
-         <authentication>password-cleartext</authentication>
-      </incomingServer>
-<?php } ?>
-
       <outgoingServer type="smtp">
          <hostname><?=$autodiscover_config['smtp']['server']; ?></hostname>
          <port><?=$autodiscover_config['smtp']['port']; ?></port>
          <socketType>SSL</socketType>
-         <username>%EMAILADDRESS%</username>
-         <authentication>password-cleartext</authentication>
-      </outgoingServer>
-      <outgoingServer type="smtp">
-         <hostname><?=$autodiscover_config['smtp']['server']; ?></hostname>
-         <port><?=$autodiscover_config['smtp']['tlsport']; ?></port>
-         <socketType>STARTTLS</socketType>
          <username>%EMAILADDRESS%</username>
          <authentication>password-cleartext</authentication>
       </outgoingServer>

--- a/data/web/autodiscover.php
+++ b/data/web/autodiscover.php
@@ -172,6 +172,16 @@ if ($login_role === "user") {
         <AuthRequired>on</AuthRequired>
       </Protocol>
       <Protocol>
+        <Type>POP3</Type>
+        <Server><?=$autodiscover_config['pop3']['server'];?></Server>
+        <Port><?=$autodiscover_config['pop3']['port'];?></Port>
+        <DomainRequired>off</DomainRequired>
+        <LoginName><?=$email;?></LoginName>
+        <SPA>off</SPA>
+        <SSL>on</SSL>
+        <AuthRequired>on</AuthRequired>
+      </Protocol>
+      <Protocol>
         <Type>SMTP</Type>
         <Server><?=$autodiscover_config['smtp']['server'];?></Server>
         <Port><?=$autodiscover_config['smtp']['port'];?></Port>


### PR DESCRIPTION
## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->

This PR streamlines the exposure of protocols in autoconfig and autodiscover by dropping dynamic config based on SRV values for autoconfig, for more information see https://github.com/mailcow/mailcow-dockerized/issues/5944 and https://github.com/mailcow/mailcow-dockerized/pull/5945 .

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

## Did you run tests?

No