### PR TITLE
Example configuration for AIO config: mailcow +caddy +borg +mailman

### DIFF
--- a/data/Dockerfiles/caddy/Dockerfile
+++ b/data/Dockerfiles/caddy/Dockerfile
@@ -1,0 +1,14 @@
+# This dockerfile builds a custom caddy process, configured with optional 
+# modules for caddy-uwsgi-transport (for mailman) and caddy-events-exec for 
+# reloading dovecot/postfix when new certificates are issued
+# to build, do 'docker compose build' before running 'docker compose up -d'
+ARG CADDY_VERSION=2.9.1
+FROM caddy:${CADDY_VERSION}-builder AS builder
+
+RUN xcaddy build \
+    --with github.com/BadAimWeeb/caddy-uwsgi-transport \
+    --with github.com/mholt/caddy-events-exec
+
+FROM caddy:${CADDY_VERSION}-alpine
+RUN apk add jq
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/data/conf/borgmatic/etc/config.yaml
+++ b/data/conf/borgmatic/etc/config.yaml
@@ -1,0 +1,35 @@
+source_directories:
+    - /mnt/source/vmail
+    - /mnt/source/crypt
+    - /mnt/source/redis
+    - /mnt/source/rspamd
+    - /mnt/source/postfix
+    - /mnt/source/docker-mailman
+repositories:
+    - path: ssh://root@example.org/./mailcow
+      label: backup1
+exclude_patterns:
+    - '/mnt/source/postfix/public/'
+    - '/mnt/source/postfix/private/'
+    - '/mnt/source/rspamd/rspamd.sock'
+
+keep_hourly: 24
+keep_daily: 7
+keep_weekly: 4
+keep_monthly: 6
+
+mariadb_databases:
+    - name: ${MAILCOW_DBNAME}
+      hostname: ${MAILCOW_DBHOST}
+      username: ${MAILCOW_DBUSER}
+      password: ${MAILCOW_DBPASS}
+      options: "--default-character-set=utf8mb4 --skip-ssl"
+      list_options: "--skip-ssl"
+      restore_options: "--skip-ssl"
+
+postgresql_databases:
+    - name: ${MAILMAN_DB_NAME}
+      hostname: ${MAILMAN_DB_HOST}
+      username: ${MAILMAN_DB_USER}
+      password: ${MAILMAN_DB_PASS}
+

--- a/data/conf/borgmatic/etc/crontab.txt
+++ b/data/conf/borgmatic/etc/crontab.txt
@@ -1,0 +1,1 @@
+14 * * * * PATH=$PATH:/usr/local/bin /usr/local/bin/borgmatic --stats -v 0 2>&1

