### PR TITLE
Remove discontinued Nixspam DNSBL

### DIFF
--- a/data/Dockerfiles/postfix/postfix.sh
+++ b/data/Dockerfiles/postfix/postfix.sh
@@ -403,7 +403,6 @@ postscreen_dnsbl_sites = wl.mailspike.net=127.0.0.[18;19;20]*-2
   list.dnswl.org=127.0.[0..255].1*-4
   list.dnswl.org=127.0.[0..255].2*-6
   list.dnswl.org=127.0.[0..255].3*-8
-  ix.dnsbl.manitu.net*2
   bl.spamcop.net*2
   bl.suomispam.net*2
   hostkarma.junkemailfilter.com=127.0.0.2*3

--- a/data/Dockerfiles/postfix/postfix.sh
+++ b/data/Dockerfiles/postfix/postfix.sh
@@ -395,7 +395,7 @@ EOF
 
 if [ ! -f /opt/postfix/conf/dns_blocklists.cf ]; then
   cat <<EOF > /opt/postfix/conf/dns_blocklists.cf
-# This file can be edited. 
+# This file can be edited.
 # Delete this file and restart postfix container to revert any changes.
 postscreen_dnsbl_sites = wl.mailspike.net=127.0.0.[18;19;20]*-2
   hostkarma.junkemailfilter.com=127.0.0.1*-2
@@ -417,6 +417,9 @@ postscreen_dnsbl_sites = wl.mailspike.net=127.0.0.[18;19;20]*-2
 EOF
 fi
 DNSBL_CONFIG=$(grep -v '^#' /opt/postfix/conf/dns_blocklists.cf | grep '\S')
+
+# Remove discontinued Nixspam DNSBL from existing dns_blocklists.cf
+sed -i '/ix\.dnsbl\.manitu\.net\*2/d' /opt/postfix/conf/dns_blocklists.cf
 
 if [ ! -z "$DNSBL_CONFIG" ]; then
   echo -e "\e[33mChecking if ASN for your IP is listed for Spamhaus Bad ASN List...\e[0m"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -316,7 +316,7 @@ services:
             - dovecot
 
     postfix-mailcow:
-      image: mailcow/postfix:1.78
+      image: mailcow/postfix:1.79
       depends_on:
         mysql-mailcow:
           condition: service_started


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Nixspam was discontinued last week: https://www.heise.de/news/Spamfilter-DNS-Blacklist-Nixspam-stellt-Betrieb-ein-10248349.html?wt_mc=rss.red.ho.ho.atom.beitrag.beitrag

###  Affected Containers

- postfix

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->