### PR TITLE
[Web] add missing translation for ratelimit in templates overview

### DIFF
--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -693,8 +693,8 @@ jQuery(function($){
             } else if (item.attributes.rl_frame === "d"){
               item.attributes.rl_frame = lang_rl.day;
             }
-            item.attributes.rl_value = escapeHtml(item.attributes.rl_value);
-
+            item.attributes.rl_value = (!item.attributes.rl_value) ? "∞" : escapeHtml(item.attributes.rl_value);
+            item.attributes.ratelimit = item.attributes.rl_value + " " + item.attributes.rl_frame;
 
             if (item.template.toLowerCase() == "default"){
               item.action = '<div class="btn-group">' +
@@ -818,14 +818,8 @@ jQuery(function($){
           }
         },
         {
-          title: 'rl_frame',
-          data: 'attributes.rl_frame',
-          defaultContent: '',
-          class: 'none',
-        },
-        {
-          title: 'rl_value',
-          data: 'attributes.rl_value',
+          title: lang_edit.ratelimit,
+          data: 'attributes.ratelimit',
           defaultContent: '',
           class: 'none',
         },
@@ -1183,7 +1177,8 @@ jQuery(function($){
             } else if (item.attributes.rl_frame === "d"){
               item.attributes.rl_frame = lang_rl.day;
             }
-            item.attributes.rl_value = escapeHtml(item.attributes.rl_value);
+            item.attributes.rl_value = (!item.attributes.rl_value) ? "∞" : escapeHtml(item.attributes.rl_value);
+            item.attributes.ratelimit = item.attributes.rl_value + " " + item.attributes.rl_frame;
 
             item.attributes.quota = humanFileSize(item.attributes.quota);
 
@@ -1328,14 +1323,8 @@ jQuery(function($){
           }
         },
         {
-          title: "rl_frame",
-          data: 'attributes.rl_frame',
-          defaultContent: '',
-          class: 'none',
-        },
-        {
-          title: 'rl_value',
-          data: 'attributes.rl_value',
+          title: lang_edit.ratelimit,
+          data: 'attributes.ratelimit',
           defaultContent: '',
           class: 'none',
         },

--- a/data/web/mailbox.php
+++ b/data/web/mailbox.php
@@ -41,6 +41,7 @@ $template_data = [
   'mailboxes' => $mailboxes,
   'lang_mailbox' => json_encode($lang['mailbox']),
   'lang_rl' => json_encode($lang['ratelimit']),
+  'lang_edit' => json_encode($lang['edit']),
   'lang_datatables' => json_encode($lang['datatables']),
 ];
 

--- a/data/web/templates/mailbox.twig
+++ b/data/web/templates/mailbox.twig
@@ -68,6 +68,7 @@
   var acl = '{{ acl_json|raw }}';
   var lang = {{ lang_mailbox|raw }};
   var lang_rl = {{ lang_rl|raw }};
+  var lang_edit = {{ lang_edit|raw }};
   var lang_datatables = {{ lang_datatables|raw }};
   var csrf_token = '{{ csrf_token }}';
   var pagination_size = Math.trunc('{{ pagination_size }}');


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->
Add missing translation for ratelimit in domain and mailbox template overview
Resolves https://github.com/mailcow/mailcow-dockerized/issues/6046

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
- PHP-FPM

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
Checked if the ratelimit is displayed with correct translation

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->
The rate limit value is now displayed with the correct label. I reused an existing language string, so the translation was already in place.