### PR TITLE
[Web] Check if mailbox is active before renaming

### DIFF
--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -3324,7 +3324,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           }
 
           $is_now = mailbox('get', 'mailbox_details', $old_username);
-          if (empty($is_now)) {
+          if (empty($is_now) || ($is_now['active'] != '1' && $is_now['active'] != '2')) {
             $_SESSION['return'][] = array(
               'type' => 'danger',
               'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->
Fixes https://github.com/mailcow/mailcow-dockerized/issues/6372

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
- PHP-FPM

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
I tested mailbox renaming with the following states: `active`, `inactive`, and `disallow login`

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->
When the mailbox was in the inactive state, an error was returned.
