### PR TITLE
postfix: added master.pid removal and startsecs to supervisord

### DIFF
--- a/data/Dockerfiles/postfix/postfix.sh
+++ b/data/Dockerfiles/postfix/postfix.sh
@@ -509,6 +509,11 @@ chgrp -R postdrop /var/spool/postfix/public
 chgrp -R postdrop /var/spool/postfix/maildrop
 postfix set-permissions
 
+# Checking if there is a leftover of a crashed postfix container before starting a new one
+if [ -e /var/spool/postfix/pid/master.pid ]; then
+  rm -rf /var/spool/postfix/pid/master.pid
+fi
+
 # Check Postfix configuration
 postconf -c /opt/postfix/conf > /dev/null
 

--- a/data/Dockerfiles/postfix/supervisord.conf
+++ b/data/Dockerfiles/postfix/supervisord.conf
@@ -18,6 +18,7 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 autorestart=true
+startsecs=10
 
 [eventlistener:processes]
 command=/usr/local/sbin/stop-supervisor.sh


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR improves the stability of postfix in general by enabling startsecs inside supervisord and by deleting the old master.pid file from the `/var/spool/postfix/pid` directory in oder to let it regenerate properly once postfix has crashed somehow inside the container.

This PR is heavily inspired by this community post here (thanks):
https://community.mailcow.email/d/2998-postfix-not-starting

###  Affected Containers

- postfix-mailcow

## Did you run tests?

### What did you tested?

I've tested the normal startup of postfix and how supervisord reacts if postfix is not running longer than 10s at startup.

### What were the final results? (Awaited, got)

Due to this change, supervisord now waits 10s before declaring postfix to be healthy to not forcily restart the container while starting up, which can cause postfix to break as he cannot manage his master.pid file due to this.

As addition, the postfix.sh script now removes as a precautionary measure the master.pid before he is starting up postfix itself to prevent such breaks at this point.