### PR TITLE
mysql: increased thread_stack to 192k for mariadb 10.5.27

### DIFF
--- a/data/conf/mysql/my.cnf
+++ b/data/conf/mysql/my.cnf
@@ -20,7 +20,7 @@ thread_cache_size       = 8
 query_cache_type        = 0
 query_cache_size        = 0
 max_heap_table_size     = 48M
-thread_stack            = 128K
+thread_stack            = 192K
 skip-host-cache
 skip-name-resolve
 log-warnings            = 0


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR fixes #6171 for new mailcow instances using versions of mysql newer than 10.5.27.

###  Affected Containers

- mysql-mailcow

## Did you run tests?

### What did you tested?

I've tested the mailcow startup for fresh mailcow and existing mailcows.

### What were the final results? (Awaited, got)

mailcow is starting up normally, the mysql database is getting properly created upon first boot. existing databases were not affected.