### PR TITLE
use ghcr.io for backupimage

### DIFF
--- a/.github/workflows/rebuild_backup_image.yml
+++ b/.github/workflows/rebuild_backup_image.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   docker_image_build:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,17 +21,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.BACKUPIMAGEBUILD_ACTION_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.BACKUPIMAGEBUILD_ACTION_DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           file: data/Dockerfiles/backup/Dockerfile
           push: true
-          tags: mailcow/backup:latest
+          tags: ghcr.io/mailcow/backup:latest

--- a/data/Dockerfiles/backup/Dockerfile
+++ b/data/Dockerfiles/backup/Dockerfile
@@ -1,3 +1,3 @@
 FROM debian:bookworm-slim
 
-RUN apt update && apt install pigz
+RUN apt update && apt install pigz -y --no-install-recommends

--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEBIAN_DOCKER_IMAGE="mailcow/backup:latest"
+DEBIAN_DOCKER_IMAGE="ghcr.io/mailcow/backup:latest"
 
 if [[ ! -z ${MAILCOW_BACKUP_LOCATION} ]]; then
   BACKUP_LOCATION="${MAILCOW_BACKUP_LOCATION}"


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

This PR include the swap of the backup container from Docker Hub to Github Container Registry (or short ghcr.io).

Also following secrets can be deleted:
```
BACKUPIMAGEBUILD_ACTION_DOCKERHUB_USERNAME
BACKUPIMAGEBUILD_ACTION_DOCKERHUB_TOKEN
```

This action will use `GITHUB_TOKEN` as this seems the [recommended way](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-in-a-github-actions-workflow).

###  Affected Containers

- backup

## Did you run tests?

on my private fork I did test the action

### What did you tested?

single run of the workflow

<!-- Please write shortly, what you've tested (which components etc.). -->

### What were the final results? (Awaited, got)

Pushed to GHCR successfully

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->