### PR TITLE
fix: 🚑 Fixed version parsing of docker

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -329,7 +329,7 @@ for bin in curl docker git awk sha1sum grep cut; do
 done
 
 # Check Docker Version (need at least 24.X)
-docker_version=$(docker -v | grep -oP '\d+\.\d+\.\d+' | cut -d '.' -f 1)
+docker_version=$(docker -v | grep -oP '\d+\.\d+\.\d+' | cut -d '.' -f 1 | head -1)
 
 if [[ $docker_version -lt 24 ]]; then
   echo -e "\e[31mCannot find Docker with a Version higher or equals 24.0.0\e[0m"


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Fixes the Docker version parsing in `update.sh`. Resolves #6015 

<!-- Please write a short description, what your PR does here. -->

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

## Did you run tests?

### What did you tested?

`./update.sh` works fine and without the syntax error.  

Additionally i've tested the affected lines manually to ensure a proper result is returned:

```shell
> docker -v | grep -oP '\d+\.\d+\.\d+' | cut -d '.' -f 1 # BAD
24
24
22
> docker -v | grep -oP '\d+\.\d+\.\d+' | cut -d '.' -f 1 | head -1 # GOOD
24
```
<!-- Please write shortly, what you've tested (which components etc.). -->

### What were the final results? (Awaited, got)

The result is as expected. The syntax error is gone and the docker version tests succeeds.
<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->