### PR TITLE
Introducing mailcow Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Translation status](https://translate.mailcow.email/widgets/mailcow-dockerized/-/translation/svg-badge.svg)](https://translate.mailcow.email/engage/mailcow-dockerized/)
 [![Twitter URL](https://img.shields.io/twitter/url/https/twitter.com/mailcow_email.svg?style=social&label=Follow%20%40mailcow_email)](https://twitter.com/mailcow_email)
 ![Mastodon Follow](https://img.shields.io/mastodon/follow/109388212176073348?domain=https%3A%2F%2Fmailcow.social&label=Follow%20%40doncow%40mailcow.social&link=https%3A%2F%2Fmailcow.social%2F%40doncow)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20mailcow%20Guru-006BFF)](https://gurubase.io/g/mailcow)
 
 
 ## Want to support mailcow?


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [mailcow Guru](https://gurubase.io/g/mailcow) to Gurubase. mailcow Guru uses the data from this repo and data from the [docs](https://docs.mailcow.email/) to answer questions by leveraging the LLM.

In this PR, I showcased the "mailcow Guru", which highlights that mailcow now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable mailcow Guru in Gurubase, just let me know that's totally fine.
