### PR TITLE
Pushover/Quarantine utf 8 fix - fixes #6028

### DIFF
--- a/data/conf/rspamd/meta_exporter/pipe.php
+++ b/data/conf/rspamd/meta_exporter/pipe.php
@@ -52,7 +52,7 @@ $headers = getallheaders();
 
 $qid      = $headers['X-Rspamd-Qid'];
 $fuzzy    = $headers['X-Rspamd-Fuzzy'];
-$subject  = $headers['X-Rspamd-Subject'];
+$subject  = iconv_mime_decode($headers['X-Rspamd-Subject']);
 $score    = $headers['X-Rspamd-Score'];
 $rcpts    = $headers['X-Rspamd-Rcpt'];
 $user     = $headers['X-Rspamd-User'];

--- a/data/conf/rspamd/meta_exporter/pushover.php
+++ b/data/conf/rspamd/meta_exporter/pushover.php
@@ -53,7 +53,7 @@ $qid      = $headers['X-Rspamd-Qid'];
 $rcpts    = $headers['X-Rspamd-Rcpt'];
 $sender   = $headers['X-Rspamd-From'];
 $ip       = $headers['X-Rspamd-Ip'];
-$subject  = $headers['X-Rspamd-Subject'];
+$subject  = iconv_mime_decode($headers['X-Rspamd-Subject']);
 $messageid= $json_body->message_id;
 $priority = 0;
 

--- a/data/web/inc/functions.quarantine.inc.php
+++ b/data/web/inc/functions.quarantine.inc.php
@@ -307,7 +307,7 @@ function quarantine($_action, $_data = null) {
           $max_score = floatval($_data['max_score']);
         }
         $max_age = intval($_data['max_age']);
-        $subject = iconv_mime_decode($_data['subject']);
+        $subject = $_data['subject'];
         if (!filter_var($_data['bcc'], FILTER_VALIDATE_EMAIL)) {
           $bcc = '';
         }

--- a/data/web/inc/functions.quarantine.inc.php
+++ b/data/web/inc/functions.quarantine.inc.php
@@ -307,7 +307,7 @@ function quarantine($_action, $_data = null) {
           $max_score = floatval($_data['max_score']);
         }
         $max_age = intval($_data['max_age']);
-        $subject = $_data['subject'];
+        $subject = iconv_mime_decode($_data['subject']);
         if (!filter_var($_data['bcc'], FILTER_VALIDATE_EMAIL)) {
           $bcc = '';
         }


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?
It ifixes the issue mentioned in #6028 - utf-8 encoded text in the subject of the pushover message

###  Affected Containers
- rspamd-mailcow

## Did you run tests?
Yes

### What did you tested?

Ran the fix 15 hours and received Pushover messages for each email I receive.

### What were the final results? (Awaited, got)

No more encoded subjects in the pushover message