### PR TITLE
feat/replace bgp.he.net with bgp.tools

### DIFF
--- a/data/web/js/site/user.js
+++ b/data/web/js/site/user.js
@@ -103,7 +103,7 @@ jQuery(function($){
               var local_datetime = datetime.toLocaleDateString(undefined, {year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", second: "2-digit"});
               var service = '<div class="badge fs-6 bg-secondary">' + item.service.toUpperCase() + '</div>';
               var app_password = item.app_password ? ' <a href="/edit/app-passwd/' + item.app_password + '"><i class="bi bi-app-indicator"></i> ' + escapeHtml(item.app_password_name || "App") + '</a>' : '';
-              var real_rip = item.real_rip.startsWith("Web") ? item.real_rip : '<a href="https://bgp.he.net/ip/' + item.real_rip + '" target="_blank">' + item.real_rip + "</a>";
+              var real_rip = item.real_rip.startsWith("Web") ? item.real_rip : '<a href="https://bgp.tools/prefix/' + item.real_rip + '" target="_blank">' + item.real_rip + "</a>";
               var ip_location = item.location ? ' <span class="flag-icon flag-icon-' + item.location.toLowerCase() + '"></span>' : '';
               var ip_data = real_rip + ip_location + app_password;
               $(".last-login").append('<li class="list-group-item">' + local_datetime + " " + service + " " + lang.from + " " + ip_data + "</li>");

--- a/data/web/templates/admin/tab-config-f2b.twig
+++ b/data/web/templates/admin/tab-config-f2b.twig
@@ -110,7 +110,7 @@
         <p>
           <span class="badge fs-7 bg-info d-block d-sm-inline-block">
             <i class="bi bi-funnel-fill"></i>
-            <a href="https://bgp.he.net/ip/{{ active_ban.ip }}" target="_blank">
+            <a href="https://bgp.tools/prefix/{{ active_ban.ip }}" target="_blank">
               {{ active_ban.network }}
             </a>
             ({{ active_ban.banned_until }})
@@ -130,7 +130,7 @@
         <p>
           <span class="badge fs-7 bg-danger d-block d-sm-inline-block">
             <i class="bi bi-funnel-fill"></i>
-            <a href="https://bgp.he.net/ip/{{ perm_ban.ip }}" target="_blank">
+            <a href="https://bgp.tools/prefix/{{ perm_ban.ip }}" target="_blank">
               {{ perm_ban.network }}
             </a>
           </span>


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

This is a simple PR that replaces links to bgp.he.net with bgp.tools.

### Short Description

There are a few problems with bgp.he.net:

- It is slow (takes a few seconds to load)
- Pages contain a lot of irrelevant information (like links to other HE services
- HE is an American company

bgp.tools provides clear, easily readable pages, loads much faster and in my opinion is a better option for gathering such information.

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

This affects frontend code, so I <think> the nginx is container is 'affected'? 

## Did you run tests?

Yes

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
I tested manually to see if bgp.he.net/ip/9.9.9.9 delivers the same result and information as bgp.tools/prefix/9.9.9.9

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->