### PR TITLE
Fix `check_dns()` hard-coded IP address in ..`unbound/healthcheck.sh`

### DIFF
--- a/data/Dockerfiles/unbound/healthcheck.sh
+++ b/data/Dockerfiles/unbound/healthcheck.sh
@@ -50,7 +50,7 @@ local failures=0
 for domain in "${domains[@]}" ; do
     success=false
     for ((i=1; i<=3; i++)); do
-        dig_output=$(dig +short +timeout=2 +tries=1 "$domain" @127.0.0.1 2>/dev/null)
+        dig_output=$(dig +short +timeout=2 +tries=1 "$domain" @127.0.0.11 2>/dev/null)
         dig_rc=$?
 
         if [ $dig_rc -ne 0 ] || [ -z "$dig_output" ]; then


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Fix to hard-coded IP address that causes `healthcheck.sh` to fail for unbound during `docker compose up -d`

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- mailcow/unbound

-->

## Did you run tests?

Yes

### What did you tested?

Failed to pass healthceck on startup because of DNS errors before change.

### What were the final results? (Awaited, got)

Healthcheck succeeded and I was able to log in successfully after `docker compose up -d`