### PR TITLE
lang.zh-tw.json "memory" translation fix

### DIFF
--- a/data/web/lang/lang.zh-tw.json
+++ b/data/web/lang/lang.zh-tw.json
@@ -511,7 +511,7 @@
         "architecture": "結構",
         "current_time": "系統時間",
         "container_running": "正在執行",
-        "memory": "記憶",
+        "memory": "記憶體",
         "container_disabled": "容器停止或停用",
         "container_stopped": "已停止",
         "cores": "核心",


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [v] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them


## What does this PR include?

### Short Description
Includes the Mandarin for Taiwan🇹🇼(zh-TW) translation fix for memory as computer parts. From 記憶 to 記憶體.

###  Affected Containers

* nginx-mailcow


## Did you run tests?
Yes.

### What did you tested?

Ran docker compose and check if the zh-tw webpage did fix the translation.

### What were the final results? (Awaited, got)

The translation for memory should be updated and it is. 

Before change:
<img width="342" alt="Screenshot 2024-10-17 at 1 13 14 AM" src="https://github.com/user-attachments/assets/87ac2d72-ebc0-4f4e-a896-750401232482">

After change:
<img width="501" alt="Screenshot 2024-10-17 at 7 52 35 PM" src="https://github.com/user-attachments/assets/4ffb8b3f-e73b-4e42-847d-45981c99db4c">



