### PR TITLE
[Web] Fix force password update at next login

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -1001,6 +1001,7 @@ function edit_user_account($_data) {
       ':password_hashed' => $password_hashed,
       ':username' => $username
     ));
+    $_SESSION['pending_pw_update'] = false;
 
     update_sogo_static_view();
   }

--- a/data/web/inc/triggers.user.inc.php
+++ b/data/web/inc/triggers.user.inc.php
@@ -76,7 +76,9 @@ if (isset($_POST["verify_tfa_login"])) {
 
         $user_details = mailbox("get", "mailbox_details", $_SESSION['mailcow_cc_username']);
         $is_dual = (!empty($_SESSION["dual-login"]["username"])) ? true : false;
-        if (intval($user_details['attributes']['sogo_access']) == 1 && !$is_dual) {
+        if (intval($user_details['attributes']['sogo_access']) == 1 &&
+            intval($user_details['attributes']['force_pw_update']) != 1 &&
+            !$is_dual) {
           header("Location: /SOGo/so/{$_SESSION['mailcow_cc_username']}");
           die();
         } else {
@@ -139,7 +141,9 @@ if (isset($_POST["login_user"]) && isset($_POST["pass_user"])) {
 
     $user_details = mailbox("get", "mailbox_details", $login_user);
     $is_dual = (!empty($_SESSION["dual-login"]["username"])) ? true : false;
-    if (intval($user_details['attributes']['sogo_access']) == 1 && !$is_dual) {
+    if (intval($user_details['attributes']['sogo_access']) == 1 &&
+        intval($user_details['attributes']['force_pw_update']) != 1 &&
+        !$is_dual) {
       header("Location: /SOGo/so/{$login_user}");
       die();
     } else {

--- a/data/web/sogo-auth.php
+++ b/data/web/sogo-auth.php
@@ -94,7 +94,8 @@ elseif (isset($_SERVER['HTTP_X_ORIGINAL_URI']) && strcasecmp(substr($_SERVER['HT
         !empty($email) &&
         filter_var($email, FILTER_VALIDATE_EMAIL) &&
         is_array($_SESSION[$session_var_user_allowed]) &&
-        in_array($email, $_SESSION[$session_var_user_allowed])
+        in_array($email, $_SESSION[$session_var_user_allowed]) &&
+        !$_SESSION['pending_pw_update']
     ) {
       $username = $email;
       $password = file_get_contents("/etc/sogo-sso/sogo-sso.pass");


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Fixes https://github.com/mailcow/mailcow-dockerized/issues/6469

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
- PHP-FPM

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
I enabled **Force password update at next login** for a user and confirmed that they were redirected to the mailcow UI after login. Access to SOGo was blocked until the user updated their password.
