### PR TITLE
feat: Added check for newer version tags on remote

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -360,6 +360,21 @@ while (($#)); do
         exit 3
       fi
     ;;
+    --check-tags)
+      echo "Checking remote tags for updates..."
+      LATEST_TAG_REV=$(git ls-remote --exit-code --quiet --tags origin | tail -1 | cut -f1)
+      if [ "$?" -ne 0 ]; then
+        echo "A problem occurred while trying to fetch the latest tag from github."
+        exit 99
+      fi
+      if [[ -z $(git log HEAD --pretty=format:"%H" | grep "${LATEST_TAG_REV}") ]]; then
+        echo -e "New tag is available.\nThe changes can be found here: https://github.com/mailcow/mailcow-dockerized/releases/latest"
+        exit 0
+      else
+        echo "No updates available."
+        exit 3
+      fi
+    ;;
     --ours)
       MERGE_STRATEGY=ours
     ;;
@@ -396,9 +411,10 @@ while (($#)); do
       DEV=y
     ;;
     --help|-h)
-    echo './update.sh [-c|--check, --ours, --gc, --nightly, --prefetch, --skip-start, --skip-ping-check, --stable, -f|--force, -d|--dev, -h|--help]
+    echo './update.sh [-c|--check, --check-tags, --ours, --gc, --nightly, --prefetch, --skip-start, --skip-ping-check, --stable, -f|--force, -d|--dev, -h|--help]
 
   -c|--check           -   Check for updates and exit (exit codes => 0: update available, 3: no updates)
+  --check-tags         -   Check for newer tags and exit (exit codes => 0: newer tag available, 3: no newer tag)
   --ours               -   Use merge strategy option "ours" to solve conflicts in favor of non-mailcow code (local changes over remote changes), not recommended!
   --gc                 -   Run garbage collector to delete old image tags
   --nightly            -   Switch your mailcow updates to the unstable (nightly) branch. FOR TESTING PURPOSES ONLY!!!!


### PR DESCRIPTION


<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Adds a check in `update.sh` for newer tags on remote than the current local rev

###  Affected Containers

No containers affected

## Did you run tests?

### What did you tested?
`update.sh` has no syntax errors and runs fine.
Tested every command itself and the full script.

![grafik](https://github.com/user-attachments/assets/7570a082-6f35-4439-b580-e26fe6ec8803)

![grafik](https://github.com/user-attachments/assets/7265aabf-e42b-4fbb-bbb0-a7959bce1650)

### What were the final results? (Awaited, got)

Final results are as expected. The script works as expected, tests are successful.
