### PR TITLE
Fix missing property in Create Sync Job request

### DIFF
--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -1531,6 +1531,9 @@ paths:
                 port1:
                   description: the smtp port of the target mail server
                   type: string
+                user1:
+                  description: the username of the mailbox
+                  type: string
                 password:
                   description: the password of the mailbox
                   type: string


### PR DESCRIPTION
In example there was property called "user1", but it was missing from request definition.

This resulted in nswagger generating incorrect C# API code.

<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

Small change to openapi.yaml that fixes missing field.

### Short Description

Fixing openapi.yaml.

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

## Did you run tests?

### What did you tested?

I have generated working API wrapper with that yaml.

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->