### PR TITLE
[Web] broadcast maildir move to dovecot containers on mailbox_rename

### DIFF
--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -3351,7 +3351,12 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             'old_maildir' => $domain . '/' . $old_local_part,
             'new_maildir' => $domain . '/' . $new_local_part
           );
-          docker('post', 'dovecot-mailcow', 'exec', $exec_fields);
+          if (getenv("CLUSTERMODE") == "replication") {
+            // broadcast to each dovecot container
+            docker('broadcast', 'dovecot-mailcow', 'exec', $exec_fields);
+          } else {
+            docker('post', 'dovecot-mailcow', 'exec', $exec_fields);
+          }
 
           // rename username in sogo
           $exec_fields = array(


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->
Ensure that the Maildir is moved on both mailcow nodes after a mailbox has been renamed.

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
- PHP-FPM

## Did you run tests?

Yes

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
I verified that the Maildir was moved on both mailcow nodes in the cluster.

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->
After renaming a mailbox, the maildir was moved on both Mailcow nodes.