### PR TITLE
Improve the existing validation flow for sieve filter

### DIFF
--- a/data/web/inc/ajax/sieve_validation.php
+++ b/data/web/inc/ajax/sieve_validation.php
@@ -4,14 +4,14 @@ header('Content-Type: application/json');
 if (!isset($_SESSION['mailcow_cc_role'])) {
   exit();
 }
-if (isset($_GET['script'])) {
+if (isset($_REQUEST['script'])) {
   $sieve = new Sieve\SieveParser();
   try {
-    if (empty($_GET['script'])) {
+    if (empty($_REQUEST['script'])) {
       echo json_encode(array('type' => 'danger', 'msg' => $lang['danger']['script_empty']));
       exit();
     }
-    $sieve->parse($_GET['script']);
+    $sieve->parse($_REQUEST['script']);
   }
   catch (Exception $e) {
     echo json_encode(array('type' => 'danger', 'msg' => $e->getMessage()));

--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -179,9 +179,8 @@ $(document).ready(function() {
     // Get script_data textarea content from form the button was clicked in
     var script = $('textarea[name="script_data"]', $(this).parents('form:first')).val();
     $.ajax({
-      dataType: 'json',
       url: "/inc/ajax/sieve_validation.php",
-      type: "get",
+      type: "post",
       data: { script: script },
       complete: function(data) {
         var response = (data.responseText);


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

This PR improves the existing validation method flow for sieve filter validations.

### Short Description

The current validation behavior sends AJAX request form data in $_GET request query. This is problematic and unreliable when validating particularly complex and superrrr loooooooooooooong sieve rules, especially in environments that use reverse proxies--Been having this problem and this PR solves it. :)

<!-- Please write a short description, what your PR does here. -->

###  Affected Containers

- NGINX--i think

## Did you run tests?

Yes.
<img width="947" alt="image" src="https://github.com/user-attachments/assets/333fdac9-a8bd-4e51-9f33-36b123bea876">


### What did you tested?

The sieve validation feature. :)
https://mail.cow.com/mailbox -> Filters Tab -> Global Prefilter/Postfilter

<!-- Please write shortly, what you've tested (which components etc.). -->

### What were the final results? (Awaited, got)

Should show a toast notif that the sieve filter is valid or is erroneous. ;)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->