### PR TITLE
Add instant banning to netfilter

### DIFF
--- a/data/Dockerfiles/netfilter/main.py
+++ b/data/Dockerfiles/netfilter/main.py
@@ -293,7 +293,7 @@ def watch():
               if ip.is_private or ip.is_loopback:
                 continue
               # Instant Bannen for defind Rule-IDs
-              if rule_id in instant_ban_rules:
+              if int(rule_id) in instant_ban_rules:
                 logger.logCrit(
                     "Rule ID %s triggered instant ban for %s"
                     % (rule_id, addr)


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

i have add a instant bann function in netfilter for specifig regex rules

(a suggestion from me would be to check the regex rules in the web ui of the netfilter configuration which should be banned immediately)

###  Affected Containers

- netfilter-mailcow

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

## Did you run tests?

YES

### What did you tested?

I waited until false sasl logins or non-SMTP comands appeared again. These were then successfully banned immediately. Since I see it as a security risk and get a lot of attempts. It works as expected.

### What were the final results? (Awaited, got)

The attacks of the selected regex rules were successfully banned immediately with the maximum ban time

![banlist](https://github.com/user-attachments/assets/1394adf7-bd37-4939-80d5-cbdae2e4662b)
![log](https://github.com/user-attachments/assets/75b34506-8b4a-4638-8bfb-82047730650b)