### PR TITLE
[Dovecot] Increase Timeout for HTTP Login Request

### DIFF
--- a/data/conf/dovecot/auth/passwd-verify.lua
+++ b/data/conf/dovecot/auth/passwd-verify.lua
@@ -3,10 +3,10 @@ function auth_password_verify(request, password)
     return dovecot.auth.PASSDB_RESULT_USER_UNKNOWN, "No such user"
   end
 
-  json = require "cjson"
-  ltn12 = require "ltn12"
-  https = require "ssl.https"
-  https.TIMEOUT = 5
+  local json = require "cjson"
+  local ltn12 = require "ltn12"
+  local https = require "ssl.https"
+  https.TIMEOUT = 30
 
   local req = {
     username = request.user,
@@ -16,8 +16,7 @@ function auth_password_verify(request, password)
   }
   req.protocol[request.service] = true
   local req_json = json.encode(req)
-  local res = {} 
-  
+  local res = {}
   local b, c = https.request {
     method = "POST",
     url = "https://nginx:9082",
@@ -29,11 +28,16 @@ function auth_password_verify(request, password)
     sink = ltn12.sink.table(res),
     insecure = true
   }
+
+  if c ~= 200 then
+    dovecot.i_info("HTTP request failed with " .. c .. " for user " .. request.user)
+    return dovecot.auth.PASSDB_RESULT_INTERNAL_FAILURE, "Upstream error"
+  end
+
   local api_response = json.decode(table.concat(res))
   if api_response.success == true then
     return dovecot.auth.PASSDB_RESULT_OK, ""
   end
-  
   return dovecot.auth.PASSDB_RESULT_PASSWORD_MISMATCH, "Failed to authenticate"
 end
 


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->
On certain instances, the 5 second timeout for the HTTP login request from Dovecot was not enough.
This PR increases the timeout to 30 seconds and adds extended logging for debugging.

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
- Dovecot
