### PR TITLE
[PHP-FPM] Use redis as session store

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,7 @@ services:
             - rspamd
 
     php-fpm-mailcow:
-      image: mailcow/phpfpm:1.89
+      image: mailcow/phpfpm:1.90
       command: "php-fpm -d date.timezone=${TZ} -d expose_php=0"
       depends_on:
         - redis-mailcow
@@ -552,7 +552,7 @@ services:
           aliases:
             - dockerapi
 
-    
+
     ##### Will be removed soon #####
     solr-mailcow:
       image: mailcow/solr:1.8.3


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

PHP will use Redis for session storage, allowing session data to persist across PHP container restart

###  Affected Containers

- PHP-FPM

## Did you run tests?

### What did you tested?

I verified that the file `/usr/local/etc/php/conf.d/session_store.ini` inside the PHP Container is correctly generated at startup. Additionally, after logging in as an admin user and restarting the PHP container, the session remained valid.

### What were the final results? (Awaited, got)

**Awaited:** Sessions should remain valid after restarting the PHP container.
**Got:** The session was indeed valid after the PHP container was restarted.