### PR TITLE
[Dovecot][Netfilter] Fix dovecot failed login regex

### DIFF
--- a/data/Dockerfiles/dovecot/syslog-ng-redis_slave.conf
+++ b/data/Dockerfiles/dovecot/syslog-ng-redis_slave.conf
@@ -38,8 +38,13 @@ filter f_replica {
   not match("User has no mail_replica in userdb" value("MESSAGE"));
   not match("Error: sync: Unknown user in remote" value("MESSAGE"));
 };
+filter f_dovecot_auth_try {
+  not match("- trying the next passdb" value("MESSAGE")) and
+  not match("- trying the next userdb" value("MESSAGE"));
+};
 log {
   source(s_dgram);
+  filter(f_dovecot_auth_try);
   filter(f_replica);
   destination(d_stdout);
   filter(f_mail);

--- a/data/Dockerfiles/dovecot/syslog-ng.conf
+++ b/data/Dockerfiles/dovecot/syslog-ng.conf
@@ -38,8 +38,13 @@ filter f_replica {
   not match("User has no mail_replica in userdb" value("MESSAGE"));
   not match("Error: sync: Unknown user in remote" value("MESSAGE"));
 };
+filter f_dovecot_auth_try {
+  not match("- trying the next passdb" value("MESSAGE")) and
+  not match("- trying the next userdb" value("MESSAGE"));
+};
 log {
   source(s_dgram);
+  filter(f_dovecot_auth_try);
   filter(f_replica);
   destination(d_stdout);
   filter(f_mail);

--- a/data/Dockerfiles/netfilter/main.py
+++ b/data/Dockerfiles/netfilter/main.py
@@ -85,9 +85,10 @@ def refreshF2bregex():
     f2bregex[3] = r'warning: .*\[([0-9a-f\.:]+)\]: SASL .+ authentication failed: (?!.*Connection lost to authentication server).+'
     f2bregex[4] = r'warning: non-SMTP command from .*\[([0-9a-f\.:]+)]:.+'
     f2bregex[5] = r'NOQUEUE: reject: RCPT from \[([0-9a-f\.:]+)].+Protocol error.+'
-    f2bregex[6] = r'auth: \w+\([^,]+,([0-9a-f\.:]+),<[^>]+>\): Password mismatch \(SHA1 of given password: [a-f0-9]+\)'
-    f2bregex[7] = r'SOGo.+ Login from \'([0-9a-f\.:]+)\' for user .+ might not have worked'
-    f2bregex[8] = r'([0-9a-f\.:]+) \"GET \/SOGo\/.* HTTP.+\" 403 .+'
+    f2bregex[6] = r'\w+\([^,]+,([0-9a-f\.:]+),<[^>]+>\): Password mismatch \(SHA1 of given password: [a-f0-9]+\)'
+    f2bregex[7] = r'\w+\([^,]+,([0-9a-f\.:]+),<[^>]+>\): unknown user \(SHA1 of given password: [a-f0-9]+\)'
+    f2bregex[8] = r'SOGo.+ Login from \'([0-9a-f\.:]+)\' for user .+ might not have worked'
+    f2bregex[9] = r'([0-9a-f\.:]+) \"GET \/SOGo\/.* HTTP.+\" 403 .+'
     r.set('F2B_REGEX', json.dumps(f2bregex, ensure_ascii=False))
   else:
     try:

--- a/data/Dockerfiles/netfilter/main.py
+++ b/data/Dockerfiles/netfilter/main.py
@@ -85,7 +85,7 @@ def refreshF2bregex():
     f2bregex[3] = r'warning: .*\[([0-9a-f\.:]+)\]: SASL .+ authentication failed: (?!.*Connection lost to authentication server).+'
     f2bregex[4] = r'warning: non-SMTP command from .*\[([0-9a-f\.:]+)]:.+'
     f2bregex[5] = r'NOQUEUE: reject: RCPT from \[([0-9a-f\.:]+)].+Protocol error.+'
-    f2bregex[6] = r'auth: static\([^,]+,([0-9a-f\.:]+),<[^>]+>\): Password mismatch \(SHA1 of given password: [a-f0-9]+\)'
+    f2bregex[6] = r'auth: \w+\([^,]+,([0-9a-f\.:]+),<[^>]+>\): Password mismatch \(SHA1 of given password: [a-f0-9]+\)'
     f2bregex[7] = r'SOGo.+ Login from \'([0-9a-f\.:]+)\' for user .+ might not have worked'
     f2bregex[8] = r'([0-9a-f\.:]+) \"GET \/SOGo\/.* HTTP.+\" 403 .+'
     r.set('F2B_REGEX', json.dumps(f2bregex, ensure_ascii=False))

--- a/data/Dockerfiles/netfilter/main.py
+++ b/data/Dockerfiles/netfilter/main.py
@@ -85,11 +85,9 @@ def refreshF2bregex():
     f2bregex[3] = r'warning: .*\[([0-9a-f\.:]+)\]: SASL .+ authentication failed: (?!.*Connection lost to authentication server).+'
     f2bregex[4] = r'warning: non-SMTP command from .*\[([0-9a-f\.:]+)]:.+'
     f2bregex[5] = r'NOQUEUE: reject: RCPT from \[([0-9a-f\.:]+)].+Protocol error.+'
-    f2bregex[6] = r'-login: Disconnected.+ \(auth failed, .+\): user=.*, method=.+, rip=([0-9a-f\.:]+),'
-    f2bregex[7] = r'-login: Aborted login.+ \(auth failed .+\): user=.+, rip=([0-9a-f\.:]+), lip.+'
-    f2bregex[8] = r'-login: Aborted login.+ \(tried to use disallowed .+\): user=.+, rip=([0-9a-f\.:]+), lip.+'
-    f2bregex[9] = r'SOGo.+ Login from \'([0-9a-f\.:]+)\' for user .+ might not have worked'
-    f2bregex[10] = r'([0-9a-f\.:]+) \"GET \/SOGo\/.* HTTP.+\" 403 .+'
+    f2bregex[6] = r'auth: static\([^,]+,([0-9a-f\.:]+),<[^>]+>\): Password mismatch \(SHA1 of given password: [a-f0-9]+\)'
+    f2bregex[7] = r'SOGo.+ Login from \'([0-9a-f\.:]+)\' for user .+ might not have worked'
+    f2bregex[8] = r'([0-9a-f\.:]+) \"GET \/SOGo\/.* HTTP.+\" 403 .+'
     r.set('F2B_REGEX', json.dumps(f2bregex, ensure_ascii=False))
   else:
     try:

--- a/data/conf/dovecot/dovecot.conf
+++ b/data/conf/dovecot/dovecot.conf
@@ -278,6 +278,7 @@ imap_max_line_length = 2 M
 #auth_cache_negative_ttl = 0
 #auth_cache_ttl = 30 s
 #auth_cache_size = 2 M
+auth_verbose_passwords = sha1:6
 service replicator {
   process_min_avail = 1
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -454,7 +454,7 @@ services:
             - acme
 
     netfilter-mailcow:
-      image: mailcow/netfilter:1.60
+      image: mailcow/netfilter:1.61
       stop_grace_period: 30s
       restart: always
       privileged: true


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Fixes https://github.com/mailcow/mailcow-dockerized/issues/6308
Dovecot allows multiple authentication attempts within a single IMAP session. 
Netfilter only registers a failed login when the session is closed, leading to missed failed attempts.

**This Fix requires Admins to reset Fail2ban regex in mailcow UI after update.**

###  Affected Containers

- Dovecot
- Netfilter

## Did you run tests?

### What did you tested?

Attempted multiple failed logins within a single IMAP session.

### What were the final results? (Awaited, got)

Verified that each failed attempt is now properly detected by Netfilter and the correct IP is extracted.
