### PR TITLE
use cap_drop/cap_add in docker instead of privileged=true

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -451,7 +451,12 @@ services:
       image: mailcow/netfilter:1.60
       stop_grace_period: 30s
       restart: always
-      privileged: true
+      cap_drop:
+        - ALL
+      cap_add:
+        - NET_ADMIN
+        - NET_RAW
+        - SYS_MODULE
       environment:
         - TZ=${TZ}
         - IPV4_NETWORK=${IPV4_NETWORK:-172.22.1}
@@ -621,7 +626,12 @@ services:
       security_opt:
         - label=disable
       restart: always
-      privileged: true
+      cap_drop:
+        - ALL
+      cap_add:
+        - NET_ADMIN
+        - NET_RAW
+        - SYS_MODULE
       network_mode: "host"
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

privileged=true should be always avoided as stated by Owasp [1] and
CIS [2]. Instead, use cap_drop/cap_add as fine-grained capability
mechanism.

[1] https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html
[2] https://www.cisecurity.org/benchmark/docker

###  Affected Containers

- netfilter-mailcow
- ipv6nat-mailcow

## Did you run tests?

### What did you tested?

tested with a new installation and a dummy domain

### What were the final results? (Awaited, got)

avoiding the usage of `privileged=true`