### PR TITLE
compose: use ghcr.io for new/current mailcow docker images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
     unbound-mailcow:
-      image: mailcow/unbound:1.23
+      image: ghcr.io/mailcow/unbound:1.23
       environment:
         - TZ=${TZ}
         - SKIP_UNBOUND_HEALTHCHECK=${SKIP_UNBOUND_HEALTHCHECK:-n}
@@ -65,7 +65,7 @@ services:
             - redis
 
     clamd-mailcow:
-      image: mailcow/clamd:1.70
+      image: ghcr.io/mailcow/clamd:1.70
       restart: always
       depends_on:
         unbound-mailcow:
@@ -84,7 +84,7 @@ services:
             - clamd
 
     rspamd-mailcow:
-      image: mailcow/rspamd:2.0
+      image: ghcr.io/mailcow/rspamd:2.0
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow
@@ -117,7 +117,7 @@ services:
             - rspamd
 
     php-fpm-mailcow:
-      image: mailcow/phpfpm:1.92
+      image: ghcr.io/mailcow/phpfpm:1.92
       command: "php-fpm -d date.timezone=${TZ} -d expose_php=0"
       depends_on:
         - redis-mailcow
@@ -183,7 +183,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: mailcow/sogo:1.129
+      image: ghcr.io/mailcow/sogo:1.129
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}
@@ -234,7 +234,7 @@ services:
             - sogo
 
     dovecot-mailcow:
-      image: mailcow/dovecot:2.31
+      image: ghcr.io/mailcow/dovecot:2.31
       depends_on:
         - mysql-mailcow
         - netfilter-mailcow
@@ -321,7 +321,7 @@ services:
             - dovecot
 
     postfix-mailcow:
-      image: mailcow/postfix:1.80
+      image: ghcr.io/mailcow/postfix:1.80
       depends_on:
         mysql-mailcow:
           condition: service_started
@@ -377,7 +377,7 @@ services:
         - php-fpm-mailcow
         - sogo-mailcow
         - rspamd-mailcow
-      image: mailcow/nginx:1.03
+      image: ghcr.io/mailcow/nginx:1.03
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       environment:
@@ -419,7 +419,7 @@ services:
           condition: service_started
         unbound-mailcow:
           condition: service_healthy
-      image: mailcow/acme:1.91
+      image: ghcr.io/mailcow/acme:1.91
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       environment:
@@ -457,7 +457,7 @@ services:
             - acme
 
     netfilter-mailcow:
-      image: mailcow/netfilter:1.61
+      image: ghcr.io/mailcow/netfilter:1.61
       stop_grace_period: 30s
       restart: always
       privileged: true
@@ -477,7 +477,7 @@ services:
         - /lib/modules:/lib/modules:ro
 
     watchdog-mailcow:
-      image: mailcow/watchdog:2.06
+      image: ghcr.io/mailcow/watchdog:2.06
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       tmpfs:
@@ -549,7 +549,7 @@ services:
             - watchdog
 
     dockerapi-mailcow:
-      image: mailcow/dockerapi:2.10
+      image: ghcr.io/mailcow/dockerapi:2.10
       security_opt:
         - label=disable
       restart: always
@@ -569,7 +569,7 @@ services:
             - dockerapi
 
     olefy-mailcow:
-      image: mailcow/olefy:1.13
+      image: ghcr.io/mailcow/olefy:1.13
       restart: always
       environment:
         - TZ=${TZ}


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR include the swap of our ownly build docker images from Docker Hub to Github Container Registry (or short ghcr.io).

Due to Docker Hubs announcement regarding ratelimit an IP to 10 Pulls per Hour (and mailcow in total uses 18 containers) we would ran into a bottleneck, when all containers need an update (rarely the case but possible).

That's why we switch the shipment for the latest images beginning with 2025-02 to Github instead (until they come up with funny ratelimit ideas which are currently not the case (at least in my mind)

###  Affected Containers

All except not our images, which are:

- mariadb
- ofelia
- ipv6nat
- redis
- memcached

## Did you run tests?

### What did you tested?

The normal mailcow startup.

As only the image location changed it was important to test the pull too.

### What were the final results? (Awaited, got)

The pull of the new images worked as expected, also from a not dev machine.