### PR TITLE
Enable password protection for Redis

### DIFF
--- a/data/Dockerfiles/acme/acme.sh
+++ b/data/Dockerfiles/acme/acme.sh
@@ -4,9 +4,9 @@ exec 5>&1
 
 # Do not attempt to write to slave
 if [[ ! -z ${REDIS_SLAVEOF_IP} ]]; then
-  export REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS}"
+  export REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS} --no-auth-warning"
 else
-  export REDIS_CMDLINE="redis-cli -h redis -p 6379 -a ${REDISPASS}"
+  export REDIS_CMDLINE="redis-cli -h redis -p 6379 -a ${REDISPASS} --no-auth-warning"
 fi
 
 until [[ $(${REDIS_CMDLINE} PING) == "PONG" ]]; do

--- a/data/Dockerfiles/acme/acme.sh
+++ b/data/Dockerfiles/acme/acme.sh
@@ -4,9 +4,9 @@ exec 5>&1
 
 # Do not attempt to write to slave
 if [[ ! -z ${REDIS_SLAVEOF_IP} ]]; then
-  export REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT}"
+  export REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS}"
 else
-  export REDIS_CMDLINE="redis-cli -h redis -p 6379"
+  export REDIS_CMDLINE="redis-cli -h redis -p 6379 -a ${REDISPASS}"
 fi
 
 until [[ $(${REDIS_CMDLINE} PING) == "PONG" ]]; do

--- a/data/Dockerfiles/acme/obtain-certificate.sh
+++ b/data/Dockerfiles/acme/obtain-certificate.sh
@@ -124,7 +124,7 @@ case "$SUCCESS" in
     ;;
   *) # non-zero is non-fun
     log_f "Failed to obtain certificate ${CERT} for domains '${CERT_DOMAINS[*]}'"
-    redis-cli -h redis -a ${REDISPASS} SET ACME_FAIL_TIME "$(date +%s)"
+    redis-cli -h redis -a ${REDISPASS} --no-auth-warning SET ACME_FAIL_TIME "$(date +%s)"
     exit 100${SUCCESS}
     ;;
 esac

--- a/data/Dockerfiles/acme/obtain-certificate.sh
+++ b/data/Dockerfiles/acme/obtain-certificate.sh
@@ -124,7 +124,7 @@ case "$SUCCESS" in
     ;;
   *) # non-zero is non-fun
     log_f "Failed to obtain certificate ${CERT} for domains '${CERT_DOMAINS[*]}'"
-    redis-cli -h redis SET ACME_FAIL_TIME "$(date +%s)"
+    redis-cli -h redis -a ${REDISPASS} SET ACME_FAIL_TIME "$(date +%s)"
     exit 100${SUCCESS}
     ;;
 esac

--- a/data/Dockerfiles/dockerapi/main.py
+++ b/data/Dockerfiles/dockerapi/main.py
@@ -34,9 +34,9 @@ async def lifespan(app: FastAPI):
 
   # Init redis client
   if os.environ['REDIS_SLAVEOF_IP'] != "":
-    redis_client = redis = await aioredis.from_url(f"redis://{os.environ['REDIS_SLAVEOF_IP']}:{os.environ['REDIS_SLAVEOF_PORT']}/0")
+    redis_client = redis = await aioredis.from_url(f"redis://{os.environ['REDIS_SLAVEOF_IP']}:{os.environ['REDIS_SLAVEOF_PORT']}/0", password=os.environ['REDISPASS'])
   else:
-    redis_client = redis = await aioredis.from_url("redis://redis-mailcow:6379/0")
+    redis_client = redis = await aioredis.from_url("redis://redis-mailcow:6379/0", password=os.environ['REDISPASS'])
 
   # Init docker clients
   sync_docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock', version='auto')

--- a/data/Dockerfiles/dovecot/clean_q_aged.sh
+++ b/data/Dockerfiles/dovecot/clean_q_aged.sh
@@ -2,7 +2,7 @@
 
 source /source_env.sh
 
-MAX_AGE=$(redis-cli --raw -h redis-mailcow -a ${REDISPASS} GET Q_MAX_AGE)
+MAX_AGE=$(redis-cli --raw -h redis-mailcow -a ${REDISPASS} --no-auth-warning GET Q_MAX_AGE)
 
 if [[ -z ${MAX_AGE} ]]; then
   echo "Max age for quarantine items not defined"

--- a/data/Dockerfiles/dovecot/clean_q_aged.sh
+++ b/data/Dockerfiles/dovecot/clean_q_aged.sh
@@ -2,7 +2,7 @@
 
 source /source_env.sh
 
-MAX_AGE=$(redis-cli --raw -h redis-mailcow GET Q_MAX_AGE)
+MAX_AGE=$(redis-cli --raw -h redis-mailcow -a ${REDISPASS} GET Q_MAX_AGE)
 
 if [[ -z ${MAX_AGE} ]]; then
   echo "Max age for quarantine items not defined"

--- a/data/Dockerfiles/dovecot/docker-entrypoint.sh
+++ b/data/Dockerfiles/dovecot/docker-entrypoint.sh
@@ -14,9 +14,9 @@ done
 
 # Do not attempt to write to slave
 if [[ ! -z ${REDIS_SLAVEOF_IP} ]]; then
-  REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT}"
+  REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS}"
 else
-  REDIS_CMDLINE="redis-cli -h redis -p 6379"
+  REDIS_CMDLINE="redis-cli -h redis -p 6379 -a ${REDISPASS}"
 fi
 
 until [[ $(${REDIS_CMDLINE} PING) == "PONG" ]]; do

--- a/data/Dockerfiles/dovecot/docker-entrypoint.sh
+++ b/data/Dockerfiles/dovecot/docker-entrypoint.sh
@@ -14,9 +14,9 @@ done
 
 # Do not attempt to write to slave
 if [[ ! -z ${REDIS_SLAVEOF_IP} ]]; then
-  REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS}"
+  REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS} --no-auth-warning"
 else
-  REDIS_CMDLINE="redis-cli -h redis -p 6379 -a ${REDISPASS}"
+  REDIS_CMDLINE="redis-cli -h redis -p 6379 -a ${REDISPASS} --no-auth-warning"
 fi
 
 until [[ $(${REDIS_CMDLINE} PING) == "PONG" ]]; do

--- a/data/Dockerfiles/dovecot/quarantine_notify.py
+++ b/data/Dockerfiles/dovecot/quarantine_notify.py
@@ -31,7 +31,7 @@ try:
 
   while True:
     try:
-      r = redis.StrictRedis(host='redis', decode_responses=True, port=6379, db=0)
+      r = redis.StrictRedis(host='redis', decode_responses=True, port=6379, db=0, password=os.environ['REDISPASS'])
       r.ping()
     except Exception as ex:
       print('%s - trying again...'  % (ex))

