### PR TITLE
rspamd: remove .info from fishy tlds (default)

### DIFF
--- a/data/conf/rspamd/custom/fishy_tlds.map
+++ b/data/conf/rspamd/custom/fishy_tlds.map
@@ -24,7 +24,6 @@
 /.+\.guru$/i
 /.+\.icu$/i
 /.+\.id$/i
-/.+\.info$/i
 /.+\.in.net$/i
 /.+\.ir$/i
 /.+\.jetzt$/i


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->

This PR fixes #6339 by removing .info from the fishy_tld.map for rspamd.

###  Affected Containers

- rspamd-mailcow

## Did you run tests?

### What did you tested?

No, it's just the removal from one tld.

### What were the final results? (Awaited, got)

None