### PR TITLE
feat: Add mailbox_cleaner.py script for automated cleanup

### DIFF
--- a/helper-scripts/mailbox_cleaner.py
+++ b/helper-scripts/mailbox_cleaner.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+This script cleans up old messages from specified mailboxes (e.g., Trash, Junk)
+in a Mailcow environment. It can process a single user or all users, and it
+supports dry-run mode.
+
+Ideally, this script should be run daily via cron.
+"""
+
+import argparse
+import logging
+import os
+import re
+import subprocess
+import sys
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+DEFAULT_DAYS_BACK: int = 30
+DEFAULT_MAILCOW_DIR: str = "/opt/mailcow-dockerized"
+DEFAULT_MAILBOXES: list[str] = ["Trash", "Junk"]
+
+
+def _run_doveadm_command(mailcow_dir: str, user: str | None, command: list[str]) -> str:
+    """
+    Runs a doveadm command within the dovecot-mailcow container.
+
+    Args:
+        mailcow_dir: The path to the mailcow-dockerized directory.
+        user: The email address of the user to run the command for, or None for all users.
+        command: The doveadm command to run as a list of strings.
+
+    Returns:
+        The standard output of the command.
+    """
+    command = ["docker", "compose", "--project-directory", mailcow_dir, "exec", "-T", "dovecot-mailcow",
+               "doveadm"] + command
+    if user:
+        command.extend(["-u", user])
+    logging.debug(f"Executing command: {' '.join(command)}")
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        logging.error(f"Command execution failed: {' '.join(command)} (return code: {e.returncode})")
+        logging.error(f"Stderr: {e.stderr}")
+        logging.error(f"Stdout: {e.stdout}")
+        raise
+
+
+def main() -> None:
+    """
+    Main function to parse arguments and execute the cleanup process.
+    """
+    parser = argparse.ArgumentParser(
+        description="Clean up old messages from specified mailboxes in a Mailcow environment.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--user", help="Email address of the single user to process.")
+    group.add_argument("--all", action="store_true", help="Process all users found via doveadm.")
+    parser.add_argument("--days-back", type=int, default=DEFAULT_DAYS_BACK,
+                        help="Number of days back to consider for message deletion.")
+    parser.add_argument("--mailcow-directory", default=DEFAULT_MAILCOW_DIR,
+                        help="Path to the mailcow-dockerized directory.")
+    parser.add_argument("--mailboxes", nargs='+', default=DEFAULT_MAILBOXES,
+                        help="List of top-level mailboxes (and their subfolders) to process (e.g., Trash Junk).")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging.")
+    parser.add_argument("--dry-run", action="store_true", help="Perform a dry run without deleting anything.")
+
+    args = parser.parse_args()
+
+    if args.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    if not os.path.isdir(args.mailcow_directory):
+        raise FileNotFoundError(
+            f"Mailcow directory '{args.mailcow_directory}' does not exist or is not a directory.")
+    # If --all is specified, get all users
+    if args.all:
+        doveadm_output = _run_doveadm_command(args.mailcow_directory, None, ["user", "*"])
+        users = [line.strip() for line in doveadm_output.splitlines() if line.strip()]
+    # Otherwise, use the specified user
+    else:
+        try:
+            _run_doveadm_command(args.mailcow_directory, None, ["user", args.user])
+        except subprocess.CalledProcessError:
+            logging.error(f"User '{args.user}' not found.")
+            sys.exit(1)
+        users = [args.user]
+    logging.info(f"Starting processing for {len(users)} users.")
+    logging.debug(f"Users to process: {', '.join(users)}")
+    # Iterate over each user
+    for user in users:
+        # Get all mailboxes for the current user
+        logging.info(f"Processing user: '{user}'.")
+        doveadm_output = _run_doveadm_command(args.mailcow_directory, user, ["mailbox", "list"])
+        # get all user mailboxes, sorted in reverse order
+        mailboxes = sorted([line.strip() for line in doveadm_output.splitlines() if line.strip()], reverse=True)
+        logging.info(f"User '{user}' has {len(mailboxes)} mailboxes.")
+        logging.debug(f"Mailboxes for user '{user}': {', '.join(mailboxes)}")
+        for mailbox in mailboxes:
+            # Iterate over each mailbox
+            logging.debug(f"Processing mailbox '{mailbox}' for user '{user}'.")
+            # Check if the mailbox is a target mailbox
+            if not any(re.match(rf"{re.escape(tmb)}(/|$)", mailbox, re.IGNORECASE) for tmb in args.mailboxes):
+                logging.debug(f"Skipping mailbox '{mailbox}' for user '{user}' as it is not a target mailbox.")
+                continue
+            # Expunge old messages from the mailbox
+            logging.info(
+                f"Expunging messages older than {args.days_back} days from mailbox '{mailbox}' for user '{user}'.")
+            if args.dry_run:
+                logging.info(f"[DRY-RUN] Skipping expunge command for mailbox '{mailbox}' of user '{user}'.")
+            else:
+                # Run the expunge command
+                _run_doveadm_command(args.mailcow_directory, user,
+                                     ["expunge", "mailbox", mailbox, "savedbefore", f"{args.days_back}d"])
+            # Check if the mailbox is a sub-mailbox
+            if "/" not in mailbox:
+                logging.debug(
+                    f"Skipping deletion check for top-level mailbox '{mailbox}' to preserve standard folders.")
+                continue
+            # Check if the mailbox is empty
+            doveadm_output = _run_doveadm_command(args.mailcow_directory, user, ["mailbox", "status", "messages", mailbox])
+            messages_count = int(doveadm_output.split("=")[1])
+            logging.debug(f"Mailbox '{mailbox}' for user '{user}' contains {messages_count} messages.")
+            if messages_count > 0:
+                logging.info(f"Skipping deletion of mailbox '{mailbox}' for user '{user}' as it is not empty.")
+                continue
+            # Delete the mailbox if it's empty
+            logging.info(f"Deleting mailbox '{mailbox}' for user '{user}' (only if empty).")
+            if args.dry_run:
+                logging.info(f"[DRY-RUN] Skipping delete command for mailbox '{mailbox}' of user '{user}'.")
+            else:
+                # As a safeguard, -e flag prevents mailbox deletion in case it's not empty
+                _run_doveadm_command(args.mailcow_directory, user, ["mailbox", "delete", "-e", "-s", mailbox])
+
+
+if __name__ == "__main__":
+    main()

--- a/helper-scripts/mailbox_cleaner.py
+++ b/helper-scripts/mailbox_cleaner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 This script cleans up old messages from specified mailboxes (e.g., Trash, Junk)
-in a Mailcow environment. It can process a single user or all users, and it
+in a mailcow environment. It can process a single user or all users, and it
 supports dry-run mode.
 
 Ideally, this script should be run daily via cron.
@@ -53,7 +53,7 @@ def main() -> None:
     Main function to parse arguments and execute the cleanup process.
     """
     parser = argparse.ArgumentParser(
-        description="Clean up old messages from specified mailboxes in a Mailcow environment.",
+        description="Clean up old messages from specified mailboxes in a mailcow environment.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     group = parser.add_mutually_exclusive_group(required=True)
@@ -75,7 +75,7 @@ def main() -> None:
 
     if not os.path.isdir(args.mailcow_directory):
         raise FileNotFoundError(
-            f"Mailcow directory '{args.mailcow_directory}' does not exist or is not a directory.")
+            f"mailcow directory '{args.mailcow_directory}' does not exist or is not a directory.")
     # If --all is specified, get all users
     if args.all:
         doveadm_output = _run_doveadm_command(args.mailcow_directory, None, ["user", "*"])

