### PR TITLE
rspamd: upgraded rspamd to 3.11.0-2 (incl. NIXSPAM Removal)

### DIFF
--- a/data/Dockerfiles/rspamd/Dockerfile
+++ b/data/Dockerfiles/rspamd/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bookworm-slim
 LABEL maintainer="The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG RSPAMD_VER=rspamd_3.11.0-1~90a175b45
+ARG RSPAMD_VER=rspamd_3.11.0-2~90a175b45
 ARG CODENAME=bookworm
 ENV LC_ALL=C
 


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

This PR is installing the hotfixed rspamd 3.11.0-2 version which include the removal of NIXSPAM inside rspamd (according to Issue: https://github.com/rspamd/rspamd/issues/5344).

**The Docker Image mailcow/rspamd:2.0 has been repushed to Docker Hub already**

###  Affected Containers

- rspamd-mailcow

## Did you run tests?

### What did you tested?

As this Change only includes the removal of NIXSPAM inside Rspamd and the previous Rspamd Update (3.11.0) worked i've only tested the build process of mailcow as well as the startup.

### What were the final results? (Awaited, got)

mailcow itself came up as normal, operating as it should (no failures seen).