### PR TITLE
Allow additional domains in OAuth2 redirect URLs

### DIFF
--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -5847,6 +5847,7 @@ paths:
                           client_id: "mailcow_client"
                           client_secret: "*"
                           redirect_url: "https://mail.mailcow.tld"
+                          redirect_url_extra: ["https://extramail.mailcow.tld"]
                           version: "26.1.3"
                           default_template: "Default"
                           mappers:
@@ -5900,6 +5901,9 @@ paths:
                     redirect_url:
                       description: The redirect URL that OIDC Provider will use after authentication. Required if `authsource` is keycloak or generic-oidc.
                       type: string
+                    redirect_url_extra:
+                      description: Additional redirect URLs that OIDC Provider can use after authentication if valid.
+                      type: array
                     version:
                       description: Specifies the Keycloak version. Required if `authsource` is keycloak.
                       type: string
@@ -5990,6 +5994,7 @@ paths:
                     client_id: "mailcow_client"
                     client_secret: "Xy7GdPqvJ9m3R8sT2LkVZ5W1oNbCaYQf"
                     redirect_url: "https://mail.mailcow.tld"
+                    redirect_url_extra: ["https://extramail.mailcow.tld"]
                     version: "26.1.3"
                     default_template: "Default"
                     mappers: ["small_mbox", "medium_mbox"]
@@ -6034,6 +6039,7 @@ paths:
                     client_id: "mailcow_client"
                     client_secret: "Xy7GdPqvJ9m3R8sT2LkVZ5W1oNbCaYQf"
                     redirect_url: "https://mail.mailcow.tld"
+                    redirect_url_extra: ["https://extramail.mailcow.tld"]
                     client_scopes: "openid profile email mailcow_template"
                     default_template: "Default"
                     mappers: ["small_mbox", "medium_mbox"]

