### PR TITLE
dkim: Add support for 3072 and 4096 bit RSA keys

### DIFF
--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -409,7 +409,7 @@ paths:
                   description: a list of domains for which a dkim key should be generated
                   type: string
                 key_size:
-                  description: the key size (1024 or 2048)
+                  description: the key size (1024, 2048, 3072 or 4096)
                   type: number
               type: object
       summary: Generate DKIM Key

--- a/data/web/inc/functions.dkim.inc.php
+++ b/data/web/inc/functions.dkim.inc.php
@@ -241,7 +241,7 @@ function dkim($_action, $_data = null, $privkey = false) {
           $dkimdata['length'] = "1024";
         }
         elseif (strlen($dkimdata['pubkey']) < 564) {
-          $dkimdata['length'] = "2048"
+          $dkimdata['length'] = "2048";
         }
         elseif (strlen($dkimdata['pubkey']) < 736) {
           $dkimdata['length'] = "3072";

--- a/data/web/inc/functions.dkim.inc.php
+++ b/data/web/inc/functions.dkim.inc.php
@@ -240,8 +240,11 @@ function dkim($_action, $_data = null, $privkey = false) {
         if (strlen($dkimdata['pubkey']) < 391) {
           $dkimdata['length'] = "1024";
         }
+        elseif (strlen($dkimdata['pubkey']) < 564) {
+          $dkimdata['length'] = "2048"
+        }
         elseif (strlen($dkimdata['pubkey']) < 736) {
-          $dkimdata['length'] = "2048";
+          $dkimdata['length'] = "3072";
         }
         elseif (strlen($dkimdata['pubkey']) < 1416) {
           $dkimdata['length'] = "4096";

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -4,7 +4,7 @@ function init_db_schema()
   try {
     global $pdo;
 
-    $db_version = "20112024_1105";
+    $db_version = "11032025_0926";
 
     $stmt = $pdo->query("SHOW TABLES LIKE 'versions'");
     $num_results = count($stmt->fetchAll(PDO::FETCH_ASSOC));
@@ -1385,7 +1385,7 @@ function init_db_schema()
         "relay_all_recipients" => 0,
         "relay_unknown_only" => 0,
         "dkim_selector" => "dkim",
-        "key_size" => 2048,
+        "key_size" => 4096,
         "max_quota_for_domain" => 10240 * 1048576,
       )
     );

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -4,7 +4,7 @@ function init_db_schema()
   try {
     global $pdo;
 
-    $db_version = "11032025_0926";
+    $db_version = "20112024_1105";
 
     $stmt = $pdo->query("SHOW TABLES LIKE 'versions'");
     $num_results = count($stmt->fetchAll(PDO::FETCH_ASSOC));
@@ -1385,7 +1385,7 @@ function init_db_schema()
         "relay_all_recipients" => 0,
         "relay_unknown_only" => 0,
         "dkim_selector" => "dkim",
-        "key_size" => 4096,
+        "key_size" => 2048,
         "max_quota_for_domain" => 10240 * 1048576,
       )
     );

--- a/data/web/templates/admin/tab-config-dkim.twig
+++ b/data/web/templates/admin/tab-config-dkim.twig
@@ -117,6 +117,8 @@
             <select data-style="btn btn-light btn-sm" class="form-control" id="key_size" name="key_size" title="{{ lang.admin.dkim_key_length }}" required>
               <option data-subtext="bits">1024</option>
               <option data-subtext="bits">2048</option>
+              <option data-subtext="bits">3072</option>
+              <option data-subtext="bits">4096</option>
             </select>
           </div>
         </div>

--- a/data/web/templates/edit/domain-templates.twig
+++ b/data/web/templates/edit/domain-templates.twig
@@ -103,6 +103,8 @@
         <select data-style="btn btn-light" class="form-control" id="key_size" name="key_size">
           <option value="1024" data-subtext="bits" {% if template.attributes.key_size == 1024 %} selected{% endif %}>1024</option>
           <option value="2048" data-subtext="bits" {% if template.attributes.key_size == 2048 %} selected{% endif %}>2048</option>
+          <option value="3072" data-subtext="bits" {% if template.attributes.key_size == 3072 %} selected{% endif %}>3072</option>
+          <option value="4096" data-subtext="bits" {% if template.attributes.key_size == 4096 %} selected{% endif %}>4096</option>
         </select>
       </div>
     </div>

--- a/data/web/templates/modals/mailbox.twig
+++ b/data/web/templates/modals/mailbox.twig
@@ -489,9 +489,9 @@
             <div class="col-sm-10">
               <select data-style="btn btn-light" class="form-control" id="key_size" name="key_size">
                 <option data-subtext="bits" value="1024">1024</option>
-                <option data-subtext="bits" value="2048" selected>2048</option>
+                <option data-subtext="bits" value="2048">2048</option>
                 <option data-subtext="bits" value="3072">3072</option>
-                <option data-subtext="bits" value="4096">4096</option>
+                <option data-subtext="bits" value="4096" selected>4096</option>
               </select>
             </div>
           </div>
@@ -629,9 +629,9 @@
             <div class="col-sm-10">
               <select data-style="btn btn-light" class="form-control" id="key_size" name="key_size">
                 <option data-subtext="bits">1024</option>
-                <option data-subtext="bits" selected>2048</option>
+                <option data-subtext="bits">2048</option>
                 <option data-subtext="bits">3072</option>
-                <option data-subtext="bits">4096</option>
+                <option data-subtext="bits" selected>4096</option>
               </select>
             </div>
           </div>
@@ -846,9 +846,9 @@
             <div class="col-sm-10">
               <select data-style="btn btn-light" class="form-control" id="key_size2" name="key_size">
                 <option data-subtext="bits">1024</option>
-                <option data-subtext="bits" selected>2048</option>
+                <option data-subtext="bits">2048</option>
                 <option data-subtext="bits">3072</option>
-                <option data-subtext="bits">4096</option>
+                <option data-subtext="bits" selected>4096</option>
               </select>
             </div>
           </div>

--- a/data/web/templates/modals/mailbox.twig
+++ b/data/web/templates/modals/mailbox.twig
@@ -490,6 +490,8 @@
               <select data-style="btn btn-light" class="form-control" id="key_size" name="key_size">
                 <option data-subtext="bits" value="1024">1024</option>
                 <option data-subtext="bits" value="2048" selected>2048</option>
+                <option data-subtext="bits" value="3072">3072</option>
+                <option data-subtext="bits" value="4096">4096</option>
               </select>
             </div>
           </div>
@@ -628,6 +630,8 @@
               <select data-style="btn btn-light" class="form-control" id="key_size" name="key_size">
                 <option data-subtext="bits">1024</option>
                 <option data-subtext="bits" selected>2048</option>
+                <option data-subtext="bits">3072</option>
+                <option data-subtext="bits">4096</option>
               </select>
             </div>
           </div>
@@ -843,6 +847,8 @@
               <select data-style="btn btn-light" class="form-control" id="key_size2" name="key_size">
                 <option data-subtext="bits">1024</option>
                 <option data-subtext="bits" selected>2048</option>
+                <option data-subtext="bits">3072</option>
+                <option data-subtext="bits">4096</option>
               </select>
             </div>
           </div>

--- a/data/web/templates/modals/mailbox.twig
+++ b/data/web/templates/modals/mailbox.twig
@@ -489,9 +489,9 @@
             <div class="col-sm-10">
               <select data-style="btn btn-light" class="form-control" id="key_size" name="key_size">
                 <option data-subtext="bits" value="1024">1024</option>
-                <option data-subtext="bits" value="2048">2048</option>
+                <option data-subtext="bits" value="2048" selected>2048</option>
                 <option data-subtext="bits" value="3072">3072</option>
-                <option data-subtext="bits" value="4096" selected>4096</option>
+                <option data-subtext="bits" value="4096">4096</option>
               </select>
             </div>
           </div>
@@ -629,9 +629,9 @@
             <div class="col-sm-10">
               <select data-style="btn btn-light" class="form-control" id="key_size" name="key_size">
                 <option data-subtext="bits">1024</option>
-                <option data-subtext="bits">2048</option>
+                <option data-subtext="bits" selected>2048</option>
                 <option data-subtext="bits">3072</option>
-                <option data-subtext="bits" selected>4096</option>
+                <option data-subtext="bits">4096</option>
               </select>
             </div>
           </div>
@@ -846,9 +846,9 @@
             <div class="col-sm-10">
               <select data-style="btn btn-light" class="form-control" id="key_size2" name="key_size">
                 <option data-subtext="bits">1024</option>
-                <option data-subtext="bits">2048</option>
+                <option data-subtext="bits" selected>2048</option>
                 <option data-subtext="bits">3072</option>
-                <option data-subtext="bits" selected>4096</option>
+                <option data-subtext="bits">4096</option>
               </select>
             </div>
           </div>


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->

This PR implements generation of 3072 and 4096 bit RSA keys for DKIM directly in the UI and correctly labels 3072 bit RSA keys.

Fixes #6364

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

- php-fpm-mailcow

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->

- Generated 3072 and 4096 keys using the UI
- Used new key size options in domain template modals
- Created new domain with new key size option selected

### What were the final results? (Awaited, got)

- Keys were successfully generated and labelled
- Domain templates were successfully adapted
- Key was automatically generated for the new domain

<img width="1148" alt="image" src="https://github.com/user-attachments/assets/8840ea2e-0811-4d34-ab3f-510a279fad8a" />

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->