### PR TITLE
Check if skip_sogo is not set before redirecting to SOGo

### DIFF
--- a/data/web/inc/triggers.user.inc.php
+++ b/data/web/inc/triggers.user.inc.php
@@ -76,7 +76,7 @@ if (isset($_POST["verify_tfa_login"])) {
 
         $user_details = mailbox("get", "mailbox_details", $_SESSION['mailcow_cc_username']);
         $is_dual = (!empty($_SESSION["dual-login"]["username"])) ? true : false;
-        if (intval($user_details['attributes']['sogo_access']) == 1 && !$is_dual) {
+        if (intval($user_details['attributes']['sogo_access']) == 1 && !$is_dual && getenv('SKIP_SOGO') != "y") {
           header("Location: /SOGo/so/{$_SESSION['mailcow_cc_username']}");
           die();
         } else {
@@ -139,7 +139,7 @@ if (isset($_POST["login_user"]) && isset($_POST["pass_user"])) {
 
     $user_details = mailbox("get", "mailbox_details", $login_user);
     $is_dual = (!empty($_SESSION["dual-login"]["username"])) ? true : false;
-    if (intval($user_details['attributes']['sogo_access']) == 1 && !$is_dual) {
+    if (intval($user_details['attributes']['sogo_access']) == 1 && !$is_dual && getenv('SKIP_SOGO') != "y") {
       header("Location: /SOGo/so/{$login_user}");
       die();
     } else {

--- a/data/web/index.php
+++ b/data/web/index.php
@@ -11,7 +11,7 @@ if (isset($_SESSION['mailcow_cc_role']) && isset($_SESSION['oauth2_request'])) {
 elseif (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == 'user') {
   $user_details = mailbox("get", "mailbox_details", $_SESSION['mailcow_cc_username']);
   $is_dual = (!empty($_SESSION["dual-login"]["username"])) ? true : false;
-  if (intval($user_details['attributes']['sogo_access']) == 1 && !$is_dual) {
+  if (intval($user_details['attributes']['sogo_access']) == 1 && !$is_dual && getenv('SKIP_SOGO') != "y") {
     header("Location: /SOGo/so/{$_SESSION['mailcow_cc_username']}");
   } else {
     header("Location: /user");


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them


## What does this PR include?

### Short Description

The PR fixes mailcow#6494 through checking if SKIP_SOGO is set and redirecting to /user (mailcow UI) in that case. 

###  Affected Containers

- php-fpm


## Did you run tests?

### What did you tested?

I logged into mailcow. 

### What were the final results? (Awaited, got)

Instead of being redirected to SOGo (I have SKIP_SOGo set) I got redirected to mailcow UI. 