--- a/data/web/js/site/admin.js
+++ b/data/web/js/site/admin.js
@@ -789,6 +789,18 @@ jQuery(function($){
   $('.iam_ldap_rolemap_del').click(async function(e){
     deleteAttributeMappingRow(this, e);
   });
+  $('.iam_redirect_add_keycloak').click(async function(e){
+    addRedirectUrlRow('#iam_keycloak_redirect_list', '.iam_keycloak_redirect_del', e);
+  });
+  $('.iam_redirect_add_generic').click(async function(e){
+    addRedirectUrlRow('#iam_generic_redirect_list', '.iam_generic_redirect_del', e);
+  });
+  $('.iam_keycloak_redirect_del').click(async function(e){
+    deleteRedirectUrlRow(this, e);
+  });
+  $('.iam_generic_redirect_del').click(async function(e){
+    deleteRedirectUrlRow(this, e);
+  });
   // selecting identity provider
   $('#iam_provider').on('change', function(){
     // toggle password fields
@@ -831,6 +843,24 @@ jQuery(function($){
     if(!$(elem).parent().parent().parent().find('select').prop('required'))
       return true;
     if ($(elem).parent().parent().parent().parent().children().length > 1)
+      $(elem).parent().parent().parent().remove();
+  }
+  function addRedirectUrlRow(list_id, del_class, e) {
+    e.preventDefault();
+
+    var parent = $(list_id)
+    $(parent).children().last().clone().appendTo(parent);
+    var newChild = $(parent).children().last();
+    $(newChild).find('input').val('');
+
+    $(del_class).off('click');
+    $(del_class).click(async function(e){
+      deleteRedirectUrlRow(this, e);
+    });
+  }
+  function deleteRedirectUrlRow(elem, e) {
+    e.preventDefault();
+    if ($(elem).parent().parent().parent().parent().children().length > 2)
       $(elem).parent().parent().parent().remove();
   }
 });

--- a/data/web/templates/admin/tab-config-identity-provider.twig
+++ b/data/web/templates/admin/tab-config-identity-provider.twig
@@ -64,10 +64,42 @@
           </div>
           <div class="row mb-2">
             <div class="col-md-3 d-flex align-items-center justify-content-md-end">
-              <label class="control-label" for="iam_keycloak_redirecturl">{{ lang.admin.iam_redirect_url }}:</label>
+              <label class="control-label">{{ lang.admin.iam_redirect_url }}:</label>
             </div>
             <div class="col-12 col-md-9 col-lg-4">
-              <input type="text" class="form-control" id="iam_keycloak_redirecturl" name="redirect_url" value="{{ iam_settings.redirect_url }}" required>
+              <div class="row px-2 align-items-center">
+                <span class="col-10 p-0 pe-2">
+                  <input type="text" class="form-control"  name="redirect_url" value="{{ iam_settings.redirect_url }}" required>
+                </span>
+                <div class="col-2 p-0 d-flex">
+                  <button class="btn btn-sm d-block d-sm-inline btn-secondary ms-auto iam_redirect_add_keycloak"><i class="bi bi-plus-lg"></i></button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="row mb-2" id="iam_keycloak_redirect_list">
+            <input type="hidden" name="redirect_url_extra" value="">
+            {% for key, url in iam_settings.redirect_url_extra %}
+            <div class="offset-md-3 col-12 col-md-9 col-lg-4 mb-2">
+              <div class="row px-2">
+                <div class="col-10 p-0 pe-2">
+                  <input type="text" class="form-control me-2" name="redirect_url_extra" value="{{ iam_settings.redirect_url_extra[key] }}">
+                </div>
+                <div class="col-2 p-0 d-flex">
+                  <button class="iam_keycloak_redirect_del btn btn-sm d-block d-sm-inline btn-secondary ms-auto"><i class="bi bi-x-lg"></i></button>
+                </div>
+              </div>
+            </div>
+            {% endfor %}
+            <div class="offset-md-3 col-12 col-md-9 col-lg-4 mb-2">
+              <div class="row px-2">
+                <div class="col-10 p-0 pe-2">
+                  <input type="text" class="form-control me-2" name="redirect_url_extra" value="">
+                </div>
+                <div class="col-2 p-0 d-flex">
+                  <button class="iam_keycloak_redirect_del btn btn-sm d-block d-sm-inline btn-secondary ms-auto"><i class="bi bi-x-lg"></i></button>
+                </div>
+              </div>
             </div>
           </div>
           <div class="row mb-4">
@@ -274,10 +306,42 @@
           </div>
           <div class="row mb-2">
             <div class="col-md-3 d-flex align-items-center justify-content-md-end">
-              <label class="control-label" for="iam_redirect_url">{{ lang.admin.iam_redirect_url }}:</label>
+              <label class="control-label">{{ lang.admin.iam_redirect_url }}:</label>
             </div>
             <div class="col-12 col-md-9 col-lg-4">
-              <input type="text" class="form-control" id="iam_redirect_url" name="redirect_url" value="{{ iam_settings.redirect_url }}" required>
+              <div class="row px-2 align-items-center">
+                <span class="col-10 p-0 pe-2">
+                  <input type="text" class="form-control" name="redirect_url" value="{{ iam_settings.redirect_url }}" required>
+                </span>
+                <div class="col-2 p-0 d-flex">
+                  <button class="btn btn-sm d-block d-sm-inline btn-secondary ms-auto iam_redirect_add_generic"><i class="bi bi-plus-lg"></i></button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="row mb-2" id="iam_generic_redirect_list">
+            <input type="hidden" name="redirect_url_extra" value="">
+            {% for key, url in iam_settings.redirect_url_extra %}
+            <div class="offset-md-3 col-12 col-md-9 col-lg-4 mb-2">
+              <div class="row px-2">
+                <div class="col-10 p-0 pe-2">
+                  <input type="text" class="form-control me-2" name="redirect_url_extra" value="{{ iam_settings.redirect_url_extra[key] }}">
+                </div>
+                <div class="col-2 p-0 d-flex">
+                  <button class="iam_generic_redirect_del btn btn-sm d-block d-sm-inline btn-secondary ms-auto"><i class="bi bi-x-lg"></i></button>
+                </div>
+              </div>
+            </div>
+            {% endfor %}
+            <div class="offset-md-3 col-12 col-md-9 col-lg-4 mb-2">
+              <div class="row px-2">
+                <div class="col-10 p-0 pe-2">
+                  <input type="text" class="form-control me-2" name="redirect_url_extra" value="">
+                </div>
+                <div class="col-2 p-0 d-flex">
+                  <button class="iam_generic_redirect_del btn btn-sm d-block d-sm-inline btn-secondary ms-auto"><i class="bi bi-x-lg"></i></button>
+                </div>
+              </div>
             </div>
           </div>
           <div class="row mb-4">


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->

Currently with OAuth2, you must set a redirect URL that the OAuth provider will redirect users to after authentication.

If you want mailcow to be available on multiple domains (for example a dedicated SOGo subdomain), OAuth2 login will redirect back to the primary domain, leaving the additional domain unusable.

This lets you define additional redirect URLs, and attempts to match them based on your current domain to send to the provider.

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

- nginx
- php-fpm

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->

Adding/editing identity providers with 0, 1 and 2 additional URLs specified.

Logging in with OAuth2 from 2 domains pointing to mailcow.

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->

I was able to login from both my primary, and webmail domains. The OAuth provider got the correct redirect URL depending on which domain I started on, and redirected me back to the appropriate URL.