### PR TITLE
php: upgrade to alpine 3.20 (base os)

### DIFF
--- a/data/Dockerfiles/phpfpm/Dockerfile
+++ b/data/Dockerfiles/phpfpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-alpine3.18
+FROM php:8.2-fpm-alpine3.20
 
 LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
             - rspamd
 
     php-fpm-mailcow:
-      image: mailcow/phpfpm:1.90
+      image: mailcow/phpfpm:1.91
       command: "php-fpm -d date.timezone=${TZ} -d expose_php=0"
       depends_on:
         - redis-mailcow


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR includes the base os Upgrade to Alpine 3.20 (again) after some fixes internally of Alpine.

###  Affected Containers

- php-fpm

## Did you run tests?

### What did you tested?

I tested the general usability of mailcow with these Upgrade. Like the previous times a error is not reproducable on any tested machine.

### What were the final results? (Awaited, got)

mailcow just runs like normal with that upgrade, only the base OS packages have changed here.