### PR TITLE
[Dovecot] Fix EAS login issue with app passwords and improve auth cache handling in Dovecot

### DIFF
--- a/data/conf/dovecot/auth/mailcowauth.php
+++ b/data/conf/dovecot/auth/mailcowauth.php
@@ -79,7 +79,9 @@ if ($isSOGoRequest) {
   }
 }
 if ($result === false){
-  $result = apppass_login($post['username'], $post['password'], array($post['service'] => true), array(
+  // If it's a SOGo Request, don't check for protocol access
+  $service = (isSOGoRequest) ? false : array($post['service'] => true);
+  $result = apppass_login($post['username'], $post['password'], $service, array(
     'is_internal' => true,
     'remote_addr' => $post['real_rip']
   ));

--- a/data/conf/dovecot/auth/mailcowauth.php
+++ b/data/conf/dovecot/auth/mailcowauth.php
@@ -80,7 +80,7 @@ if ($isSOGoRequest) {
 }
 if ($result === false){
   // If it's a SOGo Request, don't check for protocol access
-  $service = (isSOGoRequest) ? false : array($post['service'] => true);
+  $service = ($isSOGoRequest) ? false : array($post['service'] => true);
   $result = apppass_login($post['username'], $post['password'], $service, array(
     'is_internal' => true,
     'remote_addr' => $post['real_rip']

--- a/data/conf/dovecot/auth/passwd-verify.lua
+++ b/data/conf/dovecot/auth/passwd-verify.lua
@@ -29,7 +29,7 @@ function auth_password_verify(request, password)
     insecure = true
   }
 
-  if c ~= 200 then
+  if c ~= 200 and c ~= 401 then
     dovecot.i_info("HTTP request failed with " .. c .. " for user " .. request.user)
     return dovecot.auth.PASSDB_RESULT_INTERNAL_FAILURE, "Upstream error"
   end

--- a/data/conf/dovecot/auth/passwd-verify.lua
+++ b/data/conf/dovecot/auth/passwd-verify.lua
@@ -34,8 +34,15 @@ function auth_password_verify(request, password)
     return dovecot.auth.PASSDB_RESULT_INTERNAL_FAILURE, "Upstream error"
   end
 
-  local api_response = json.decode(table.concat(res))
-  if api_response.success == true then
+  local response_str = table.concat(res)
+  local is_response_valid, response_json = pcall(json.decode, response_str)
+
+  if not is_response_valid then
+    dovecot.i_info("Invalid JSON received: " .. response_str)
+    return dovecot.auth.PASSDB_RESULT_INTERNAL_FAILURE, "Invalid response format"
+  end
+
+  if response_json.success == true then
     return dovecot.auth.PASSDB_RESULT_OK, ""
   end
 


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

- Fixes https://github.com/mailcow/mailcow-dockerized/issues/6470
- Avoids misleading `Upstream error` log when credentials are wrong.
- `passwd-verify.lua` now returns `PASSDB_RESULT_PASSWORD_MISMATCH` on failed login to ensure auth cache is cleared when TTL expires.

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
- Dovecot

## Did you run tests?

### What did you tested?

- I created an app password restricted to EAS and confirmed that authentication via the EAS protocol succeeds using the generated credentials.
- I tested that the auth cache is correctly cleared when logging in with wrong credentials, after the TTL expired.