### PR TITLE
Refactor/Change Dockerfiles cmd from shell to exec form

### DIFF
--- a/data/Dockerfiles/dockerapi/Dockerfile
+++ b/data/Dockerfiles/dockerapi/Dockerfile
@@ -24,4 +24,4 @@ COPY main.py /app/main.py
 COPY modules/ /app/modules/
 
 ENTRYPOINT ["/bin/sh", "/app/docker-entrypoint.sh"]
-CMD exec python main.py
+CMD ["python", "main.py"]

--- a/data/Dockerfiles/postfix/Dockerfile
+++ b/data/Dockerfiles/postfix/Dockerfile
@@ -60,4 +60,4 @@ EXPOSE 588
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-CMD exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/data/Dockerfiles/sogo/Dockerfile
+++ b/data/Dockerfiles/sogo/Dockerfile
@@ -55,4 +55,4 @@ RUN chmod +x /bootstrap-sogo.sh \
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-CMD exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/data/Dockerfiles/unbound/Dockerfile
+++ b/data/Dockerfiles/unbound/Dockerfile
@@ -33,4 +33,4 @@ HEALTHCHECK --interval=30s --timeout=10s \
   CMD sh -c '[ -f /tmp/healthcheck_status ] && [ "$(cat /tmp/healthcheck_status)" -eq 0 ] || exit 1'
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/data/Dockerfiles/watchdog/Dockerfile
+++ b/data/Dockerfiles/watchdog/Dockerfile
@@ -37,4 +37,4 @@ RUN apk add --update \
 COPY watchdog.sh /watchdog.sh
 COPY check_mysql_slavestatus.sh /usr/lib/nagios/plugins/check_mysql_slavestatus.sh
 
-CMD /watchdog.sh
+CMD ["/watchdog.sh"]


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

In this PR, I modified the `Dockerfile`s to make sure all Dockerfiles uses the same `exec form` instead of old `shell form` in CMD instructions. Here's the modified components:

- dockerapi
- postfix
- sogo
- unbound
- watchdog

### Short Description

The update is to make the whole project use [`exec form of CMD (click for ref)`](https://docs.docker.com/reference/dockerfile/#shell-and-exec-form) instead of the old shell form, to make the project concise. Because some Dockerfile instructions still use the old shell form and other use the newer exec form.

###  Affected Containers

- dockerapi
- postfix
- sogo
- unbound
- watchdog

## Did you run tests?

Yes.

### What did you tested?

I tested the affected containers, mentioned above.

### What were the final results? (Awaited, got)

I build the containers that I modified and make sure they all works and in healthy state.