### PR TITLE
[Nginx] Fix 

### DIFF
--- a/data/conf/nginx/templates/sites-default.conf.j2
+++ b/data/conf/nginx/templates/sites-default.conf.j2
@@ -137,13 +137,22 @@ location ~ /(?:m|M)ail/(?:c|C)onfig-v1.1.xml {
 
 {% if not SKIP_RSPAMD %}
 location /rspamd/ {
+    location /rspamd/auth {
+      # proxy_pass is not inherited
+      proxy_pass       http://{{ RSPAMDHOST }}:11334/auth;
+      proxy_intercept_errors on;
+      proxy_set_header Host      $http_host;
+      proxy_set_header X-Forwarded-For {% if not NGINX_USE_PROXY_PROTOCOL %}$proxy_add_x_forwarded_for{% else %}$proxy_protocol_addr{%endif%};
+      proxy_set_header X-Real-IP {% if not NGINX_USE_PROXY_PROTOCOL %}$remote_addr{% else %}$proxy_protocol_addr{%endif%};
+      proxy_redirect off;
+      error_page 401 /_rspamderror.php;
+    }
+
     proxy_pass       http://{{ RSPAMDHOST }}:11334/;
     proxy_set_header Host      $http_host;
     proxy_set_header X-Forwarded-For {% if not NGINX_USE_PROXY_PROTOCOL %}$proxy_add_x_forwarded_for{% else %}$proxy_protocol_addr{%endif%};
     proxy_set_header X-Real-IP {% if not NGINX_USE_PROXY_PROTOCOL %}$remote_addr{% else %}$proxy_protocol_addr{%endif%};
     proxy_redirect off;
-    proxy_intercept_errors on;
-    error_page 401 /_rspamderror.php;
 }
 {% endif %}
 


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->
This PR fixes https://github.com/mailcow/mailcow-dockerized/issues/6275

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

- NGINX

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->

### What were the final results? (Awaited, got)

After navigating to /rspamd, the invalid password log was no longer shown.
```
php-fpm-mailcow-1    | [28-Jan-2025 20:29:06] WARNING: [pool web-worker] child 68 said into stderr: "NOTICE: PHP message: Rspamd UI: Invalid password by x.x.x.x"
```
<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->