### PR TITLE
dovecot: added timeout option when sa-rules cannot be downloaded

### DIFF
--- a/data/Dockerfiles/dovecot/sa-rules.sh
+++ b/data/Dockerfiles/dovecot/sa-rules.sh
@@ -18,7 +18,7 @@ if curl --connect-timeout 15 --retry 10 --max-time 30 https://www.spamassassin.h
   fi
 else
   echo "Failed to download SA rules. Exiting."
-  exit 1
+  exit 0 # Must be 0 otherwise dovecot would not start at all
 fi
 
 sed -i -e 's/\([^\\]\)\$\([^\/]\)/\1\\$\2/g' /etc/rspamd/custom/sa-rules

--- a/data/Dockerfiles/dovecot/sa-rules.sh
+++ b/data/Dockerfiles/dovecot/sa-rules.sh
@@ -11,10 +11,14 @@ else
 fi
 
 # Deploy
-curl --connect-timeout 15 --retry 10 --max-time 30 https://www.spamassassin.heinlein-support.de/$(dig txt 1.4.3.spamassassin.heinlein-support.de +short | tr -d '"' | tr -dc '0-9').tar.gz --output /tmp/sa-rules-heinlein.tar.gz
-if gzip -t /tmp/sa-rules-heinlein.tar.gz; then
-  tar xfvz /tmp/sa-rules-heinlein.tar.gz -C /tmp/sa-rules-heinlein
-  cat /tmp/sa-rules-heinlein/*cf > /etc/rspamd/custom/sa-rules
+if curl --connect-timeout 15 --retry 10 --max-time 30 https://www.spamassassin.heinlein-support.de/$(dig txt 1.4.3.spamassassin.heinlein-support.de +short | tr -d '"' | tr -dc '0-9').tar.gz --output /tmp/sa-rules-heinlein.tar.gz; then
+  if gzip -t /tmp/sa-rules-heinlein.tar.gz; then
+    tar xfvz /tmp/sa-rules-heinlein.tar.gz -C /tmp/sa-rules-heinlein
+    cat /tmp/sa-rules-heinlein/*cf > /etc/rspamd/custom/sa-rules
+  fi
+else
+  echo "Failed to download SA rules. Exiting."
+  exit 1
 fi
 
 sed -i -e 's/\([^\\]\)\$\([^\/]\)/\1\\$\2/g' /etc/rspamd/custom/sa-rules


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

Improvement of SA-Rules Download upon Dovecot Start/Restart

### Short Description

Issue https://github.com/mailcow/mailcow-dockerized/issues/6018 described a circumstance when dovecot is restarted, that the sa-rules are not downloaded (definitely a bug on the host machine, as it should work flawlessly) and therefore dovecot is not started. As the sa-rules are not necessary for mailcow to operate, we can exclude this after 10 failed tries...

###  Affected Containers

- dovecot
- rspamd

## Did you run tests?

### What did you tested?

If tested the build of Dovecot (worked) and the normal startup (worked too)

I also tested the exclusion of the script by modifing the timeout times and modifiying the wrong url (simulating a network failure), after X tries he's skipping the sa-rule download like wanted.

### What were the final results? (Awaited, got)

I've had to set the exit code to 0 instead of 1 as the dovecot process wouldn't started  afterwards if not exited 0. That changed it worked!