--- a/data/conf/caddy/bin/reload.sh
+++ b/data/conf/caddy/bin/reload.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+copy_cert() {
+  mkdir -p "/shared/ssl/${MAILCOW_HOSTNAME}"
+  cp "$private_key_path" /shared/ssl/key.pem
+  cp "$certificate_path" /shared/ssl/cert.pem
+}
+
+init() {
+  COMPOSE_PROJECT_NAME_LOWER=$(echo "$COMPOSE_PROJECT_NAME" | tr '[:upper:]' '[:lower:]')
+  CONTAINERS=$(wget --no-check-certificate -O - "https://dockerapi.${COMPOSE_PROJECT_NAME}_mailcow-network/containers/json" 2>/dev/null)
+  NGINX=$(echo "${CONTAINERS}" | jq -r '.[] | {name: .Config.Labels["com.docker.compose.service"], project: .Config.Labels["com.docker.compose.project"], id: .Id}' | jq -rc 'select( .name | tostring | contains("nginx-mailcow")) | select( .project | tostring | contains("'"${COMPOSE_PROJECT_NAME_LOWER}"'")) | .id' | tr "\n" " ")
+  DOVECOT=$(echo "${CONTAINERS}" | jq -r '.[] | {name: .Config.Labels["com.docker.compose.service"], project: .Config.Labels["com.docker.compose.project"], id: .Id}' | jq -rc 'select( .name | tostring | contains("dovecot-mailcow")) | select( .project | tostring | contains("'"${COMPOSE_PROJECT_NAME_LOWER}"'")) | .id' | tr "\n" " ")
+  POSTFIX=$(echo "${CONTAINERS}" | jq -r '.[] | {name: .Config.Labels["com.docker.compose.service"], project: .Config.Labels["com.docker.compose.project"], id: .Id}' | jq -rc 'select( .name | tostring | contains("postfix-mailcow")) | select( .project | tostring | contains("'"${COMPOSE_PROJECT_NAME_LOWER}"'")) | .id' | tr "\n" " ")
+
+  # Ensure trimmed content when calling $NGINX etc.
+  NGINX=$(echo "$NGINX" | sed 's/[[:space:]]*$//')
+  DOVECOT=$(echo "$DOVECOT" | sed 's/[[:space:]]*$//')
+  POSTFIX=$(echo "$POSTFIX" | sed 's/[[:space:]]*$//')
+}
+
+reload_nginx() {
+  log "Reloading Nginx..."
+  NGINX_RELOAD_RET=$(wget --no-check-certificate -O - https://dockerapi.${COMPOSE_PROJECT_NAME}_mailcow-network/containers/${NGINX}/exec --post-data='{"cmd":"reload", "task":"nginx"}' --header='Content-Type:application/json' | jq -r .type)
+  [ "${NGINX_RELOAD_RET}" != "success" ] && {
+    log "Could not reload Nginx, restarting container..."
+    restart_container "${NGINX}"
+  }
+}
+
+reload_dovecot() {
+  log "Reloading Dovecot..."
+  DOVECOT_RELOAD_RET=$(wget --no-check-certificate -O - "https://dockerapi.${COMPOSE_PROJECT_NAME}_mailcow-network/containers/${DOVECOT}/exec" --post-data='{"cmd":"reload", "task":"dovecot"}' --header='Content-Type:application/json' | jq -r .type)
+  [ "${DOVECOT_RELOAD_RET}" != "success" ] && {
+    log "Could not reload Dovecot, restarting container..."
+    restart_container "${DOVECOT}"
+  }
+}
+
+reload_postfix() {
+  log "Reloading Postfix..."
+  POSTFIX_RELOAD_RET=$(wget --no-check-certificate -O - "https://dockerapi.${COMPOSE_PROJECT_NAME}_mailcow-network/containers/${POSTFIX}/exec" --post-data='{"cmd":"reload", "task":"postfix"}' --header='Content-Type:application/json' | jq -r .type)
+  [ "${POSTFIX_RELOAD_RET}" != "success" ] && {
+    log "Could not reload Postfix, restarting container..."
+    restart_container" ${POSTFIX}"
+  }
+}
+
+restart_container() {
+  for container in $*; do
+    log "Restarting ${container}..."
+    C_REST_OUT=$(wget --no-check-certificate -O - "https://dockerapi.${COMPOSE_PROJECT_NAME}_mailcow-network/containers/${container}/restart" --post-data='' | jq -r '.msg')
+    log "${C_REST_OUT}"
+  done
+}
+
+restart() {
+  #reload_nginx - no need, caddy is reverse proxy, not using nginx ssl
+  #reload_dovecot
+  log "Restarting postfix"
+  restart_container "${DOVECOT}"
+  #reload_postfix
+  log "Restarting postfix"
+  restart_container "${POSTFIX}"
+}
+
+log() {
+  timestamp=$(date +"%Y/%m/%d %H:%M:%S.%3N")
+  echo "$timestamp $@" | tee -a /var/log/caddy/cert-reload.log
+}
+
+identifier=$1
+certificate_path=$2
+private_key_path=$3
+
+if [ "$identifier" = "$MAILCOW_HOSTNAME" ]; then
+  log "New certificate issued for $MAILCOW_HOSTNAME"
+  log "identifier = $identifier"
+  log "certificate_path = $certificate_path"
+  log "private_key_path = $private_key_path"
+  init
+  copy_cert
+  restart & # run in background, caddy kills tasks > 30s by default
+else
+  log "Ignoring cert with identifer $identifier"
+fi

--- a/data/conf/caddy/etc/Caddyfile
+++ b/data/conf/caddy/etc/Caddyfile
@@ -1,0 +1,74 @@
+{
+	acme_ca https://acme-v02.api.letsencrypt.org/directory
+	# acme_ca https://acme-staging-v02.api.letsencrypt.org/directory # for staging
+
+	default_bind {$CADDY_BIND}
+	http_port {$CADDY_HTTP_PORT}
+	https_port {$CADDY_HTTPS_PORT}
+
+	# debug 
+
+	events {
+		# this will automatically reload docker containers on cert issuance
+		on cert_obtained exec /bin/reload.sh {event.data.identifier} {event.data.certificate_path} {event.data.private_key_path}
+	}
+
+	log {
+		format console
+		output file /var/log/caddy/system.log {
+			roll_disabled
+			roll_size 512M
+			roll_uncompressed
+			roll_local_time
+			roll_keep 3
+			roll_keep_for 48h
+		}
+	}
+}
+
+{$MAILCOW_HOSTNAME} autodiscover.{$MAILCOW_HOSTNAME} autoconfig.{$MAILCOW_HOSTNAME} {
+	log {
+		format console
+		output file /var/log/caddy/{$MAILCOW_HOSTNAME}.log {
+			roll_disabled
+			roll_size 512M
+			roll_uncompressed
+			roll_local_time
+			roll_keep 3
+			roll_keep_for 48h
+		}
+	}
+
+	reverse_proxy nginx-mailcow:{$HTTPS_PORT} {
+		transport http {
+			tls
+			tls_insecure_skip_verify
+		}
+	}
+}
+
+{$MAILMAN_DOMAIN} {
+	log {
+		format console
+		output file /var/log/caddy/{$MAILMAN_DOMAIN}.log {
+			roll_disabled
+			roll_size 512M
+			roll_uncompressed
+			roll_local_time
+			roll_keep 3
+			roll_keep_for 48h
+		}
+	}
+	handle /static/* {
+		root /opt/mailman-web-data
+		file_server {
+			browse
+		}
+	}
+
+	handle {
+		reverse_proxy mailman-web:8080 {
+			transport uwsgi
+		}
+	}
+}

--- a/data/conf/mailman/core/mailman-extra.cfg
+++ b/data/conf/mailman/core/mailman-extra.cfg
@@ -1,0 +1,3 @@
+[mailman]
+default_language: de
+site_owner: mailman@example.org

--- a/data/conf/mailman/web/settings_local.py
+++ b/data/conf/mailman/web/settings_local.py
@@ -1,0 +1,10 @@
+# locale
+LANGUAGE_CODE = 'de-de'
+
+# disable social authentication
+MAILMAN_WEB_SOCIAL_AUTH = []
+
+# change it
+DEFAULT_FROM_EMAIL = 'mailman@example.org'
+
+DEBUG = False

--- a/docker-compose.caddy-mailman-borg-example.override.yml
+++ b/docker-compose.caddy-mailman-borg-example.override.yml
@@ -1,0 +1,141 @@
+services:
+  postfix-mailcow:
+    volumes:
+      - ./data/conf/mailman:/opt/mailman:Z
+  mailman-core:
+    # image: maxking/mailman-core:0.4 # Use a specific version tag (tag latest is not published)
+    image: ghcr.io/midzelis/mailman-core:rolling # custom build of dockerfile for aarch64, see https://github.com/maxking/docker-mailman/pull/741
+    hostname: mailman-core
+    restart: always
+    volumes:
+      - ./data/conf/mailman/core:/opt/mailman/
+    stop_grace_period: 30s
+    depends_on:
+      mailman-database:
+        condition: service_healthy
+    environment:
+      - DATABASE_URL=postgresql://${MAILMAN_DB_USER}:${MAILMAN_DB_PASS}@mailman-database/${MAILMAN_DB_NAME}
+      - DATABASE_TYPE=postgres
+      - DATABASE_CLASS=mailman.database.postgresql.PostgreSQLDatabase
+      - HYPERKITTY_API_KEY=${HYPERKITTY_API_KEY}
+      - MTA=postfix
+    networks:
+      mailcow-network:
+        aliases:
+          - mailman-core
+
+  mailman-web:
+    # image: maxking/mailman-core:0.4 # Use a specific version tag (tag latest is not published)
+    image: ghcr.io/midzelis/mailman-web:rolling  # custom build of dockerfile for aarch64, see https://github.com/maxking/docker-mailman/pull/741
+    hostname: mailman-web
+    restart: always
+    depends_on:
+      mailman-database:
+        condition: service_healthy
+    volumes:
+      - ./data/conf/mailman/web/settings_local.py:/opt/mailman-web/settings_local.py
+      - mailman-web-vol-1:/opt/mailman-web-data:Z
+    environment:
+      - DATABASE_TYPE=postgres
+      - DATABASE_URL=postgresql://${MAILMAN_DB_USER}:${MAILMAN_DB_PASS}@mailman-database/${MAILMAN_DB_NAME}
+      - HYPERKITTY_API_KEY=${HYPERKITTY_API_KEY}
+      - SECRET_KEY=${DJANGO_KEY}
+      - SERVE_FROM_DOMAIN=${MAILMAN_DOMAIN}
+    networks:
+      mailcow-network:
+        aliases:
+          - mailman-web
+
+  mailman-database:
+    environment:
+      - POSTGRES_DB=${MAILMAN_DB_NAME}
+      - POSTGRES_USER=${MAILMAN_DB_USER}
+      - POSTGRES_PASSWORD=${MAILMAN_DB_PASS}
+    image: postgres:12-alpine
+    volumes:
+      - postgresql-vol-1:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready --dbname ${MAILMAN_DB_NAME} --username ${MAILMAN_DB_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      mailcow-network:
+        aliases:
+          - mailman
+  
+  # borgmatic configuration
+  borgmatic-mailcow:
+    image: ghcr.io/borgmatic-collective/borgmatic
+    hostname: mailcow
+    restart: always
+    dns: ${IPV4_NETWORK:-172.22.1}.254
+    volumes:
+      - vmail-vol-1:/mnt/source/vmail:ro
+      - crypt-vol-1:/mnt/source/crypt:ro
+      - redis-vol-1:/mnt/source/redis:ro
+      - rspamd-vol-1:/mnt/source/rspamd:ro
+      - postfix-vol-1:/mnt/source/postfix:ro
+      - borg-config-vol-1:/root/.config/borg
+      - borg-cache-vol-1:/root/.cache/borg
+      - ./data/conf/borgmatic/etc:/etc/borgmatic.d:Z
+      - ./data/conf/borgmatic/ssh:/root/.ssh:Z
+      # also backup docker-mailman configuration
+      - .:/mnt/source/docker-mailman:ro
+    environment:
+      - TZ=${TZ}
+      - BORG_PASSPHRASE=${BORG_PASSPHRASE}
+      - MAILCOW_DBNAME=${DBNAME}
+      - MAILCOW_DBUSER=${DBUSER}
+      - MAILCOW_DBPASS=${DBPASS}
+      - MAILCOW_DBHOST=mysql-mailcow
+      - MAILMAN_DB_NAME=${MAILMAN_DB_NAME}
+      - MAILMAN_DB_USER=${MAILMAN_DB_USER}
+      - MAILMAN_DB_PASS=${MAILMAN_DB_PASS}
+      - MAILMAN_DB_HOST=mailman-database
+    networks:
+      mailcow-network:
+        aliases:
+          - borgmatic
+  nginx-mailcow:
+    depends_on:
+      - redis-mailcow
+      - php-fpm-mailcow
+      - sogo-mailcow
+      - rspamd-mailcow
+      - caddy
+  
+  # caddy reverse proxy
+  caddy:
+    build:
+      dockerfile: ./data/Dockerfiles/caddy/Dockerfile
+    hostname: caddy
+    restart: always
+    dns: ${IPV4_NETWORK:-172.22.1}.254
+    volumes:
+      - ./data/conf/caddy/etc:/etc/caddy:Z
+      - ./data/conf/caddy/data:/data
+      - ./data/conf/caddy/bin/reload.sh:/bin/reload.sh
+      - ./data/assets/ssl:/shared/ssl:Z
+      - mailman-web-vol-1:/opt/mailman-web-data:Z
+    ports:
+        - "${CADDY_BIND:-}:${CADDY_HTTPS_PORT:-443}:${CADDY_HTTPS_PORT:-443}"
+        - "${CADDY_BIND:-}:${CADDY_HTTP_PORT:-80}:${CADDY_HTTP_PORT:-80}"
+    environment:
+        - HTTPS_PORT=${HTTPS_PORT:-443}
+        - HTTP_PORT=${HTTP_PORT:-80}
+        - MAILCOW_HOSTNAME=${MAILCOW_HOSTNAME}
+        - MAILMAN_DOMAIN=${MAILMAN_DOMAIN}
+        - CADDY_BIND=${CADDY_BIND}
+        - CADDY_HTTP_PORT=${CADDY_HTTP_PORT}
+        - CADDY_HTTPS_PORT=${CADDY_HTTPS_PORT}
+        - COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-mailcow-dockerized}
+    networks:
+      mailcow-network:
+        aliases:
+          - caddy
+volumes:
+  borg-cache-vol-1:
+  borg-config-vol-1:
+  postgresql-vol-1:
+  mailman-web-vol-1:


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

This contains an all-in-one example of using mailcow with Caddy as reverse proxy, Borg, for backups, and Mailman, for a list manager. 

* docker-compose.caddy-mailman-borg-example.override.yml

This override makes the following configuration changes: 
1) Caddy, configured with auto container-reload script. This uses a custom caddy Dockerfile (included), to configure caddy with necessary modules, included. example conf files included. 
2) Borg - backs up all volumes, databases, and the mailcow-dockerized root (conf files). Example conf files included. 
3) Mailman - example conf files included. 

If you choose to use this override, a user should also add these configuration directives in their `mailcow.conf` file:

```
HTTP_PORT=180 # listen on alt port
HTTP_BIND=127.0.0.1 # only listen on private loopback

HTTPS_PORT=1443 # listen on alt port
HTTPS_BIND=127.0.0.1 # only listen on private loopback

CADDY_BIND=0.0.0.0
CADDY_HTTP_PORT=80
CADDY_HTTPS_PORT=443

BORG_PASSPHRASE=some-long-secure-phrase

HYPERKITTY_API_KEY=some-long-secure-key
DJANGO_KEY=some-long-secure-key
MAILMAN_DB_NAME=mailmandb
MAILMAN_DB_USER=mailmandbuser
MAILMAN_DB_PASS=some-long-secure-key
MAILMAN_DOMAIN=lists.example.org
MAILMAN_ADMIN_USER=mailman
MAILMAN_ADMIN_EMAIL=mailman@example.org

```
### Short Description

<!-- Please write a short description, what your PR does here. -->

A lot of this was mostly derived from existing guides. However, I found some a little out of date, and I didn't like some of the advise they were suggesting. 

i.e. the Caddy example used a script and a cronjob to copy certs. Instead, I used caddy events to remove need for polling, the certificate is shared using shared volume mounts, and it uses a modified script from the acme folder to use the dockerapi endpoints to restart the dovecot/postfix containers. 

The borg backup guide was ok, but I didn't like that it mounted the mysql sock. Just use the hostname instead. This was also modified to include the postgres database used by mailman. Additionally, it also bind-mounts the root mailcow-dockerized folder, so all config data is also backed-up.

The mailman guide was also ok, but it suggested to apache as a reverse proxy. I prefer Caddy, since it handles ACME/SSL automatically, and also does reverse-proxy very well. Additionally, this guide suggested to install apache not as a container, but as app installed directly on the host - would prefer to use a container solution instead. It also suggested to install mailman, using their own dockerfiles, and creating an external network to allow the two docker-compose stacks to communicate with each other. Instead, I added all of the mailman docker compose configuration files directly to the override - you do not need to download/clone mailman from git either. The example docker-compose includes everything. 

Additionally, I needed to custom build mailman's dockerfiles for aarch64 support, since I'm using Heztner cloud's arm servers. 

TODOs: 
* Caddy could replace the need for nginx completely, but that was a much bigger change, and I didn't really see the need to do that. I'm ok with the inefficiency for now. 
* Mailman also supports mariadb/mysql - but their examples were using postgres. Considering that mariadb's container doesn't support multiple databases in a single container, I didn't care too much to standardize on a single db. I think postgres does support multiple dbs per container, but not sure if mailcow can support postgres. If so, using postgres would probably be the db i would choose to standardize on, but thats just me. 

###  Affected Containers

This does add anything to any existing containers. These are new instructions/examples for users to follow if they wanted to configure an all-in-one server with mailcow, borg, and mailman. 

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

## Did you run tests?

Deployed to my production instance. 

### What did you tested?


<!-- Please write shortly, what you've tested (which components etc.). -->

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->