### PR TITLE
rspamd: update to 3.10.1

### DIFF
--- a/data/Dockerfiles/rspamd/Dockerfile
+++ b/data/Dockerfiles/rspamd/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:bookworm-slim
-LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
+LABEL maintainer="The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG RSPAMD_VER=rspamd_3.9.1-1~82f43560f
+ARG RSPAMD_VER=rspamd_3.10.1-1~9de95c2b6
 ARG CODENAME=bookworm
 ENV LC_ALL=C
 

--- a/data/conf/rspamd/local.d/options.inc
+++ b/data/conf/rspamd/local.d/options.inc
@@ -2,6 +2,7 @@ dns {
   enable_dnssec = true;
 }
 map_watch_interval = 30s;
+task_timeout = 30s;
 disable_monitoring = true;
 # In case a task times out (like DNS lookup), soft reject the message
 # instead of silently accepting the message without further processing.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
             - clamd
 
     rspamd-mailcow:
-      image: mailcow/rspamd:1.97
+      image: mailcow/rspamd:1.98
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR includes the Rspamd Update to 3.10.1.

Read changelog:
https://github.com/rspamd/rspamd/releases/tag/3.10.1

It also increases the `task_timeout` value from default 8s to 30s now in order to process all incoming mails properly, because unfiltered mails will be rejected inside mailcow.

Thanks to @dragoangel for pointing this out.

###  Affected Containers

- rspamd

## Did you run tests?

### What did you tested?

I've tested the general behaviour of mailcow (sending, receiving mails) with and without BCC Maps or Rspamd Rules.

### What were the final results? (Awaited, got)

mailcow works like normal