### PR TITLE
fix: added tls1.0/1.1 patch for openssl when using older tls versions…

### DIFF
--- a/data/Dockerfiles/dovecot/docker-entrypoint.sh
+++ b/data/Dockerfiles/dovecot/docker-entrypoint.sh
@@ -405,6 +405,17 @@ else
 	chown 401 /mail_crypt/ecprivkey.pem /mail_crypt/ecpubkey.pem
 fi
 
+# Fix OpenSSL 3.X TLS1.0, 1.1 support (https://community.mailcow.email/d/4062-hi-all/20)
+if grep -qE 'ssl_min_protocol\s*=\s*(TLSv1|TLSv1\.1)\s*$' /etc/dovecot/dovecot.conf /etc/dovecot/extra.conf; then
+    sed -i '/\[openssl_init\]/a ssl_conf = ssl_configuration' /etc/ssl/openssl.cnf
+
+    echo "[ssl_configuration]" >> /etc/ssl/openssl.cnf
+    echo "system_default = tls_system_default" >> /etc/ssl/openssl.cnf
+    echo "[tls_system_default]" >> /etc/ssl/openssl.cnf
+    echo "MinProtocol = TLSv1" >> /etc/ssl/openssl.cnf
+    echo "CipherString = DEFAULT@SECLEVEL=0" >> /etc/ssl/openssl.cnf
+fi
+
 # Compile sieve scripts
 sievec /var/vmail/sieve/global_sieve_before.sieve
 sievec /var/vmail/sieve/global_sieve_after.sieve

--- a/data/Dockerfiles/postfix/docker-entrypoint.sh
+++ b/data/Dockerfiles/postfix/docker-entrypoint.sh
@@ -12,4 +12,15 @@ if [[ ! -z ${REDIS_SLAVEOF_IP} ]]; then
   cp /etc/syslog-ng/syslog-ng-redis_slave.conf /etc/syslog-ng/syslog-ng.conf
 fi
 
+# Fix OpenSSL 3.X TLS1.0, 1.1 support (https://community.mailcow.email/d/4062-hi-all/20)
+if grep -qE '\!SSLv2|\!SSLv3|>=TLSv1(\.[0-1])?$' /opt/postfix/conf/main.cf /opt/postfix/conf/extra.cf; then
+    sed -i '/\[openssl_init\]/a ssl_conf = ssl_configuration' /etc/ssl/openssl.cnf
+
+    echo "[ssl_configuration]" >> /etc/ssl/openssl.cnf
+    echo "system_default = tls_system_default" >> /etc/ssl/openssl.cnf
+    echo "[tls_system_default]" >> /etc/ssl/openssl.cnf
+    echo "MinProtocol = TLSv1" >> /etc/ssl/openssl.cnf
+    echo "CipherString = DEFAULT@SECLEVEL=0" >> /etc/ssl/openssl.cnf
+fi  
+
 exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -224,7 +224,7 @@ services:
             - sogo
 
     dovecot-mailcow:
-      image: mailcow/dovecot:2.1
+      image: mailcow/dovecot:2.2
       depends_on:
         - mysql-mailcow
         - netfilter-mailcow
@@ -308,7 +308,7 @@ services:
             - dovecot
 
     postfix-mailcow:
-      image: mailcow/postfix:1.76
+      image: mailcow/postfix:1.77
       depends_on:
         mysql-mailcow:
           condition: service_started


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR includes a fix stated in: https://community.mailcow.email/d/4062-hi-all/20 to fix the openssl 3.0 lack of tls1.X support which has been deactivated by default.

###  Affected Containers

- dovecot
- postfix

## Did you run tests?

### What did you tested?

I tested the changes by modifying the extra.cf for both containers to readd tls1.0/1.1 support (like described in the docs).

I've checked that the openssl.conf got modified with the patch.

Then i tested if i can connect via openssl client from outside by using a TLS version of 1.0/1.1, previously it was not possible as the openssl from the container blocked those requests.

### What were the final results? (Awaited, got)

The openssl.conf got modified as awaited and i was able to connect to the server by using TLS 1.0/1.1 again.