### PR TITLE
Reduce sa rules download retry limit to 5

### DIFF
--- a/data/Dockerfiles/dovecot/sa-rules.sh
+++ b/data/Dockerfiles/dovecot/sa-rules.sh
@@ -11,7 +11,7 @@ else
 fi
 
 # Deploy
-if curl --connect-timeout 15 --retry 10 --max-time 30 https://www.spamassassin.heinlein-support.de/$(dig txt 1.4.3.spamassassin.heinlein-support.de +short | tr -d '"' | tr -dc '0-9').tar.gz --output /tmp/sa-rules-heinlein.tar.gz; then
+if curl --connect-timeout 15 --retry 5 --max-time 30 https://www.spamassassin.heinlein-support.de/$(dig txt 1.4.3.spamassassin.heinlein-support.de +short | tr -d '"' | tr -dc '0-9').tar.gz --output /tmp/sa-rules-heinlein.tar.gz; then
   if gzip -t /tmp/sa-rules-heinlein.tar.gz; then
     tar xfvz /tmp/sa-rules-heinlein.tar.gz -C /tmp/sa-rules-heinlein
     cat /tmp/sa-rules-heinlein/*cf > /etc/rspamd/custom/sa-rules


### PR DESCRIPTION
## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

### Short Description

Reduces the retry limit for the sa rules download to a more reasonable 5 retries to prevent running in a timeout condition.
Fixes https://github.com/mailcow/mailcow-dockerized/issues/6018

###  Affected Containers

- dovecot

## Did you run tests?

Yes

### What did you tested?

Startup and general functionality