--- a/data/Dockerfiles/dovecot/quota_notify.py
+++ b/data/Dockerfiles/dovecot/quota_notify.py
@@ -23,7 +23,7 @@ else:
 
 while True:
   try:
-    r = redis.StrictRedis(host='redis', decode_responses=True, port=6379, db=0)
+    r = redis.StrictRedis(host='redis', decode_responses=True, port=6379, db=0, password=os.environ['REDISPASS'])
     r.ping()
   except Exception as ex:
     print('%s - trying again...'  % (ex))

--- a/data/Dockerfiles/dovecot/repl_health.sh
+++ b/data/Dockerfiles/dovecot/repl_health.sh
@@ -4,9 +4,9 @@ source /source_env.sh
 
 # Do not attempt to write to slave
 if [[ ! -z ${REDIS_SLAVEOF_IP} ]]; then
-  REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT}"
+  REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS}"
 else
-  REDIS_CMDLINE="redis-cli -h redis -p 6379"
+  REDIS_CMDLINE="redis-cli -h redis -p 6379 -a ${REDISPASS}"
 fi
 
 # Is replication active?

--- a/data/Dockerfiles/dovecot/repl_health.sh
+++ b/data/Dockerfiles/dovecot/repl_health.sh
@@ -4,9 +4,9 @@ source /source_env.sh
 
 # Do not attempt to write to slave
 if [[ ! -z ${REDIS_SLAVEOF_IP} ]]; then
-  REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS}"
+  REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS} --no-auth-warning"
 else
-  REDIS_CMDLINE="redis-cli -h redis -p 6379 -a ${REDISPASS}"
+  REDIS_CMDLINE="redis-cli -h redis -p 6379 -a ${REDISPASS} --no-auth-warning"
 fi
 
 # Is replication active?

--- a/data/Dockerfiles/dovecot/syslog-ng-redis_slave.conf
+++ b/data/Dockerfiles/dovecot/syslog-ng-redis_slave.conf
@@ -20,6 +20,7 @@ destination d_redis_ui_log {
     host("`REDIS_SLAVEOF_IP`")
     persist-name("redis1")
     port(`REDIS_SLAVEOF_PORT`)
+    auth("`REDISPASS`")
     command("LPUSH" "DOVECOT_MAILLOG" "$(format-json time=\"$S_UNIXTIME\" priority=\"$PRIORITY\" program=\"$PROGRAM\" message=\"$MESSAGE\")\n")
   );
 };
@@ -28,6 +29,7 @@ destination d_redis_f2b_channel {
     host("`REDIS_SLAVEOF_IP`")
     persist-name("redis2")
     port(`REDIS_SLAVEOF_PORT`)
+    auth("`REDISPASS`")
     command("PUBLISH" "F2B_CHANNEL" "$(sanitize $MESSAGE)")
   );
 };

--- a/data/Dockerfiles/dovecot/syslog-ng.conf
+++ b/data/Dockerfiles/dovecot/syslog-ng.conf
@@ -20,6 +20,7 @@ destination d_redis_ui_log {
     host("redis-mailcow")
     persist-name("redis1")
     port(6379)
+    auth("`REDISPASS`")
     command("LPUSH" "DOVECOT_MAILLOG" "$(format-json time=\"$S_UNIXTIME\" priority=\"$PRIORITY\" program=\"$PROGRAM\" message=\"$MESSAGE\")\n")
   );
 };
@@ -28,6 +29,7 @@ destination d_redis_f2b_channel {
     host("redis-mailcow")
     persist-name("redis2")
     port(6379)
+    auth("`REDISPASS`")
     command("PUBLISH" "F2B_CHANNEL" "$(sanitize $MESSAGE)")
   );
 };

--- a/data/Dockerfiles/dovecot/trim_logs.sh
+++ b/data/Dockerfiles/dovecot/trim_logs.sh
@@ -10,9 +10,9 @@ catch_non_zero() {
 source /source_env.sh
 # Do not attempt to write to slave
 if [[ ! -z ${REDIS_SLAVEOF_IP} ]]; then
-  REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT}"
+  REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS}"
 else
-  REDIS_CMDLINE="redis-cli -h redis -p 6379"
+  REDIS_CMDLINE="redis-cli -h redis -p 6379 -a ${REDISPASS}"
 fi
 catch_non_zero "${REDIS_CMDLINE} LTRIM ACME_LOG 0 ${LOG_LINES}"
 catch_non_zero "${REDIS_CMDLINE} LTRIM POSTFIX_MAILLOG 0 ${LOG_LINES}"

--- a/data/Dockerfiles/dovecot/trim_logs.sh
+++ b/data/Dockerfiles/dovecot/trim_logs.sh
@@ -10,9 +10,9 @@ catch_non_zero() {
 source /source_env.sh
 # Do not attempt to write to slave
 if [[ ! -z ${REDIS_SLAVEOF_IP} ]]; then
-  REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS}"
+  REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS} --no-auth-warning"
 else
-  REDIS_CMDLINE="redis-cli -h redis -p 6379 -a ${REDISPASS}"
+  REDIS_CMDLINE="redis-cli -h redis -p 6379 -a ${REDISPASS} --no-auth-warning"
 fi
 catch_non_zero "${REDIS_CMDLINE} LTRIM ACME_LOG 0 ${LOG_LINES}"
 catch_non_zero "${REDIS_CMDLINE} LTRIM POSTFIX_MAILLOG 0 ${LOG_LINES}"

--- a/data/Dockerfiles/netfilter/main.py
+++ b/data/Dockerfiles/netfilter/main.py
@@ -106,7 +106,7 @@ def get_ip(address):
     ip = ip.ipv4_mapped
   if ip.is_private or ip.is_loopback:
     return False
-  
+
   return ip
 
 def ban(address):
@@ -434,9 +434,9 @@ if __name__ == '__main__':
       redis_slaveof_ip = os.getenv('REDIS_SLAVEOF_IP', '')
       redis_slaveof_port = os.getenv('REDIS_SLAVEOF_PORT', '')
       if "".__eq__(redis_slaveof_ip):
-        r = redis.StrictRedis(host=os.getenv('IPV4_NETWORK', '172.22.1') + '.249', decode_responses=True, port=6379, db=0)
+        r = redis.StrictRedis(host=os.getenv('IPV4_NETWORK', '172.22.1') + '.249', decode_responses=True, port=6379, db=0, password=os.environ['REDISPASS'])
       else:
-        r = redis.StrictRedis(host=redis_slaveof_ip, decode_responses=True, port=redis_slaveof_port, db=0)
+        r = redis.StrictRedis(host=redis_slaveof_ip, decode_responses=True, port=redis_slaveof_port, db=0, password=os.environ['REDISPASS'])
       r.ping()
       pubsub = r.pubsub()
     except Exception as ex:
@@ -452,7 +452,7 @@ if __name__ == '__main__':
   # clear bans in redis
   r.delete('F2B_ACTIVE_BANS')
   r.delete('F2B_PERM_BANS')
-  
+
   refreshF2boptions()
 
   watch_thread = Thread(target=watch)

--- a/data/Dockerfiles/phpfpm/docker-entrypoint.sh
+++ b/data/Dockerfiles/phpfpm/docker-entrypoint.sh
@@ -16,7 +16,7 @@ else
   REDIS_HOST="redis"
   REDIS_PORT="6379"
 fi
-REDIS_CMDLINE="redis-cli -h ${REDIS_HOST} -p ${REDIS_PORT}"
+REDIS_CMDLINE="redis-cli -h ${REDIS_HOST} -p ${REDIS_PORT} -a ${REDISPASS}"
 
 until [[ $(${REDIS_CMDLINE} PING) == "PONG" ]]; do
   echo "Waiting for Redis..."
@@ -26,7 +26,7 @@ done
 # Set redis session store
 echo -n '
 session.save_handler = redis
-session.save_path = "tcp://'${REDIS_HOST}':'${REDIS_PORT}'"
+session.save_path = "tcp://'${REDIS_HOST}':'${REDIS_PORT}'?auth='${REDISPASS}'"
 ' > /usr/local/etc/php/conf.d/session_store.ini
 
 # Check mysql_upgrade (master and slave)

--- a/data/Dockerfiles/phpfpm/docker-entrypoint.sh
+++ b/data/Dockerfiles/phpfpm/docker-entrypoint.sh
@@ -16,7 +16,7 @@ else
   REDIS_HOST="redis"
   REDIS_PORT="6379"
 fi
-REDIS_CMDLINE="redis-cli -h ${REDIS_HOST} -p ${REDIS_PORT} -a ${REDISPASS}"
+REDIS_CMDLINE="redis-cli -h ${REDIS_HOST} -p ${REDIS_PORT} -a ${REDISPASS} --no-auth-warning"
 
 until [[ $(${REDIS_CMDLINE} PING) == "PONG" ]]; do
   echo "Waiting for Redis..."

--- a/data/Dockerfiles/postfix/syslog-ng-redis_slave.conf
+++ b/data/Dockerfiles/postfix/syslog-ng-redis_slave.conf
@@ -20,6 +20,7 @@ destination d_redis_ui_log {
     host("`REDIS_SLAVEOF_IP`")
     persist-name("redis1")
     port(`REDIS_SLAVEOF_PORT`)
+    auth("`REDISPASS`")
     command("LPUSH" "POSTFIX_MAILLOG" "$(format-json time=\"$S_UNIXTIME\" priority=\"$PRIORITY\" program=\"$PROGRAM\" message=\"$MESSAGE\")\n")
   );
 };
@@ -28,6 +29,7 @@ destination d_redis_f2b_channel {
     host("`REDIS_SLAVEOF_IP`")
     persist-name("redis2")
     port(`REDIS_SLAVEOF_PORT`)
+    auth("`REDISPASS`")
     command("PUBLISH" "F2B_CHANNEL" "$(sanitize $MESSAGE)")
   );
 };

--- a/data/Dockerfiles/postfix/syslog-ng.conf
+++ b/data/Dockerfiles/postfix/syslog-ng.conf
@@ -20,6 +20,7 @@ destination d_redis_ui_log {
     host("redis-mailcow")
     persist-name("redis1")
     port(6379)
+    auth("`REDISPASS`")
     command("LPUSH" "POSTFIX_MAILLOG" "$(format-json time=\"$S_UNIXTIME\" priority=\"$PRIORITY\" program=\"$PROGRAM\" message=\"$MESSAGE\")\n")
   );
 };
@@ -28,6 +29,7 @@ destination d_redis_f2b_channel {
     host("redis-mailcow")
     persist-name("redis2")
     port(6379)
+    auth("`REDISPASS`")
     command("PUBLISH" "F2B_CHANNEL" "$(sanitize $MESSAGE)")
   );
 };

--- a/data/Dockerfiles/rspamd/docker-entrypoint.sh
+++ b/data/Dockerfiles/rspamd/docker-entrypoint.sh
@@ -56,27 +56,29 @@ if [[ ! -z ${REDIS_SLAVEOF_IP} ]]; then
   cat <<EOF > /etc/rspamd/local.d/redis.conf
 read_servers = "redis:6379";
 write_servers = "${REDIS_SLAVEOF_IP}:${REDIS_SLAVEOF_PORT}";
+password = "${REDISPASS}";
 timeout = 10;
 EOF
-  until [[ $(redis-cli -h redis-mailcow PING) == "PONG" ]]; do
+  until [[ $(redis-cli -h redis-mailcow -a ${REDISPASS} PING) == "PONG" ]]; do
     echo "Waiting for Redis @redis-mailcow..."
     sleep 2
   done
-  until [[ $(redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} PING) == "PONG" ]]; do
+  until [[ $(redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS} PING) == "PONG" ]]; do
     echo "Waiting for Redis @${REDIS_SLAVEOF_IP}..."
     sleep 2
   done
-  redis-cli -h redis-mailcow SLAVEOF ${REDIS_SLAVEOF_IP} ${REDIS_SLAVEOF_PORT}
+  redis-cli -h redis-mailcow -a ${REDISPASS} SLAVEOF ${REDIS_SLAVEOF_IP} ${REDIS_SLAVEOF_PORT}
 else
   cat <<EOF > /etc/rspamd/local.d/redis.conf
 servers = "redis:6379";
+password = "${REDISPASS}";
 timeout = 10;
 EOF
-  until [[ $(redis-cli -h redis-mailcow PING) == "PONG" ]]; do
+  until [[ $(redis-cli -h redis-mailcow -a ${REDISPASS} PING) == "PONG" ]]; do
     echo "Waiting for Redis slave..."
     sleep 2
   done
-  redis-cli -h redis-mailcow SLAVEOF NO ONE
+  redis-cli -h redis-mailcow -a ${REDISPASS} SLAVEOF NO ONE
 fi
 
 # Provide additional lua modules

--- a/data/Dockerfiles/rspamd/docker-entrypoint.sh
+++ b/data/Dockerfiles/rspamd/docker-entrypoint.sh
@@ -59,26 +59,26 @@ write_servers = "${REDIS_SLAVEOF_IP}:${REDIS_SLAVEOF_PORT}";
 password = "${REDISPASS}";
 timeout = 10;
 EOF