--- a/helper-scripts/mailbox_cleaner.py
+++ b/helper-scripts/mailbox_cleaner.py
@@ -96,7 +96,7 @@ def main() -> None:
         logging.info(f"Processing user: '{user}'.")
         doveadm_output = _run_doveadm_command(args.mailcow_directory, user, ["mailbox", "list"])
         # get all user mailboxes, sorted in reverse order
-        mailboxes = sorted([line.strip() for line in doveadm_output.splitlines() if line.strip()], reverse=True)
+        mailboxes = sorted([line.rstrip('\n\r') for line in doveadm_output.splitlines() if line.rstrip('\n\r')], reverse=True)
         logging.info(f"User '{user}' has {len(mailboxes)} mailboxes.")
         logging.debug(f"Mailboxes for user '{user}': {', '.join(mailboxes)}")
         for mailbox in mailboxes:
@@ -106,34 +106,37 @@ def main() -> None:
             if not any(re.match(rf"{re.escape(tmb)}(/|$)", mailbox, re.IGNORECASE) for tmb in args.mailboxes):
                 logging.debug(f"Skipping mailbox '{mailbox}' for user '{user}' as it is not a target mailbox.")
                 continue
-            # Expunge old messages from the mailbox
-            logging.info(
-                f"Expunging messages older than {args.days_back} days from mailbox '{mailbox}' for user '{user}'.")
-            if args.dry_run:
-                logging.info(f"[DRY-RUN] Skipping expunge command for mailbox '{mailbox}' of user '{user}'.")
-            else:
-                # Run the expunge command
-                _run_doveadm_command(args.mailcow_directory, user,
-                                     ["expunge", "mailbox", mailbox, "savedbefore", f"{args.days_back}d"])
-            # Check if the mailbox is a sub-mailbox
-            if "/" not in mailbox:
-                logging.debug(
-                    f"Skipping deletion check for top-level mailbox '{mailbox}' to preserve standard folders.")
-                continue
-            # Check if the mailbox is empty
-            doveadm_output = _run_doveadm_command(args.mailcow_directory, user, ["mailbox", "status", "messages", mailbox])
-            messages_count = int(doveadm_output.split("=")[1])
-            logging.debug(f"Mailbox '{mailbox}' for user '{user}' contains {messages_count} messages.")
-            if messages_count > 0:
-                logging.info(f"Skipping deletion of mailbox '{mailbox}' for user '{user}' as it is not empty.")
-                continue
-            # Delete the mailbox if it's empty
-            logging.info(f"Deleting mailbox '{mailbox}' for user '{user}' (only if empty).")
-            if args.dry_run:
-                logging.info(f"[DRY-RUN] Skipping delete command for mailbox '{mailbox}' of user '{user}'.")
-            else:
-                # As a safeguard, -e flag prevents mailbox deletion in case it's not empty
-                _run_doveadm_command(args.mailcow_directory, user, ["mailbox", "delete", "-e", "-s", mailbox])
+            try:
+                # Expunge old messages from the mailbox
+                logging.info(
+                    f"Expunging messages older than {args.days_back} days from mailbox '{mailbox}' for user '{user}'.")
+                if args.dry_run:
+                    logging.info(f"[DRY-RUN] Skipping expunge command for mailbox '{mailbox}' of user '{user}'.")
+                else:
+                    # Run the expunge command
+                    _run_doveadm_command(args.mailcow_directory, user,
+                                         ["expunge", "mailbox", mailbox, "savedbefore", f"{args.days_back}d"])
+                # Check if the mailbox is a sub-mailbox
+                if "/" not in mailbox:
+                    logging.debug(
+                        f"Skipping deletion check for top-level mailbox '{mailbox}' to preserve standard folders.")
+                    continue
+                # Check if the mailbox is empty
+                doveadm_output = _run_doveadm_command(args.mailcow_directory, user, ["mailbox", "status", "messages", mailbox])
+                messages_count = int(doveadm_output.split("=")[1])
+                logging.debug(f"Mailbox '{mailbox}' for user '{user}' contains {messages_count} messages.")
+                if messages_count > 0:
+                    logging.info(f"Skipping deletion of mailbox '{mailbox}' for user '{user}' as it is not empty.")
+                    continue
+                # Delete the mailbox if it's empty
+                logging.info(f"Deleting mailbox '{mailbox}' for user '{user}' (only if empty).")
+                if args.dry_run:
+                    logging.info(f"[DRY-RUN] Skipping delete command for mailbox '{mailbox}' of user '{user}'.")
+                else:
+                    # As a safeguard, -e flag prevents mailbox deletion in case it's not empty
+                    _run_doveadm_command(args.mailcow_directory, user, ["mailbox", "delete", "-e", "-s", mailbox])
+            except subprocess.CalledProcessError:
+                logging.warning(f"Skipping mailbox '{mailbox}' for user '{user}' due to doveadm error (may contain special characters).")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a Python script to expunge old emails from specified mailboxes (e.g., Trash, Junk) and remove empty subfolders. Supports single-user, all-user, and dry-run modes.

