### PR TITLE
Update Rspamd to 3.11.0 and enable SMTPUTF8 for outgoing mail

### DIFF
--- a/data/Dockerfiles/rspamd/Dockerfile
+++ b/data/Dockerfiles/rspamd/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bookworm-slim
 LABEL maintainer="The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG RSPAMD_VER=rspamd_3.10.2-1~b8a232043
+ARG RSPAMD_VER=rspamd_3.11.0-1~90a175b45
 ARG CODENAME=bookworm
 ENV LC_ALL=C
 

--- a/data/conf/postfix/main.cf
+++ b/data/conf/postfix/main.cf
@@ -162,10 +162,9 @@ transport_maps = pcre:/opt/postfix/conf/custom_transport.pcre,
   proxy:mysql:/opt/postfix/conf/sql/mysql_relay_ne.cf,
   proxy:mysql:/opt/postfix/conf/sql/mysql_transport_maps.cf
 smtp_sasl_auth_soft_bounce = no
-postscreen_discard_ehlo_keywords = silent-discard, dsn, chunking
-smtpd_discard_ehlo_keywords = chunking, silent-discard
+postscreen_discard_ehlo_keywords = chunking, silent-discard, smtputf8, dsn
+smtpd_discard_ehlo_keywords = chunking, silent-discard, smtputf8
 compatibility_level = 3.7
-smtputf8_enable = no
 # Define protocols for SMTPS and submission service
 submission_smtpd_tls_mandatory_protocols = >=TLSv1.2
 smtps_smtpd_tls_mandatory_protocols = >=TLSv1.2

--- a/data/conf/rspamd/local.d/options.inc
+++ b/data/conf/rspamd/local.d/options.inc
@@ -3,6 +3,7 @@ dns {
 }
 map_watch_interval = 30s;
 task_timeout = 30s;
+enable_mime_utf = true;
 disable_monitoring = true;
 # In case a task times out (like DNS lookup), soft reject the message
 # instead of silently accepting the message without further processing.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
             - clamd
 
     rspamd-mailcow:
-      image: mailcow/rspamd:1.99
+      image: mailcow/rspamd:2.0
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Update Rspamd to version 3.11.0 and enable SMTPUTF8 for outgoing mail, avoid using non standardized LATIN1 in Postfix as fallback from disabled UTF8.

###  Affected Containers

- rspamd
- postfix

## Did you run tests?

Yes

### What did you tested?

Emails can be received and send as usual

### What were the final results? (Awaited, got)

N/A