### PR TITLE
Fix typo in rspamd rule in composites.conf

### DIFF
--- a/data/conf/rspamd/local.d/composites.conf
+++ b/data/conf/rspamd/local.d/composites.conf
@@ -8,7 +8,7 @@ VIRUS_FOUND {
 }
 # Bad policy from free mail providers
 FREEMAIL_POLICY_FAILURE {
-  expression = "FREEMAIL_FROM & !DMARC_POLICY_ALLOW & !MAILLIST& !WHITELISTED_FWD_HOST & -g+:policies";
+  expression = "FREEMAIL_FROM & !DMARC_POLICY_ALLOW & !MAILLIST & !WHITELISTED_FWD_HOST & -g+:policies";
   score = 16.0;
 }
 # Applies to freemail with undisclosed recipients


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

The FREEMAIL_POLICY_FAILURE rule in Rspamd lacked a space character in its definition.

###  Affected Containers

- Rspamd

## Did you run tests?

### What did you tested?

No testing needed, simple typo fix.

### What were the final results? (Awaited, got)

No longer has typo.