### PR TITLE
[Web] allow dots in dkim selectors

### DIFF
--- a/data/web/inc/functions.dkim.inc.php
+++ b/data/web/inc/functions.dkim.inc.php
@@ -26,7 +26,7 @@ function dkim($_action, $_data = null, $privkey = false) {
           );
           continue;
         }
-        if (!ctype_alnum(str_replace(['-', '_'], '', $dkim_selector))) {
+        if (!ctype_alnum(str_replace(['-', '_', '.'], '', $dkim_selector))) {
           $_SESSION['return'][] = array(
             'type' => 'danger',
             'log' => array(__FUNCTION__, $_action, $_data),
@@ -188,7 +188,7 @@ function dkim($_action, $_data = null, $privkey = false) {
           return false;
         }
       }
-      if (!ctype_alnum($dkim_selector)) {
+      if (!ctype_alnum(str_replace(['-', '_', '.'], '', $dkim_selector))) {
         $_SESSION['return'][] = array(
           'type' => 'danger',
           'log' => array(__FUNCTION__, $_action, $_data),


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->
When adding or importing DKIM keys via the UI, dots weren't allowed in the DKIM selector.
This PR allows the use of dots in DKIM selectors.

Resolves https://github.com/mailcow/mailcow-dockerized/issues/4518

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
- PHP-FPM

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
I've added a domain with the DKIM selector `dkim.test`.

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->
The DKIM key was successfully added, and emails were correctly signed with the key.