### PR TITLE
[Web] Fix SOGo access after Passwordless auth

### DIFF
--- a/data/web/inc/triggers.admin.inc.php
+++ b/data/web/inc/triggers.admin.inc.php
@@ -19,11 +19,16 @@ if (isset($_POST["verify_tfa_login"])) {
   unset($_SESSION['pending_tfa_methods']);
 }
 if (isset($_POST["verify_fido2_login"])) {
-  fido2(array(
+  $res = fido2(array(
     "action" => "verify",
     "token" => $_POST["token"],
     "user" => "admin"
   ));
+  if (is_array($res) && $res['role'] == "admin" && !empty($res['username'])){
+    $_SESSION["mailcow_cc_username"] = $res['username'];
+    $_SESSION["mailcow_cc_role"] = $res['role'];
+    $_SESSION["fido2_cid"] = $res['cid'];
+  }
   exit;
 }
 

--- a/data/web/inc/triggers.domainadmin.inc.php
+++ b/data/web/inc/triggers.domainadmin.inc.php
@@ -30,11 +30,16 @@ if (isset($_POST["verify_tfa_login"])) {
   unset($_SESSION['pending_tfa_methods']);
 }
 if (isset($_POST["verify_fido2_login"])) {
-  fido2(array(
+  $res = fido2(array(
     "action" => "verify",
     "token" => $_POST["token"],
     "user" => "domainadmin"
   ));
+  if (is_array($res) && $res['role'] == "domainadmin" && !empty($res['username'])){
+    $_SESSION["mailcow_cc_username"] = $res['username'];
+    $_SESSION["mailcow_cc_role"] = $res['role'];
+    $_SESSION["fido2_cid"] = $res['cid'];
+  }
   exit;
 }
 

--- a/data/web/inc/triggers.user.inc.php
+++ b/data/web/inc/triggers.user.inc.php
@@ -84,11 +84,15 @@ if (isset($_POST["verify_tfa_login"])) {
   unset($_SESSION['pending_tfa_methods']);
 }
 if (isset($_POST["verify_fido2_login"])) {
-  fido2(array(
+  $res = fido2(array(
     "action" => "verify",
     "token" => $_POST["token"],
     "user" => "user"
   ));
+  if (is_array($res) && $res['role'] == "user" && !empty($res['username'])){
+    set_user_loggedin_session($res['username']);
+    $_SESSION["fido2_cid"] = $res['cid'];
+  }
   exit;
 }
 


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->
Fixes https://github.com/mailcow/mailcow-dockerized/issues/6392

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
- PHP-FPM

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
I tested passwordless login for User, Domain Admin, and Admin accounts.

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->
Passwordless auth was successful for all roles and after user auth, I was able to access SOGo