### PR TITLE
sogo: added SOGoDisableOrganizerEventCheck value to sogo.conf

### DIFF
--- a/data/conf/sogo/sogo.conf
+++ b/data/conf/sogo/sogo.conf
@@ -16,6 +16,9 @@
     SOGoFoldersSendEMailNotifications = YES;
     SOGoForwardEnabled = YES;
 
+    // Fixes "MODIFICATION_FAILED" error (HTTP 412) in Clients when accepting invitations from external services
+    SOGoDisableOrganizerEventCheck = YES;
+
     // Option to set Users as admin to globally manage calendar permissions etc. Disabled by default
     // SOGoSuperUsernames = ("moo@example.com");
 


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR adds SOGoDisableOrganizerEventCheck value to sogo to allow E-mail clients (e.g. Thunderbird) to accept external made invitations without getting a error code.

Adapting idea from: https://community.mailcow.email/d/3490-calendar-import-412-precondition-failed

###  Affected Containers

- sogo-mailcow

## Did you run tests?

### What did you tested?

Got testing feedback from the mailcow community and a paid customer: On both ends it worked by using the same value.

### What were the final results? (Awaited, got)

Accepting such calendar entries now works.