### PR TITLE
Prompt user before applying major updates

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -715,6 +715,7 @@ detect_major_update() {
     # Array with major versions
     # Add major versions here
     MAJOR_VERSIONS=(
+      "2025-02"
     )
 
     current_version=$(git describe --tags $(git rev-list --tags --max-count=1))

--- a/update.sh
+++ b/update.sh
@@ -710,6 +710,43 @@ migrate_solr_config_options() {
   fi
 }
 
+detect_major_update() {
+  if [ ${BRANCH} == "master" ]; then
+    # Array with major versions
+    # Add major versions here
+    MAJOR_VERSIONS=(
+    )
+
+    current_version=$(git describe --tags $(git rev-list --tags --max-count=1))
+    release_url="https://github.com/mailcow/mailcow-dockerized/releases/tag"
+
+    updates_to_apply=()
+
+    for version in "${MAJOR_VERSIONS[@]}"; do
+      if [[ "$current_version" < "$version" ]]; then
+        updates_to_apply+=("$version")
+      fi
+    done
+
+    if [[ ${#updates_to_apply[@]} -gt 0 ]]; then
+      echo -e "\e[33m\nMAJOR UPDATES to be applied:\e[0m"
+      for update in "${updates_to_apply[@]}"; do
+        echo "$update - $release_url/$update"
+      done
+
+      echo -e "\n⚠️  Please read the release notes before proceeding.\n"
+
+      read -p "Do you want to proceed with the update? [y/n] " response
+      if [[ "${response}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+        echo "Proceeding with the update..."
+      else
+        echo "Update canceled. Exiting."
+        exit 1
+      fi
+    fi
+  fi
+}
+
 ############## End Function Section ##############
 
 # Check permissions
@@ -1345,6 +1382,7 @@ if [ ! "$FORCE" ]; then
     echo "OK, exiting."
     exit 0
   fi
+  detect_major_update
   migrate_docker_nat
 fi
 


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

When a user upgrades mailcow, the update.sh script will check for major version updates 
and prompt the user with a link to the release notes.

Versions that contain major changes can be added to the `MAJOR_VERSIONS` array in update.sh.

###  Affected Containers

None

## Did you run tests?

### What did you tested?

I successfully tested that the prompt is triggered when a major update is detected.
