### PR TITLE
Fix warning thrown in update script regarding non-portable flag usage in cp

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1051,7 +1051,7 @@ $COMPOSE_COMMAND pull
 
 # Fix missing SSL, does not overwrite existing files
 [[ ! -d data/assets/ssl ]] && mkdir -p data/assets/ssl
-cp -n -d data/assets/ssl-example/*.pem data/assets/ssl/
+cp --update=none -d data/assets/ssl-example/*.pem data/assets/ssl/
 
 echo -e "Checking IPv6 settings... "
 if grep -q 'SYSCTL_IPV6_DISABLED=1' mailcow.conf; then


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This is a minor fix to the update script. Currently, "cp: warning: behavior of -n is non-portable and may change in future; use --update=none instead" is thrown when dealing with SSL certificates. This commit replaces -n with the correct flag, removing the warning.

###  Affected Containers

None; affects only the update script

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

## Did you run tests?

### What did you tested?

I commented out the "new version check" part of the script on my install to ensure the change wasn't overwritten, and then ran the update script. 

### What were the final results? (Awaited, got)

Results were as expected - the warning no longer shows, and certificates were copied/left alone as they should be.