### PR TITLE
compose: added clamd as depends_on to rspamd

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow
+        - clamd-mailcow
       environment:
         - TZ=${TZ}
         - IPV4_NETWORK=${IPV4_NETWORK:-172.22.1}


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Fixes https://github.com/mailcow/mailcow-dockerized/issues/5738.

It appends clamd as a depends_on flag to docker-compose.yml

###  Affected Containers

- rspamd

## Did you run tests?

### What did you tested?

I've tested the behaviour of rspamd when clamd is turned on via mailcow.conf or off in case of starting the service.

### What were the final results? (Awaited, got)

Rspamd starts normally, as it should. That pr is basically a start order change to make sure clamav is definately earlier started then rspamd.