### PR TITLE
/feat | Ability to Login to SOGo with a One-Click-Link from another Application

### DIFF
--- a/data/web/sogossologin/sogo-auth.php
+++ b/data/web/sogossologin/sogo-auth.php
@@ -1,0 +1,60 @@
+<?php
+
+session_start();
+$session_var_user_allowed = 'sogo-sso-user-allowed';
+$session_var_pass = 'sogo-sso-pass';
+
+
+function checkTokenExists($pdo, $username, $token): bool
+{
+    try {
+
+        $stmt = $pdo->prepare("SELECT * FROM `sogo_sso_tokens` WHERE `username` = :username AND `token` = :token");
+        $stmt->bindParam(':username', $username);
+        $stmt->bindParam(':token', $token);
+
+        $stmt->execute();
+
+        $res = $stmt->fetchAll();
+        if(count($res) == 1){
+            return true;
+        }else{
+            return false;
+        }
+    } catch (PDOException $e) {
+        return false;
+    }
+}
+
+
+
+
+
+
+if(isset($_GET['email']) && $_GET['token']){
+    require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
+    if(checkTokenExists($pdo, $_GET['email'], $_GET['token'])){
+        try {
+            $sogo_sso_pass = file_get_contents("/etc/sogo-sso/sogo-sso.pass");
+            $_SESSION[$session_var_user_allowed][] = $_GET['email'];
+            $_SESSION[$session_var_pass] = $sogo_sso_pass;
+            $stmt = $pdo->prepare("REPLACE INTO sasl_log (`service`, `app_password`, `username`, `real_rip`) VALUES ('SSO', 0, :username, :remote_addr)");
+            $stmt->execute(array(
+                ':username' => $_GET['email'],
+                ':remote_addr' => (isset($_SERVER['HTTP_X_REAL_IP']) ? $_SERVER['HTTP_X_REAL_IP'] : $_SERVER['REMOTE_ADDR'])
+            ));
+        }catch (PDOException $e){
+            echo $e->getMessage();
+        }
+
+
+        header("Location: /SOGo/so/{$_GET['email']}");
+    }else{
+        http_response_code(401);
+    }
+}
+
+// if username is empty, SOGo will use the normal login methods / login form
+header("X-User: ");
+header("X-Auth: ");
+header("X-Auth-Type: ");

--- a/data/web/sogossologin/sogo-tokengenerate.php
+++ b/data/web/sogossologin/sogo-tokengenerate.php
@@ -1,0 +1,76 @@
+<?php
+
+require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
+$_POST = json_decode(file_get_contents('php://input'), true);
+
+function createIfTableDoesntExist($pdo, $debug = false)
+{
+    try {
+        $stmt = $pdo->prepare("CREATE TABLE IF NOT EXISTS `sogo_sso_tokens` (
+            `id` INT AUTO_INCREMENT PRIMARY KEY,
+            `username` TEXT NOT NULL,
+            `token` TEXT NOT NULL
+        )");
+        $stmt->execute();
+    } catch (PDOException $e) {
+        if ($debug) echo $e->getMessage();
+    }
+}
+
+function showTables($pdo)
+{
+    try {
+        $stmt2 = $pdo->query("SHOW TABLES");
+        $res = $stmt2->fetchAll(PDO::FETCH_ASSOC);
+        var_dump($res);
+    } catch (PDOException $e) {
+        echo $e->getMessage();
+    }
+}
+
+function writeTokenToDB($username, $token, $pdo): bool
+{
+    try {
+        $stmt = $pdo->prepare("INSERT INTO `sogo_sso_tokens` (`username`, `token`) VALUES (:username, :token)");
+        $stmt->bindParam(':username', $username);
+        $stmt->bindParam(':token', $token);
+        $success = $stmt->execute();
+        return $success;
+    } catch (PDOException $e) {
+        echo $e->getMessage();
+        return false;
+    }
+}
+
+function generateToken($username): string
+{
+    return md5(base64_encode($username) . random_bytes(16) . md5(time()));
+}
+
+function getApiKey($pdo)
+{
+    try {
+        $stmt = $pdo->prepare("SELECT `api_key` FROM `api` LIMIT 1");
+        $stmt->execute();
+        return $stmt->fetchColumn();
+
+    } catch (PDOException $e) {
+        return null;
+    }
+}
+
+
+if (isset($_POST['username']) && isset($_POST['apikey'])) {
+
+    if ($_POST['apikey'] == getApiKey($pdo)) {
+        $username = $_POST['username'];
+        $token = generateToken($username);
+        createIfTableDoesntExist($pdo);
+        writeTokenToDB($username, $token, $pdo);
+        echo json_encode(array(
+            "success" => true,
+            "username"=> $username,
+            "token" => $token
+        ));
+    }
+}


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR is a little "Add-On" to the SOGo-One-Click-Auth already implemented in Mailcow. 
It gives the function to create a token for an Login to SOGo From other applications only with the API token.

#### How does it work?
1. POST Request from Application to Mailcow
-> Body: username: {MAILBOX EMAIL ADDRESS} | apikey: {APIKEY} (JSON)
2. Response: 
-> Body: success: true/false | username: {RETURN OF USERNAME} | token: {ONE-TIME AUTH TOKEN FOR SOGO}
3. User gets redirected to /sogossologin/sogo-auth.php?email=EMAIL&token=TOKEN
-> GET Parameters: email: {MAILBOX EMAIL ADDRESS} | token: {ONE-TIME AUTH TOKEN}

Tadaaa! User is logged in to SOGo.

---
Yes, that means that with the API Key, everyone can login to a Mailaccount. But Admins can login from the panel either way.
And there is no difference between a comprimized Admin Mailcow Account or a leaked API-Key because the API Key can do as much as the admin account.

###  Affected Containers

- php-fpm
- sogo

## Did you run tests?

### What did you tested?

I generated a token, used the token in the URL and got logged in to SOGo

### What were the final results? (Awaited, got)

Everything worked just as i intended it to.