### PR TITLE
postfix: add X-Original-To header per default

### DIFF
--- a/data/conf/postfix/main.cf
+++ b/data/conf/postfix/main.cf
@@ -170,6 +170,8 @@ smtputf8_enable = no
 submission_smtpd_tls_mandatory_protocols = >=TLSv1.2
 smtps_smtpd_tls_mandatory_protocols = >=TLSv1.2
 parent_domain_matches_subdomains = debug_peer_list,fast_flush_domains,mynetworks,qmqpd_authorized_clients
+# This Option is added to correctly set the X-Original-To Header when mails are send to lmtp (dovecot)
+lmtp_destination_recipient_limit=1
 
 # DO NOT EDIT ANYTHING BELOW #
 # Overrides #

--- a/data/conf/postfix/master.cf
+++ b/data/conf/postfix/master.cf
@@ -105,7 +105,7 @@ retry      unix  -       -       n       -       -       error
 discard    unix  -       -       n       -       -       discard
 local      unix  -       n       n       -       -       local
 virtual    unix  -       n       n       -       -       virtual
-lmtp       unix  -       -       n       -       -       lmtp
+lmtp       unix  -       -       n       -       -       lmtp flags=O
 anvil      unix  -       -       n       -       1       anvil
 scache     unix  -       -       n       -       1       scache
 maildrop   unix  -       n       n       -       -       pipe flags=DRhu


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fulfill on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR adds correctly sets the X-Original-To Header in Mails received via Postfix and send to Dovecot.

Previously this header was not set.

###  Affected Containers

- postfix

## Did you run tests?

### What did you tested?

I've tested mail sending, receiving and redirects

### What were the final results? (Awaited, got)

 All work like before. DKIM signatures are also intact.