-  until [[ $(redis-cli -h redis-mailcow -a ${REDISPASS} PING) == "PONG" ]]; do
+  until [[ $(redis-cli -h redis-mailcow -a ${REDISPASS} --no-auth-warning PING) == "PONG" ]]; do
     echo "Waiting for Redis @redis-mailcow..."
     sleep 2
   done
-  until [[ $(redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS} PING) == "PONG" ]]; do
+  until [[ $(redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS} --no-auth-warning PING) == "PONG" ]]; do
     echo "Waiting for Redis @${REDIS_SLAVEOF_IP}..."
     sleep 2
   done
-  redis-cli -h redis-mailcow -a ${REDISPASS} SLAVEOF ${REDIS_SLAVEOF_IP} ${REDIS_SLAVEOF_PORT}
+  redis-cli -h redis-mailcow -a ${REDISPASS} --no-auth-warning SLAVEOF ${REDIS_SLAVEOF_IP} ${REDIS_SLAVEOF_PORT}
 else
   cat <<EOF > /etc/rspamd/local.d/redis.conf
 servers = "redis:6379";
 password = "${REDISPASS}";
 timeout = 10;
 EOF
-  until [[ $(redis-cli -h redis-mailcow -a ${REDISPASS} PING) == "PONG" ]]; do
+  until [[ $(redis-cli -h redis-mailcow -a ${REDISPASS} --no-auth-warning PING) == "PONG" ]]; do
     echo "Waiting for Redis slave..."
     sleep 2
   done
-  redis-cli -h redis-mailcow -a ${REDISPASS} SLAVEOF NO ONE
+  redis-cli -h redis-mailcow -a ${REDISPASS} --no-auth-warning SLAVEOF NO ONE
 fi
 
 # Provide additional lua modules

--- a/data/Dockerfiles/sogo/syslog-ng-redis_slave.conf
+++ b/data/Dockerfiles/sogo/syslog-ng-redis_slave.conf
@@ -22,6 +22,7 @@ destination d_redis_ui_log {
     host("`REDIS_SLAVEOF_IP`")
     persist-name("redis1")
     port(`REDIS_SLAVEOF_PORT`)
+    auth("`REDISPASS`")
     command("LPUSH" "SOGO_LOG" "$(format-json time=\"$S_UNIXTIME\" priority=\"$PRIORITY\" program=\"$PROGRAM\" message=\"$MESSAGE\")\n")
   );
 };
@@ -30,6 +31,7 @@ destination d_redis_f2b_channel {
     host("`REDIS_SLAVEOF_IP`")
     persist-name("redis2")
     port(`REDIS_SLAVEOF_PORT`)
+    auth("`REDISPASS`")
     command("PUBLISH" "F2B_CHANNEL" "$(sanitize $MESSAGE)")
   );
 };

--- a/data/Dockerfiles/sogo/syslog-ng.conf
+++ b/data/Dockerfiles/sogo/syslog-ng.conf
@@ -22,6 +22,7 @@ destination d_redis_ui_log {
     host("redis-mailcow")
     persist-name("redis1")
     port(6379)
+    auth("`REDISPASS`")
     command("LPUSH" "SOGO_LOG" "$(format-json time=\"$S_UNIXTIME\" priority=\"$PRIORITY\" program=\"$PROGRAM\" message=\"$MESSAGE\")\n")
   );
 };
@@ -30,6 +31,7 @@ destination d_redis_f2b_channel {
     host("redis-mailcow")
     persist-name("redis2")
     port(6379)
+    auth("`REDISPASS`")
     command("PUBLISH" "F2B_CHANNEL" "$(sanitize $MESSAGE)")
   );
 };

--- a/data/Dockerfiles/watchdog/watchdog.sh
+++ b/data/Dockerfiles/watchdog/watchdog.sh
@@ -40,9 +40,9 @@ done
 
 # Do not attempt to write to slave
 if [[ ! -z ${REDIS_SLAVEOF_IP} ]]; then
-  REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS}"
+  REDIS_CMDLINE="redis-cli -h ${REDIS_SLAVEOF_IP} -p ${REDIS_SLAVEOF_PORT} -a ${REDISPASS} --no-auth-warning"
 else
-  REDIS_CMDLINE="redis-cli -h redis -p 6379 -a ${REDISPASS}"
+  REDIS_CMDLINE="redis-cli -h redis -p 6379 -a ${REDISPASS} --no-auth-warning"
 fi
 
 until [[ $(${REDIS_CMDLINE} PING) == "PONG" ]]; do
