### PR TITLE
Add backwards compatibility for old dns_blocklists.cf files

### DIFF
--- a/data/Dockerfiles/postfix/postfix.sh
+++ b/data/Dockerfiles/postfix/postfix.sh
@@ -417,7 +417,7 @@ postscreen_dnsbl_sites = wl.mailspike.net=127.0.0.[18;19;20]*-2
   bl.mailspike.net=127.0.0.[10;11;12]*4
 EOF
 fi
-DNSBL_CONFIG=$(grep -v '^#' /opt/postfix/conf/dns_blocklists.cf | grep '\S')
+DNSBL_CONFIG=$(grep -v '^[[:space:]]*#' /opt/postfix/conf/dns_blocklists.cf | grep '\S' | sed 's/^[[:space:]]*postscreen_dnsbl_sites/postscreen_dnsbl_sites/')
 
 if [ ! -z "$DNSBL_CONFIG" ]; then
   echo -e "\e[33mChecking if ASN for your IP is listed for Spamhaus Bad ASN List...\e[0m"


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [ X ] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Some people had problems with the latest mailcow release (2024-11, see https://community.mailcow.email/d/4244-i-no-longer-receive-emails-and-i-no-longer-send-emails). The reason for the problems was an older version of data/conf/postfix/dns_blocklists.cf which was created with another indentation than the currently used one.
A new Postfix config line was introduced in https://github.com/mailcow/mailcow-dockerized/commit/c53bf85480697c24912214bf74a1718a73052a06 which led to erroneous parsing due to the indentation and resulting in this error:

```
bad numerical configuration: lmtp_destination_recipient_limit = 1 postscreen_dnsbl_sites = wl.mailspike.net=127.0.0.[18;19;20]-2 hostkarma.junkemailfilter.com=127.0.0.1-2 list.dnswl.org=127.0.[0..255].0-2 list.dnswl.org=127.0.[0..255].1-4 list.dnswl.org=127.0.[0..255].2-6 list.dnswl.org=127.0.[0..255].3-8 ix.dnsbl.manitu.net2 bl.spamcop.net2 bl.suomispam.net2 hostkarma.junkemailfilter.com=127.0.0.23 hostkarma.junkemailfilter.com=127.0.0.42 hostkarma.junkemailfilter.com=127.0.1.21 backscatter.spameatingmonkey.net2 bl.ipv6.spameatingmonkey.net2 bl.spameatingmonkey.net2 b.barracudacentral.org=127.0.0.27 bl.mailspike.net=127.0.0.25 bl.mailspike.net=127.0.0.[10;11;12]4 dnsbl.sorbs.net=127.0.0.108 dnsbl.sorbs.net=127.0.0.56 dnsbl.sorbs.net=127.0.0.73 dnsbl.sorbs.net=127.0.0.82 dnsbl.sorbs.net=127.0.0.62 dnsbl.sorbs.net=127.0.0.92 zen.spamhaus.org=127.0.0.[10;11]8 zen.spamhaus.org=127.0.0.[4..7]6 zen.spamhaus.org=127.0.0.34 zen.spamhaus.org=127.0.0.23 zen.spamhaus.org=127.0.0.[10;11]8 zen.spamhaus.org=127.0.0.[4..7]6 zen.spamhaus.org=127.0.0.34 zen.spamhaus.org=127.0.0.23
```
Due to the indentation of data/conf/postfix/dns_blocklists.cf the content was added to the lmtp_destination_recipient_limit parameter, leading to the error.

The fix strips the whitespaces at the beginning of the line containing "postscreen_dnsbl_sites" to restore a proper indentation.

###  Affected Containers

- postfix


## Did you run tests?

Yes

### What did you tested?

Edited /opt/postfix.sh inside the container to apply my new command, tested multiple variants of the dns_blocklists.cf file

### What were the final results? (Awaited, got)

The indentation was corrected.

Before:
```
root@b01960898244:/# postconf -c /opt/postfix/conf/ | grep lmtp_destination_recipient_limit
lmtp_destination_recipient_limit = 1 postscreen_dnsbl_sites = wl.mailspike.net=127.0.0.[18;19;20]*-2 hostkarma.junkemailfilter.com=127.0.0.1*-2 list.dnswl.org=127.0.[0..255].0*-2 list.dnswl.org=127.0.[0..255].1*-4 list.dnswl.org=127.0.[0..255].2*-6 list.dnswl.org=127.0.[0..255].3*-8 ix.dnsbl.manitu.net*2 bl.spamcop.net*2 bl.suomispam.net*2 hostkarma.junkemailfilter.com=127.0.0.2*3 hostkarma.junkemailfilter.com=127.0.0.4*2 hostkarma.junkemailfilter.com=127.0.1.2*1 backscatter.spameatingmonkey.net*2 bl.ipv6.spameatingmonkey.net*2 bl.spameatingmonkey.net*2 b.barracudacentral.org=127.0.0.2*7 bl.mailspike.net=127.0.0.2*5 bl.mailspike.net=127.0.0.[10;11;12]*4 dnsbl.sorbs.net=127.0.0.10*8 dnsbl.sorbs.net=127.0.0.5*6 dnsbl.sorbs.net=127.0.0.7*3 dnsbl.sorbs.net=127.0.0.8*2 dnsbl.sorbs.net=127.0.0.6*2 dnsbl.sorbs.net=127.0.0.9*2 zen.spamhaus.org=127.0.0.[10;11]*8 zen.spamhaus.org=127.0.0.[4..7]*6 zen.spamhaus.org=127.0.0.3*4 zen.spamhaus.org=127.0.0.2*3 zen.spamhaus.org=127.0.0.[10;11]*8 zen.spamhaus.org=127.0.0.[4..7]*6 zen.spamhaus.org=127.0.0.3*4 zen.spamhaus.org=127.0.0.2*3

root@b01960898244:/# postconf -c /opt/postfix/conf/ | grep postscreen_dnsbl_sites 
postscreen_dnsbl_sites =
```
After:
```
root@b01960898244:/# postconf -c /opt/postfix/conf/ | grep lmtp_destination_recipient_limit
lmtp_destination_recipient_limit = 1 

root@b01960898244:/# postconf -c /opt/postfix/conf/ | grep postscreen_dnsbl_sites 
postscreen_dnsbl_sites = wl.mailspike.net=127.0.0.[18;19;20]*-2 hostkarma.junkemailfilter.com=127.0.0.1*-2 list.dnswl.org=127.0.[0..255].0*-2 list.dnswl.org=127.0.[0..255].1*-4 list.dnswl.org=127.0.[0..255].2*-6 list.dnswl.org=127.0.[0..255].3*-8 ix.dnsbl.manitu.net*2 bl.spamcop.net*2 bl.suomispam.net*2 hostkarma.junkemailfilter.com=127.0.0.2*3 hostkarma.junkemailfilter.com=127.0.0.4*2 hostkarma.junkemailfilter.com=127.0.1.2*1 backscatter.spameatingmonkey.net*2 bl.ipv6.spameatingmonkey.net*2 bl.spameatingmonkey.net*2 b.barracudacentral.org=127.0.0.2*7 bl.mailspike.net=127.0.0.2*5 bl.mailspike.net=127.0.0.[10;11;12]*4 dnsbl.sorbs.net=127.0.0.10*8 dnsbl.sorbs.net=127.0.0.5*6 dnsbl.sorbs.net=127.0.0.7*3 dnsbl.sorbs.net=127.0.0.8*2 dnsbl.sorbs.net=127.0.0.6*2 dnsbl.sorbs.net=127.0.0.9*2 zen.spamhaus.org=127.0.0.[10;11]*8 zen.spamhaus.org=127.0.0.[4..7]*6 zen.spamhaus.org=127.0.0.3*4 zen.spamhaus.org=127.0.0.2*3 zen.spamhaus.org=127.0.0.[10;11]*8 zen.spamhaus.org=127.0.0.[4..7]*6 zen.spamhaus.org=127.0.0.3*4 zen.spamhaus.org=127.0.0.2*3
```