### PR TITLE
Mount new volumes in the sogo-mailcow container, for better UI customisation.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,6 +201,9 @@ services:
         - ./data/conf/sogo/:/etc/sogo/:z
         - ./data/web/inc/init_db.inc.php:/init_db.inc.php:z
         - ./data/conf/sogo/custom-favicon.ico:/usr/lib/GNUstep/SOGo/WebServerResources/img/sogo.ico:z
+        - ./data/conf/sogo/custom-shortlogo.svg:/usr/lib/GNUstep/SOGo/WebServerResources/img/sogo-compact.svg:z
+        - ./data/conf/sogo/custom-fulllogo.svg:/usr/lib/GNUstep/SOGo/WebServerResources/img/sogo-full.svg:z
+        - ./data/conf/sogo/custom-fulllogo.png:/usr/lib/GNUstep/SOGo/WebServerResources/img/sogo-logo.png:z
         - ./data/conf/sogo/custom-theme.js:/usr/lib/GNUstep/SOGo/WebServerResources/js/theme.js:z
         - ./data/conf/sogo/custom-sogo.js:/usr/lib/GNUstep/SOGo/WebServerResources/js/custom-sogo.js:z
         - mysql-socket-vol-1:/var/run/mysqld/


### PR DESCRIPTION
Allow customisation of SOGo mail web client. This change allows users to easily replace the logo on the SOGo web page.

## Contribution Guidelines

* [√] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

This PR includes addition of 3 lines to `docker-compose.yml` file, for the volume part of the sogo container:
```
- ./data/conf/sogo/custom-shortlogo.svg:/usr/lib/GNUstep/SOGo/WebServerResources/img/sogo-compact.svg:z
- ./data/conf/sogo/custom-fulllogo.svg:/usr/lib/GNUstep/SOGo/WebServerResources/img/sogo-full.svg:z
- ./data/conf/sogo/custom-fulllogo.png:/usr/lib/GNUstep/SOGo/WebServerResources/img/sogo-logo.png:z
```

### Short Description

Currently if users want to change the UI of the SOGo interface, they have to manually search for a way to do it, and then change the `docker-compose.yml` file, to include the specified above paths. This PR is aimed to simplify this process, and allow users to more easily customise the interface.

###  Affected Containers
- sogo-mailcow

## Did you run tests?
Multiple tests performed

### What did you tested?
UI and the functionality of the client (sending, receiving)

### What were the final results? (Awaited, got)
All tests ran without issues. It is important to make sure that the file extensions are matched, for correct results.