<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Adds a Python script (`mailbox_cleaner.py`) located in `helper-scripts/` designed to automatically clean up old emails from specified mailboxes (defaults to Trash, Junk) for single or all users in a Mailcow installation. It includes features like configurable retention days, dry-run mode, and automatic deletion of empty subfolders within the target mailboxes. Intended for cron job execution.

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

- None (This PR only adds the script to the repository structure; it does not modify any existing container images or configurations.)

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
- Tested script execution with Python 3.x.
- Tested against a live Mailcow instance.
- Validated `--user <email>` argument for single-user processing.
- Validated `--all` argument for multi-user processing.
- Validated `--dry-run` functionality (logs actions without performing them).
- Tested default `--days-back 30` and custom values.
- Tested default mailboxes (`Trash`, `Junk`) and custom `--mailboxes` argument.
- Verified correct identification and processing of target mailboxes and their subfolders.
- Verified expunge logic based on `savedbefore <days>d`.
- Verified deletion logic for *empty* subfolders within target mailboxes.
- Verified that non-empty subfolders and top-level standard folders are not deleted.
- Checked standard and `--debug` logging output.

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->
- **Awaited:** Script correctly identifies target mailboxes/users, simulates actions in dry-run, expunges emails older than the specified period, and deletes empty subfolders under target mailboxes in normal mode.
- **Got:** The script performed exactly as awaited in all tested scenarios. Dry-run accurately predicted changes. Normal execution successfully cleaned up old emails and empty specified subfolders without affecting other data. Logs provided clear information.