### PR TITLE
[Nginx] Move conf.d include before SNI vhosts

### DIFF
--- a/data/conf/nginx/templates/nginx.conf.j2
+++ b/data/conf/nginx/templates/nginx.conf.j2
@@ -182,6 +182,8 @@ http {
         }
     }
 
+    include /etc/nginx/conf.d/*.conf;
+
     {% for cert in valid_cert_dirs %}
     server {
         {% if not HTTP_REDIRECT %}
@@ -206,6 +208,4 @@ http {
         include /etc/nginx/includes/sites-default.conf;
     }
     {% endfor %}
-
-    include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->
Fixes https://github.com/mailcow/mailcow-dockerized/issues/6340

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
- Nginx

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
I created a custom vhost, added it as `ADDITIONAL_SAN` in `mailcow.conf`, and set `ENABLE_SNI=y`.

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->
Nginx throws warnings about `conflicting server name`, but it now correctly serves the intended vhost.