### PR TITLE
Implement search mailboxes by fullname

### DIFF
--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -1067,9 +1067,10 @@ if (isset($_GET['query'])) {
                   ['db' => 'last_mail_login', 'dt' => 4, 'dummy' => true, 'order_subquery' => "SELECT MAX(`datetime`) FROM `sasl_log` WHERE `service` != 'SSO' AND `username` = `m`.`username`"],
                   ['db' => 'last_pw_change', 'dt' => 5, 'dummy' => true, 'order_subquery' => "JSON_EXTRACT(attributes, '$.passwd_update')"],
                   ['db' => 'in_use', 'dt' => 6, 'dummy' => true, 'order_subquery' => "(SELECT SUM(bytes) FROM `quota2` WHERE `quota2`.`username` = `m`.`username`) / `m`.`quota`"],
+                  ['db' => 'name', 'dt' => 7],
                   ['db' => 'messages', 'dt' => 17, 'dummy' => true, 'order_subquery' => "SELECT SUM(messages) FROM `quota2` WHERE `quota2`.`username` = `m`.`username`"],
                   ['db' => 'tags', 'dt' => 20, 'dummy' => true, 'search' => ['join' => 'LEFT JOIN `tags_mailbox` AS `tm` ON `tm`.`username` = `m`.`username`', 'where_column' => '`tm`.`tag_name`']],
-                  ['db' => 'active', 'dt' => 21]
+                  ['db' => 'active', 'dt' => 21],
                 ];
 
                 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/lib/ssp.class.php';


### PR DESCRIPTION
## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

This PR will make searching mailboxes via **full name**

### Short Description

if you have a mailbox with username `m1@domain.tld` and has the name `test`, then you cannot search via the name `test` but only by username which is `m1` in this case. But this PR will fix it and make mailboxes searchable by **full name** too.

![search by name](https://i.imgur.com/1IgBf3e.png)

###  Affected Containers

- php-fpm-mailcow
- nginx-mailcow (**not directly modified**)