### PR TITLE
[Web] remove f2b banlist from json_api.php

### DIFF
--- a/data/web/admin.php
+++ b/data/web/admin.php
@@ -104,7 +104,7 @@ $template_data = [
   'all_domains' => $all_domains,
   'mailboxes' => $mailboxes,
   'f2b_data' => $f2b_data,
-  'f2b_banlist_url' => getBaseUrl() . "/api/v1/get/fail2ban/banlist/" . $f2b_data['banlist_id'],
+  'f2b_banlist_url' => getBaseUrl() . "/f2b-banlist?id=" . $f2b_data['banlist_id'],
   'q_data' => quarantine('settings'),
   'qn_data' => quota_notification('get'),
   'pw_reset_data' => reset_password('get_notification'),

--- a/data/web/f2b-banlist.php
+++ b/data/web/f2b-banlist.php
@@ -1,0 +1,11 @@
+<?php
+
+require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
+
+if (isset($_GET['id'])) {
+    header('Content-Type: text/plain');
+    echo fail2ban('banlist', 'get', $_GET['id']);
+} else {
+    header('HTTP/1.1 404 Not Found');
+    exit;
+}

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -510,16 +510,6 @@ if (isset($_GET['query'])) {
           $_SESSION['challenge'] = $WebAuthn->getChallenge();
           return;
         break;
-        case "fail2ban":
-          if (!isset($_SESSION['mailcow_cc_role'])){
-            switch ($object) {
-              case 'banlist':
-                header('Content-Type: text/plain');
-                echo fail2ban('banlist', 'get', $extra);
-              break;
-            }
-          }
-        break;
       }
       if (isset($_SESSION['mailcow_cc_role'])) {
         switch ($category) {
@@ -1420,10 +1410,6 @@ if (isset($_GET['query'])) {
           break;
           case "fail2ban":
             switch ($object) {
-              case 'banlist':
-                header('Content-Type: text/plain');
-                echo fail2ban('banlist', 'get', $extra);
-              break;
               default:
                 $data = fail2ban('get');
                 process_get_return($data);

--- a/data/web/templates/admin/tab-config-f2b.twig
+++ b/data/web/templates/admin/tab-config-f2b.twig
@@ -99,7 +99,7 @@
       {% endif %}
       <form class="form-inline" data-id="f2b_banlist" role="form" method="post">
         <div class="input-group mb-3">
-          <input type="text" class="form-control" aria-label="Banlist url" value="{{ f2b_banlist_url}}" id="banlist_url">
+          <input type="text" class="form-control" aria-label="Banlist url" value="{{ f2b_banlist_url }}" id="banlist_url">
           {% if is_https %}
           <button class="btn btn-secondary" type="button" onclick="copyToClipboard('banlist_url')"><i class="bi bi-clipboard"></i></button>
           {% endif %}

--- a/update.sh
+++ b/update.sh
@@ -299,7 +299,7 @@ fix_broken_dnslist_conf() {
         echo -e "\e[35mOk, not deleting it! Please make sure you take a look at postfix upon start then..."
         return 2
       fi
-  fi  
+  fi
 
 }
 


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->
Move the `f2b-banlist` endpoint from `json_api.php` to a separate PHP file to ensure the correct Content-Type (`text/plain`) is sent.  
Resolves https://github.com/mailcow/mailcow-dockerized/issues/6089

**Admins using this feature will need to update the `f2b-banlist` URL after applying this update!**

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
- PHP-FPM

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
I checked that the new `f2b-banlist` link appears as `/f2b-banlist?id=<ID>` and that the correct Content-Type is being sent.

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->
I verified that the correct Content-Type `text/plain` is sent when navigating to `/f2b-banlist?id=<ID>`.