### PR TITLE
Update generate_config.sh version checking for wider compatibility

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -26,7 +26,7 @@ for bin in openssl curl docker git awk sha1sum grep cut; do
 done
 
 # Check Docker Version (need at least 24.X)
-docker_version=$(docker -v | grep -oE '\d+\.\d+\.\d+' | head -n 1 | cut -d '.' -f 1)
+docker_version=$(docker version --format '{{.Server.Version}}' | cut -d '.' -f 1)
 
 if [[ $docker_version -lt 24 ]]; then
   echo -e "\e[31mCannot find Docker with a Version higher or equals 24.0.0\e[0m"

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -26,7 +26,7 @@ for bin in openssl curl docker git awk sha1sum grep cut; do
 done
 
 # Check Docker Version (need at least 24.X)
-docker_version=$(docker -v | grep -oP '\d+\.\d+\.\d+' | head -n 1 | cut -d '.' -f 1)
+docker_version=$(docker -v | grep -oE '\d+\.\d+\.\d+' | head -n 1 | cut -d '.' -f 1)
 
 if [[ $docker_version -lt 24 ]]; then
   echo -e "\e[31mCannot find Docker with a Version higher or equals 24.0.0\e[0m"


### PR DESCRIPTION
fix: replace `grep -oP` with `grep -oE` for broader compatibility

The `-P` option (Perl-compatible regex) is not supported in all versions of `grep`, particularly the default BSD `grep` on macOS. This change replaces `-P` with `-E` (extended regex), which is more widely available and ensures compatibility across different environments.

Tested on macOS and Linux.

<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fulfill in order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR replaces `grep -oP` with `grep -oE` to improve compatibility across different environments. The `-P` option (Perl-compatible regex) is not supported in all versions of `grep`, particularly the default BSD `grep` on macOS. The script fails in its current format on MacOS. Using `-E` (extended regex) ensures broader support while maintaining the intended functionality.

### Affected Containers

<!-- Please list all affected Docker containers here, which you committed changes to -->

None (this is a script change, not a change to Docker containers).

## Did you run tests?

### What did you test?

Tested the updated command on both macOS and Linux to ensure it extracts the major version correctly.

### What were the final results? (Expected, actual)

**Expected:** The command should return only the major version number from `docker --version`.  
**Actual:** The command correctly returns the major version number on both macOS and Linux.

