### PR TITLE
Add create command to prevent external: true warnings

### DIFF
--- a/helper-scripts/_cold-standby.sh
+++ b/helper-scripts/_cold-standby.sh
@@ -202,6 +202,17 @@ if [ ${ec} -ne 0 ] && [ ${ec} -ne 24 ]; then
   exit 1
 fi
 
+# Let the remote side create all network, volumes and containers to prevent need for external:true #
+echo -e "\e[33mCreating networks, volumes and containers on remote...\e[0m"
+
+if ! ssh -o StrictHostKeyChecking=no \
+  -i "${REMOTE_SSH_KEY}" \
+  ${REMOTE_SSH_HOST} \
+  -p ${REMOTE_SSH_PORT} \
+  ${COMPOSE_COMMAND} -f "${SCRIPT_DIR}/../docker-compose.yml" create 2>&1 ; then
+    >&2 echo -e "\e[31m[ERR]\e[0m - Could not create networks, volumes and containers on remote"
+fi
+
 # Trigger a Redis save for a consistent Redis copy
 echo -ne "\033[1mRunning redis-cli save... \033[0m"
 docker exec $(docker ps -qf name=redis-mailcow) redis-cli save


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

This is related to https://github.com/mailcow/mailcow-dockerized/issues/5970 and https://community.mailcow.email/d/2126-backup-restore/2

It adds `docker compose create` to the script which gets executed directly after the sync of the mailcow-dockerized directory. This way the Docker daemon on the remote side creates everything (so the volumes are "owned" by the remote side) and we get rid of the warning `volume "XYZ" already exists but was not created by Docker Compose. Use 'external: true' to use an existing volume`

This is helpful especially if you use the script `create-cold-standby.sh` to **migrate** your mailcow installation to another server and don't want to get those warnings after the migration.

###  Affected Containers

Script: `create-cold-standby.sh`

## Did you run tests?

Sure 😎

### What did you test?

I modified the script like in this PR and tested it during a mail server migration.

### What were the final results? (Awaited, got)

No more warnings like `volume "XYZ" already exists but was not created by Docker Compose. Use 'external: true' to use an existing volume`:

Output on local side:

```
[...]

Preparing remote...
Synchronizing mailcow base directory...
Creating networks, volumes and containers on remote...
 Network mailcowdockerized_mailcow-network  Creating
 Network mailcowdockerized_mailcow-network  Created
 Volume "mailcowdockerized_solr-vol-1"  Creating
 Volume "mailcowdockerized_solr-vol-1"  Created
 Volume "mailcowdockerized_vmail-vol-1"  Creating
 Volume "mailcowdockerized_vmail-vol-1"  Created
 Volume "mailcowdockerized_sogo-userdata-backup-vol-1"  Creating
 Volume "mailcowdockerized_sogo-userdata-backup-vol-1"  Created
 Volume "mailcowdockerized_rspamd-vol-1"  Creating
 Volume "mailcowdockerized_rspamd-vol-1"  Created
 Volume "mailcowdockerized_crypt-vol-1"  Creating
 Volume "mailcowdockerized_crypt-vol-1"  Created
 Volume "mailcowdockerized_clamd-db-vol-1"  Creating
 Volume "mailcowdockerized_clamd-db-vol-1"  Created
 Volume "mailcowdockerized_sogo-web-vol-1"  Creating
 Volume "mailcowdockerized_sogo-web-vol-1"  Created
 Volume "mailcowdockerized_mysql-socket-vol-1"  Creating
 Volume "mailcowdockerized_mysql-socket-vol-1"  Created
 Volume "mailcowdockerized_mysql-vol-1"  Creating
 Volume "mailcowdockerized_mysql-vol-1"  Created
 Volume "mailcowdockerized_postfix-vol-1"  Creating
 Volume "mailcowdockerized_postfix-vol-1"  Created
 Volume "mailcowdockerized_redis-vol-1"  Creating
 Volume "mailcowdockerized_redis-vol-1"  Created
 Volume "mailcowdockerized_vmail-index-vol-1"  Creating
 Volume "mailcowdockerized_vmail-index-vol-1"  Created
 Container mailcowdockerized-memcached-mailcow-1  Creating
 Container mailcowdockerized-netfilter-mailcow-1  Creating
 Container mailcowdockerized-dockerapi-mailcow-1  Creating
 Container mailcowdockerized-unbound-mailcow-1  Creating
 Container mailcowdockerized-sogo-mailcow-1  Creating
 Container mailcowdockerized-olefy-mailcow-1  Creating
 Container mailcowdockerized-dockerapi-mailcow-1  Created
 Container mailcowdockerized-olefy-mailcow-1  Created
 Container mailcowdockerized-netfilter-mailcow-1  Created
 Container mailcowdockerized-redis-mailcow-1  Creating
 Container mailcowdockerized-solr-mailcow-1  Creating
 Container mailcowdockerized-unbound-mailcow-1  Created
 Container mailcowdockerized-mysql-mailcow-1  Creating
 Container mailcowdockerized-clamd-mailcow-1  Creating
 Container mailcowdockerized-memcached-mailcow-1  Created
 Container mailcowdockerized-sogo-mailcow-1  Created
 Container mailcowdockerized-clamd-mailcow-1  Created
 Container mailcowdockerized-solr-mailcow-1  Created
 Container mailcowdockerized-redis-mailcow-1  Created
 Container mailcowdockerized-php-fpm-mailcow-1  Creating
 Container mailcowdockerized-mysql-mailcow-1  Created
 Container mailcowdockerized-dovecot-mailcow-1  Creating
 Container mailcowdockerized-postfix-mailcow-1  Creating
 Container mailcowdockerized-dovecot-mailcow-1  Created
 Container mailcowdockerized-rspamd-mailcow-1  Creating
 Container mailcowdockerized-ofelia-mailcow-1  Creating
 Container mailcowdockerized-postfix-mailcow-1  Created
 Container mailcowdockerized-php-fpm-mailcow-1  Created
 Container mailcowdockerized-nginx-mailcow-1  Creating
 Container mailcowdockerized-ofelia-mailcow-1  Created
 Container mailcowdockerized-rspamd-mailcow-1  Created
 Container mailcowdockerized-nginx-mailcow-1  Created
 Container mailcowdockerized-acme-mailcow-1  Creating
 Container mailcowdockerized-acme-mailcow-1  Created
 Container mailcowdockerized-watchdog-mailcow-1  Creating
 Container mailcowdockerized-watchdog-mailcow-1  Created
Running redis-cli save... OK
Creating remote mountpoint /var/lib/docker/volumes/mailcowdockerized_clamd-db-vol-1/_data for mailcowdockerized_clamd-db-vol-1...
Synchronizing mailcowdockerized_clamd-db-vol-1 from local /var/lib/docker/volumes/mailcowdockerized_clamd-db-vol-1/_data...

[...]
```

This is also "repeat-proof" so the command does not produce any additional output after everything has been created successfully on initial execution.

Output on remote side after starting the containers:
![image](https://github.com/user-attachments/assets/316fa949-28ef-4693-af34-0fea7177c0f5)