### PR TITLE
Update postfix.sh, so mysql_sender_dependent_default_transport_maps.cf is in line with mysql_sasl_passwd_maps_sender_dependent.cf

### DIFF
--- a/data/Dockerfiles/postfix/postfix.sh
+++ b/data/Dockerfiles/postfix/postfix.sh
@@ -183,16 +183,6 @@ query = SELECT CONCAT_WS(':', username, password) AS auth_data FROM relayhosts
   WHERE id IN (
     SELECT COALESCE(
       (SELECT id FROM relayhosts
-      LEFT OUTER JOIN domain ON domain.relayhost = relayhosts.id
-      WHERE relayhosts.active = '1'
-        AND (domain.domain = '%d'
-          OR domain.domain IN (
-            SELECT target_domain FROM alias_domain
-            WHERE alias_domain = '%d'
-          )
-        )
-      ),
-      (SELECT id FROM relayhosts
       LEFT OUTER JOIN mailbox ON JSON_UNQUOTE(JSON_VALUE(mailbox.attributes, '$.relayhost')) = relayhosts.id
       WHERE relayhosts.active = '1'
         AND (
@@ -202,6 +192,16 @@ query = SELECT CONCAT_WS(':', username, password) AS auth_data FROM relayhosts
                 WHERE alias.active = '1'
                   AND alias.address = '%s'
                   AND alias.address NOT LIKE '@%%'
+          )
+        )
+      ),
+      (SELECT id FROM relayhosts
+      LEFT OUTER JOIN domain ON domain.relayhost = relayhosts.id
+      WHERE relayhosts.active = '1'
+        AND (domain.domain = '%d'
+          OR domain.domain IN (
+            SELECT target_domain FROM alias_domain
+            WHERE alias_domain = '%d'
           )
         )
       )


### PR DESCRIPTION
* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

In case when the domain has relay host configures (rh.example.com) and you configure a separate relay host for user within that domain (rh2.example.com) credentials for relay host are selected from domain relay host (rh.example.com) no users, like:

[at]example.com - relay host rh.example.com
example[at]example.com - relay host rh2.example.com

Expected result:
When sending email from any email under domain use rh.example.com, when sending from example[at]example.com use rh2.example.com, both hosts require authentication, correct authentication is provided and email sent.

Actual result:
When sending email from any email under domain use rh.example.com, when sending from example[at]example.com use rh2.example.com, authentication credentials for rh2.example.com are selected from rh.example.com.

Cause:
mysql_sender_dependent_default_transport_maps.cf `SELECT COALESCE` starts by `relayhosts LEFT OUTER JOIN mailbox` and then uses `relayhosts LEFT OUTER JOIN domain`, but mysql_sasl_passwd_maps_sender_dependent.cf currently does opposite, so I flipped the order so that both queries have same logic.

###  Affected Containers

- postfix

## Did you run tests?
Yes

### What did you tested?

I tested postfix, sending, receiving mail using relays and not, relays in different configurations. Since I have used this fix in production for about two weeks now.

### What were the final results? (Awaited, got)

The connection was always made and authenticated correctly.