@@ -503,12 +503,12 @@ dovecot_repl_checks() {
   err_count=0
   diff_c=0
   THRESHOLD=${DOVECOT_REPL_THRESHOLD}
-  D_REPL_STATUS=$(redis-cli -h redis -a ${REDISPASS} -r GET DOVECOT_REPL_HEALTH)
+  D_REPL_STATUS=$(redis-cli -h redis -a ${REDISPASS} --no-auth-warning -r GET DOVECOT_REPL_HEALTH)
   # Reduce error count by 2 after restarting an unhealthy container
   trap "[ ${err_count} -gt 1 ] && err_count=$(( ${err_count} - 2 ))" USR1
   while [ ${err_count} -lt ${THRESHOLD} ]; do
     err_c_cur=${err_count}
-    D_REPL_STATUS=$(redis-cli --raw -h redis -a ${REDISPASS} GET DOVECOT_REPL_HEALTH)
+    D_REPL_STATUS=$(redis-cli --raw -h redis -a ${REDISPASS} --no-auth-warning GET DOVECOT_REPL_HEALTH)
     if [[ "${D_REPL_STATUS}" != "1" ]]; then
       err_count=$(( ${err_count} + 1 ))
     fi
@@ -578,19 +578,19 @@ ratelimit_checks() {
   err_count=0
   diff_c=0
   THRESHOLD=${RATELIMIT_THRESHOLD}
-  RL_LOG_STATUS=$(redis-cli -h redis -a ${REDISPASS} LRANGE RL_LOG 0 0 | jq .qid)
+  RL_LOG_STATUS=$(redis-cli -h redis -a ${REDISPASS} --no-auth-warning LRANGE RL_LOG 0 0 | jq .qid)
   # Reduce error count by 2 after restarting an unhealthy container
   trap "[ ${err_count} -gt 1 ] && err_count=$(( ${err_count} - 2 ))" USR1
   while [ ${err_count} -lt ${THRESHOLD} ]; do
     err_c_cur=${err_count}
     RL_LOG_STATUS_PREV=${RL_LOG_STATUS}
-    RL_LOG_STATUS=$(redis-cli -h redis -a ${REDISPASS} LRANGE RL_LOG 0 0 | jq .qid)
+    RL_LOG_STATUS=$(redis-cli -h redis -a ${REDISPASS} --no-auth-warning LRANGE RL_LOG 0 0 | jq .qid)
     if [[ ${RL_LOG_STATUS_PREV} != ${RL_LOG_STATUS} ]]; then
       err_count=$(( ${err_count} + 1 ))
       echo 'Last 10 applied ratelimits (may overlap with previous reports).' > /tmp/ratelimit
       echo 'Full ratelimit buckets can be emptied by deleting the ratelimit hash from within mailcow UI (see /debug -> Protocols -> Ratelimit):' >> /tmp/ratelimit
       echo >> /tmp/ratelimit
-      redis-cli --raw -h redis -a ${REDISPASS} LRANGE RL_LOG 0 10 | jq . >> /tmp/ratelimit
+      redis-cli --raw -h redis -a ${REDISPASS} --no-auth-warning LRANGE RL_LOG 0 10 | jq . >> /tmp/ratelimit
     fi
     [ ${err_c_cur} -eq ${err_count} ] && [ ! $((${err_count} - 1)) -lt 0 ] && err_count=$((${err_count} - 1)) diff_c=1
     [ ${err_c_cur} -ne ${err_count} ] && diff_c=$(( ${err_c_cur} - ${err_count} ))
@@ -673,7 +673,7 @@ acme_checks() {
   err_count=0
   diff_c=0
   THRESHOLD=${ACME_THRESHOLD}
-  ACME_LOG_STATUS=$(redis-cli -h redis -a ${REDISPASS} GET ACME_FAIL_TIME)
+  ACME_LOG_STATUS=$(redis-cli -h redis -a ${REDISPASS} --no-auth-warning GET ACME_FAIL_TIME)
   if [[ -z "${ACME_LOG_STATUS}" ]]; then
     ${REDIS_CMDLINE} SET ACME_FAIL_TIME 0
     ACME_LOG_STATUS=0
@@ -685,7 +685,7 @@ acme_checks() {
     ACME_LOG_STATUS_PREV=${ACME_LOG_STATUS}
     ACME_LC=0
     until [[ ! -z ${ACME_LOG_STATUS} ]] || [ ${ACME_LC} -ge 3 ]; do
-      ACME_LOG_STATUS=$(redis-cli -h redis -a ${REDISPASS} GET ACME_FAIL_TIME 2> /dev/null)
+      ACME_LOG_STATUS=$(redis-cli -h redis -a ${REDISPASS} --no-auth-warning GET ACME_FAIL_TIME 2> /dev/null)
       sleep 3
       ACME_LC=$((ACME_LC+1))
     done

--- a/data/conf/redis/docker-entrypoint.sh
+++ b/data/conf/redis/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cat <<EOF > /redis.conf
+requirepass $REDISPASS
+EOF
+exec redis-server /redis.conf

--- a/data/conf/redis/redis-conf.sh
+++ b/data/conf/redis/redis-conf.sh
@@ -3,4 +3,5 @@
 cat <<EOF > /redis.conf
 requirepass $REDISPASS
 EOF
+
 exec redis-server /redis.conf

--- a/data/conf/rspamd/dynmaps/aliasexp.php
+++ b/data/conf/rspamd/dynmaps/aliasexp.php
@@ -25,6 +25,7 @@ catch (PDOException $e) {
 // Init Redis
 $redis = new Redis();
 $redis->connect('redis-mailcow', 6379);
+$redis->auth(getenv("REDISPASS"));
 
 function parse_email($email) {
   if(!filter_var($email, FILTER_VALIDATE_EMAIL)) return false;

--- a/data/conf/rspamd/dynmaps/forwardinghosts.php
+++ b/data/conf/rspamd/dynmaps/forwardinghosts.php
@@ -4,6 +4,7 @@ ini_set('error_reporting', 0);
 
 $redis = new Redis();
 $redis->connect('redis-mailcow', 6379);
+$redis->auth(getenv("REDISPASS"));
 
 function in_net($addr, $net) {
   $net = explode('/', $net);

--- a/data/conf/rspamd/meta_exporter/pipe.php
+++ b/data/conf/rspamd/meta_exporter/pipe.php
@@ -24,6 +24,7 @@ catch (PDOException $e) {
 // Init Redis
 $redis = new Redis();
 $redis->connect('redis-mailcow', 6379);
+$redis->auth(getenv("REDISPASS"));
 
 // Functions
 function parse_email($email) {
@@ -96,10 +97,10 @@ $rcpt_final_mailboxes = array();
 foreach (json_decode($rcpts, true) as $rcpt) {
   // Remove tag
   $rcpt = preg_replace('/^(.*?)\+.*(@.*)$/', '$1$2', $rcpt);
-  
+
   // Break rcpt into local part and domain part
   $parsed_rcpt = parse_email($rcpt);
-  
+
   // Skip if not a mailcow handled domain
   try {
     if (!$redis->hGet('DOMAIN_MAP', $parsed_rcpt['domain'])) {
@@ -243,7 +244,7 @@ foreach ($rcpt_final_mailboxes as $rcpt_final) {
         WHERE `rcpt` = :rcpt2
         ORDER BY id DESC
         LIMIT :retention_size
-      ) x 
+      ) x
     );');
     $stmt->execute(array(
       ':rcpt' => $rcpt_final,

--- a/data/conf/rspamd/meta_exporter/pipe_rl.php
+++ b/data/conf/rspamd/meta_exporter/pipe_rl.php
@@ -14,6 +14,7 @@ try {
   else {
     $redis->connect('redis-mailcow', 6379);
   }
+  $redis->auth(getenv("REDISPASS"));
 }
 catch (Exception $e) {
   exit;

--- a/data/conf/rspamd/meta_exporter/pushover.php
+++ b/data/conf/rspamd/meta_exporter/pushover.php
@@ -24,6 +24,7 @@ catch (PDOException $e) {
 // Init Redis
 $redis = new Redis();
 $redis->connect('redis-mailcow', 6379);
+$redis->auth(getenv("REDISPASS"));
 
 // Functions
 function parse_email($email) {

--- a/data/web/_rspamderror.php
+++ b/data/web/_rspamderror.php
@@ -7,6 +7,7 @@ try {
   else {
     $redis->connect('redis-mailcow', 6379);
   }
+  $redis->auth(getenv("REDISPASS"));
 }
 catch (Exception $e) {
   exit;

--- a/data/web/autodiscover.php
+++ b/data/web/autodiscover.php
@@ -16,6 +16,7 @@ try {
   else {
     $redis->connect('redis-mailcow', 6379);
   }
+  $redis->auth(getenv("REDISPASS"));
 }
 catch (Exception $e) {
   exit;

--- a/data/web/inc/prerequisites.inc.php
+++ b/data/web/inc/prerequisites.inc.php
@@ -68,6 +68,7 @@ try {
   else {
     $redis->connect('redis-mailcow', 6379);
   }
+  $redis->auth(getenv("REDISPASS"));
 }
 catch (Exception $e) {
 // Stop when redis is not available
@@ -321,7 +322,7 @@ $UI_TEXTS = customize('get', 'ui_texts');
 if (file_exists('/web/css/themes/'.$UI_THEME.'-bootstrap.css'))
   $css_minifier->add('/web/css/themes/'.$UI_THEME.'-bootstrap.css');
 else
-  $css_minifier->add('/web/css/themes/lumen-bootstrap.css'); 
+  $css_minifier->add('/web/css/themes/lumen-bootstrap.css');
 // minify css build files
 foreach ($css_dir as $css_file) {
   $css_minifier->add('/web/css/build/' . $css_file);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
 
     redis-mailcow:
       image: redis:7-alpine
+      command: '--requirepass ${REDISPASS}'
       volumes:
         - redis-vol-1:/data/
       restart: always
@@ -52,6 +53,7 @@ services:
         - "${REDIS_PORT:-127.0.0.1:7654}:6379"
       environment:
         - TZ=${TZ}
+        - REDISPASS=${REDISPASS}
       sysctls:
         - net.core.somaxconn=4096
       networks:
@@ -80,7 +82,7 @@ services:
             - clamd
 
     rspamd-mailcow:
-      image: mailcow/rspamd:1.98
+      image: mailcow/rspamd:1.99
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow
@@ -91,6 +93,7 @@ services:
         - IPV6_NETWORK=${IPV6_NETWORK:-fd4d:6169:6c63:6f77::/64}
         - REDIS_SLAVEOF_IP=${REDIS_SLAVEOF_IP:-}
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
+        - REDISPASS=${REDISPASS}
         - SPAMHAUS_DQS_KEY=${SPAMHAUS_DQS_KEY:-}
       volumes:
         - ./data/hooks/rspamd:/hooks:Z
@@ -112,7 +115,7 @@ services:
             - rspamd
 
     php-fpm-mailcow:
-      image: mailcow/phpfpm:1.91.1
+      image: mailcow/phpfpm:1.92
       command: "php-fpm -d date.timezone=${TZ} -d expose_php=0"
       depends_on:
         - redis-mailcow
@@ -139,6 +142,7 @@ services:
       environment:
         - REDIS_SLAVEOF_IP=${REDIS_SLAVEOF_IP:-}
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
+        - REDISPASS=${REDISPASS}
         - LOG_LINES=${LOG_LINES:-9999}
         - TZ=${TZ}
         - DBNAME=${DBNAME}
@@ -177,7 +181,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: mailcow/sogo:1.127.1
+      image: mailcow/sogo:1.128
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}
@@ -194,6 +198,7 @@ services:
         - MASTER=${MASTER:-y}
         - REDIS_SLAVEOF_IP=${REDIS_SLAVEOF_IP:-}
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
+        - REDISPASS=${REDISPASS}
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       volumes:
@@ -224,7 +229,7 @@ services:
             - sogo
 
     dovecot-mailcow:
-      image: mailcow/dovecot:2.2
+      image: mailcow/dovecot:2.21
       depends_on:
         - mysql-mailcow
         - netfilter-mailcow
@@ -266,6 +271,7 @@ services:
         - MASTER=${MASTER:-y}
         - REDIS_SLAVEOF_IP=${REDIS_SLAVEOF_IP:-}
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
+        - REDISPASS=${REDISPASS}
         - COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-mailcow-dockerized}
         - FLATCURVE_EXPERIMENTAL=${FLATCURVE_EXPERIMENTAL:-n}
       ports:
@@ -308,7 +314,7 @@ services:
             - dovecot
 
     postfix-mailcow:
-      image: mailcow/postfix:1.77
+      image: mailcow/postfix:1.78
       depends_on:
         mysql-mailcow:
           condition: service_started
@@ -330,6 +336,7 @@ services:
         - DBPASS=${DBPASS}
         - REDIS_SLAVEOF_IP=${REDIS_SLAVEOF_IP:-}
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
+        - REDISPASS=${REDISPASS}
         - MAILCOW_HOSTNAME=${MAILCOW_HOSTNAME}
         - SPAMHAUS_DQS_KEY=${SPAMHAUS_DQS_KEY:-}
       cap_add:
@@ -401,7 +408,7 @@ services:
           condition: service_started
         unbound-mailcow:
           condition: service_healthy
-      image: mailcow/acme:1.90
+      image: mailcow/acme:1.91
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       environment:
@@ -424,6 +431,7 @@ services:
         - TZ=${TZ}
         - REDIS_SLAVEOF_IP=${REDIS_SLAVEOF_IP:-}
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
+        - REDISPASS=${REDISPASS}
         - SNAT_TO_SOURCE=${SNAT_TO_SOURCE:-n}
         - SNAT6_TO_SOURCE=${SNAT6_TO_SOURCE:-n}
       volumes:
@@ -438,7 +446,7 @@ services:
             - acme
 
     netfilter-mailcow:
-      image: mailcow/netfilter:1.59
+      image: mailcow/netfilter:1.60
       stop_grace_period: 30s
       restart: always
       privileged: true
@@ -450,6 +458,7 @@ services:
         - SNAT6_TO_SOURCE=${SNAT6_TO_SOURCE:-n}
         - REDIS_SLAVEOF_IP=${REDIS_SLAVEOF_IP:-}
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
+        - REDISPASS=${REDISPASS}
         - MAILCOW_REPLICA_IP=${MAILCOW_REPLICA_IP:-}
         - DISABLE_NETFILTER_ISOLATION_RULE=${DISABLE_NETFILTER_ISOLATION_RULE:-n}
       network_mode: "host"
@@ -457,7 +466,7 @@ services:
         - /lib/modules:/lib/modules:ro
 
     watchdog-mailcow:
-      image: mailcow/watchdog:2.05
+      image: mailcow/watchdog:2.06
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       tmpfs:
@@ -503,6 +512,7 @@ services:
         - HTTPS_PORT=${HTTPS_PORT:-443}
         - REDIS_SLAVEOF_IP=${REDIS_SLAVEOF_IP:-}
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
+        - REDISPASS=${REDISPASS}
         - EXTERNAL_CHECKS_THRESHOLD=${EXTERNAL_CHECKS_THRESHOLD:-1}
         - NGINX_THRESHOLD=${NGINX_THRESHOLD:-5}
         - UNBOUND_THRESHOLD=${UNBOUND_THRESHOLD:-5}
@@ -528,7 +538,7 @@ services:
             - watchdog
 
     dockerapi-mailcow:
-      image: mailcow/dockerapi:2.09
+      image: mailcow/dockerapi:2.10
       security_opt:
         - label=disable
       restart: always
@@ -539,6 +549,7 @@ services:
         - TZ=${TZ}
         - REDIS_SLAVEOF_IP=${REDIS_SLAVEOF_IP:-}
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
+        - REDISPASS=${REDISPASS}
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock:ro
       networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,10 +43,10 @@ services:
 
     redis-mailcow:
       image: redis:7-alpine
-      entrypoint: /docker-entrypoint.sh
+      entrypoint: /redis-conf.sh
       volumes:
         - redis-vol-1:/data/
-        - ./data/conf/redis/docker-entrypoint.sh:/docker-entrypoint.sh:z
+        - ./data/conf/redis/redis-conf.sh:/redis-conf.sh:z
       restart: always
       depends_on:
         - netfilter-mailcow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,9 +43,10 @@ services:
 
     redis-mailcow:
       image: redis:7-alpine
-      command: '--requirepass ${REDISPASS}'
+      entrypoint: /docker-entrypoint.sh
       volumes:
         - redis-vol-1:/data/
+        - ./data/conf/redis/docker-entrypoint.sh:/docker-entrypoint.sh:z
       restart: always
       depends_on:
         - netfilter-mailcow

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -43,7 +43,7 @@ if docker compose > /dev/null 2>&1; then
       sleep 2
       echo -e "\e[33mNotice: You'll have to update this Compose Version via your Package Manager manually!\e[0m"
     else
-      echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m" 
+      echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m"
       echo -e "\e[31mPlease update/install it manually regarding to this doc site: https://docs.mailcow.email/install/\e[0m"
       exit 1
     fi
@@ -56,14 +56,14 @@ elif docker-compose > /dev/null 2>&1; then
       sleep 2
       echo -e "\e[33mNotice: For an automatic update of docker-compose please use the update_compose.sh scripts located at the helper-scripts folder.\e[0m"
     else
-      echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m" 
+      echo -e "\e[31mCannot find Docker Compose with a Version Higher than 2.X.X.\e[0m"
       echo -e "\e[31mPlease update/install manually regarding to this doc site: https://docs.mailcow.email/install/\e[0m"
       exit 1
     fi
   fi
 
 else
-  echo -e "\e[31mCannot find Docker Compose.\e[0m" 
+  echo -e "\e[31mCannot find Docker Compose.\e[0m"
   echo -e "\e[31mPlease install it regarding to this doc site: https://docs.mailcow.email/install/\e[0m"
   exit 1
 fi
@@ -229,7 +229,7 @@ else
   echo -e "\033[31mCould not determine branch input..."
   echo -e "\033[31mExiting."
   exit 1
-fi  
+fi
 
 if [ ! -z "${MAILCOW_BRANCH}" ]; then
   git_branch=${MAILCOW_BRANCH}
@@ -263,6 +263,12 @@ DBUSER=mailcow
 
 DBPASS=$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 2> /dev/null | head -c 28)
 DBROOT=$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 2> /dev/null | head -c 28)
+
+# ------------------------------
+# REDIS configuration
+# ------------------------------
+
+REDISPASS=$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 2> /dev/null | head -c 28)
 
 # ------------------------------
 # HTTP/S Bindings
@@ -510,7 +516,7 @@ WEBAUTHN_ONLY_TRUSTED_VENDORS=n
 
 # Spamhaus Data Query Service Key
 # Optional: Leave empty for none
-# Enter your key here if you are using a blocked ASN (OVH, AWS, Cloudflare e.g) for the unregistered Spamhaus Blocklist. 
+# Enter your key here if you are using a blocked ASN (OVH, AWS, Cloudflare e.g) for the unregistered Spamhaus Blocklist.
 # If empty, it will completely disable Spamhaus blocklists if it detects that you are running on a server using a blocked AS.
 # Otherwise it will work normally.
 SPAMHAUS_DQS_KEY=

--- a/helper-scripts/_cold-standby.sh
+++ b/helper-scripts/_cold-standby.sh
@@ -204,7 +204,7 @@ fi
 
 # Trigger a Redis save for a consistent Redis copy
 echo -ne "\033[1mRunning redis-cli save... \033[0m"
-docker exec $(docker ps -qf name=redis-mailcow) redis-cli -a ${REDISPASS} save
+docker exec $(docker ps -qf name=redis-mailcow) redis-cli -a ${REDISPASS} --no-auth-warning save
 
 # Syncing volumes related to compose project
 # Same here: make sure destination exists

--- a/helper-scripts/_cold-standby.sh
+++ b/helper-scripts/_cold-standby.sh
@@ -150,7 +150,7 @@ else
   exit 1
 fi
 
- REMOTE_ARCH=$(ssh -o StrictHostKeyChecking=no -i "${REMOTE_SSH_KEY}" ${REMOTE_SSH_HOST} -p ${REMOTE_SSH_PORT} "uname -m") 
+ REMOTE_ARCH=$(ssh -o StrictHostKeyChecking=no -i "${REMOTE_SSH_KEY}" ${REMOTE_SSH_HOST} -p ${REMOTE_SSH_PORT} "uname -m")
 
 }
 
@@ -204,7 +204,7 @@ fi
 
 # Trigger a Redis save for a consistent Redis copy
 echo -ne "\033[1mRunning redis-cli save... \033[0m"
-docker exec $(docker ps -qf name=redis-mailcow) redis-cli save
+docker exec $(docker ps -qf name=redis-mailcow) redis-cli -a ${REDISPASS} save
 
 # Syncing volumes related to compose project
 # Same here: make sure destination exists

--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -119,7 +119,7 @@ function backup() {
         ${DEBIAN_DOCKER_IMAGE} /bin/tar --warning='no-file-ignored' --use-compress-program="pigz --rsyncable -p ${THREADS}" -Pcvpf /backup/backup_crypt.tar.gz /crypt
       ;;&
     redis|all)
-      docker exec $(docker ps -qf name=redis-mailcow) redis-cli save
+      docker exec $(docker ps -qf name=redis-mailcow) redis-cli -a ${REDISPASS} save
       docker run --name mailcow-backup --rm \
         -v ${BACKUP_LOCATION}/mailcow-${DATE}:/backup:z \
         -v $(docker volume ls -qf name=^${CMPS_PRJ}_redis-vol-1$):/redis:ro,z \

--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -119,7 +119,7 @@ function backup() {
         ${DEBIAN_DOCKER_IMAGE} /bin/tar --warning='no-file-ignored' --use-compress-program="pigz --rsyncable -p ${THREADS}" -Pcvpf /backup/backup_crypt.tar.gz /crypt
       ;;&
     redis|all)
-      docker exec $(docker ps -qf name=redis-mailcow) redis-cli -a ${REDISPASS} save
+      docker exec $(docker ps -qf name=redis-mailcow) redis-cli -a ${REDISPASS} --no-auth-warning save
       docker run --name mailcow-backup --rm \
         -v ${BACKUP_LOCATION}/mailcow-${DATE}:/backup:z \
         -v $(docker volume ls -qf name=^${CMPS_PRJ}_redis-vol-1$):/redis:ro,z \

--- a/helper-scripts/nextcloud.sh
+++ b/helper-scripts/nextcloud.sh
@@ -101,7 +101,7 @@ if [[ ${NC_PURGE} == "y" ]]; then
     echo -e "\033[33mNot purging anything...\033[0m"
     exit 1
   fi
-  docker exec -it $(docker ps -f name=redis-mailcow -q) /bin/sh -c "cat <<EOF | redis-cli -a ${REDISPASS}
+  docker exec -it $(docker ps -f name=redis-mailcow -q) /bin/sh -c "cat <<EOF | redis-cli -a ${REDISPASS} --no-auth-warning
 SELECT 10
 FLUSHDB
 EOF

--- a/helper-scripts/nextcloud.sh
+++ b/helper-scripts/nextcloud.sh
@@ -101,11 +101,11 @@ if [[ ${NC_PURGE} == "y" ]]; then
     echo -e "\033[33mNot purging anything...\033[0m"
     exit 1
   fi
-  docker exec -it $(docker ps -f name=redis-mailcow -q) /bin/sh -c ' cat <<EOF | redis-cli
+  docker exec -it $(docker ps -f name=redis-mailcow -q) /bin/sh -c "cat <<EOF | redis-cli -a ${REDISPASS}
 SELECT 10
 FLUSHDB
 EOF
-'
+"
   if [ -d ./data/web/nextcloud/config ]; then
     mv ./data/web/nextcloud/config/ ./data/conf/nextcloud-config-folder-$(date +%s).bak
   fi

--- a/helper-scripts/reset-learns.sh
+++ b/helper-scripts/reset-learns.sh
@@ -15,15 +15,15 @@ if [[ "$response" =~ ^(yes|y)$ ]]; then
     docker stop ${RSPAMD_ID}
     echo "LUA will return nil when it succeeds or print a warning/error when it fails."
     echo "Deleting all RS* keys - if any"
-    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'RS*'
+    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} --no-auth-warning EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'RS*'
     echo "Deleting all BAYES* keys - if any"
-    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'BAYES*'
+    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} --no-auth-warning EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'BAYES*'
     echo "Deleting all learned* keys - if any"
-    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'learned*'
+    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} --no-auth-warning EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'learned*'
     echo "Deleting all fuzzy* keys - if any"
-    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'fuzzy*'
+    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} --no-auth-warning EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'fuzzy*'
     echo "Deleting all tRFANN* keys - if any"
-    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'tRFANN*'
+    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} --no-auth-warning EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'tRFANN*'
     echo "Starting Rspamd container"
     docker start ${RSPAMD_ID}
   fi

--- a/helper-scripts/reset-learns.sh
+++ b/helper-scripts/reset-learns.sh
@@ -15,15 +15,15 @@ if [[ "$response" =~ ^(yes|y)$ ]]; then
     docker stop ${RSPAMD_ID}
     echo "LUA will return nil when it succeeds or print a warning/error when it fails."
     echo "Deleting all RS* keys - if any"
-    docker exec -it ${REDIS_ID} redis-cli EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'RS*'
+    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'RS*'
     echo "Deleting all BAYES* keys - if any"
-    docker exec -it ${REDIS_ID} redis-cli EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'BAYES*'
+    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'BAYES*'
     echo "Deleting all learned* keys - if any"
-    docker exec -it ${REDIS_ID} redis-cli EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'learned*'
+    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'learned*'
     echo "Deleting all fuzzy* keys - if any"
-    docker exec -it ${REDIS_ID} redis-cli EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'fuzzy*'
+    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'fuzzy*'
     echo "Deleting all tRFANN* keys - if any"
-    docker exec -it ${REDIS_ID} redis-cli EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'tRFANN*'
+    docker exec -it ${REDIS_ID} redis-cli -a ${REDISPASS} EVAL "for _,k in ipairs(redis.call('keys', ARGV[1])) do redis.call('del', k) end" 0 'tRFANN*'
     echo "Starting Rspamd container"
     docker start ${RSPAMD_ID}
   fi

--- a/update.sh
+++ b/update.sh
@@ -540,6 +540,7 @@ CONFIG_ARRAY=(
   "SPAMHAUS_DQS_KEY"
   "SKIP_UNBOUND_HEALTHCHECK"
   "DISABLE_NETFILTER_ISOLATION_RULE"
+  "REDISPASS"
 )
 
 detect_bad_asn
@@ -831,6 +832,14 @@ for option in "${CONFIG_ARRAY[@]}"; do
       echo '# Prevent netfilter from setting an iptables/nftables rule to isolate the mailcow docker network - y/n' >> mailcow.conf
       echo '# CAUTION: Disabling this may expose container ports to other neighbors on the same subnet, even if the ports are bound to localhost' >> mailcow.conf
       echo 'DISABLE_NETFILTER_ISOLATION_RULE=n' >> mailcow.conf
+    fi
+  elif [[ "${option}" == "REDISPASS" ]]; then
+    if ! grep -q "${option}" mailcow.conf; then
+      echo "Adding new option \"${option}\" to mailcow.conf"
+      echo -e '\n# ------------------------------' >> mailcow.conf
+      echo '# REDIS configuration' >> mailcow.conf
+      echo -e '# ------------------------------\n' >> mailcow.conf
+      echo "REDISPASS=$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 2> /dev/null | head -c 28)" >> mailcow.conf
     fi
   elif ! grep -q "${option}" mailcow.conf; then
     echo "Adding new option \"${option}\" to mailcow.conf"


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Secure Redis with a password

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

- Rspamd
- PHPFPM
- SOGo
- Dovecot
- Postfix
- Acme
- Netfilter
- Watchdog
- DockerApi

## Did you run tests?

Yes

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
- Tested successful logging to Redis for SOGo, Postfix, and Dovecot by verifying logs in the mailcow UI.
- Confirmed that quota and quarantine notifications are triggered successfully.
- Verified that Netfilter and DockerAPI start successfully and can subscribe to Redis Pub/Sub.
- Checked that PHPFPM can read and write to Redis, and sessions are stored successfully.
- Checked that Acme can successfully request a certificate.
- Verified that Watchdog reports Redis as healthy.

### What were the final results? (Awaited, got)

The result was that each changed component could still successfully connect to Redis with the password.
