### PR TITLE
[fix] Clamav score for FP CLAM_SECI_SPAM symbol

### DIFF
--- a/data/conf/rspamd/local.d/composites.conf
+++ b/data/conf/rspamd/local.d/composites.conf
@@ -76,7 +76,7 @@ ENCRYPTED_CHAT {
 CLAMD_SPAM_FOUND {
   expression = "CLAM_SECI_SPAM & !MAILCOW_WHITE";
   description = "Probably Spam, Securite Spam Flag set through ClamAV";
-  score = 5;
+  score = 1;
 }
 
 CLAMD_BAD_PDF {


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [ ] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?
Decrease CLAM_SECI_SPAM score to 1 instead of 5 to low quality of database and significant false-positive rate

### Short Description
`spam_marketing.ndb` is very false positive database that listing hex values of emails without proper separation, f.e. it contains hashes like `SecuriteInfo.com.Spam-120111:0:*:726a40676d61696c2e636f6d` which decoded as `rj@gmail.com` and doesn't contain any limitations, meaning that any email body that contains `rj@gmail.com` in any way will be treated as spam and get 5 score. This total nonsence. In addition `SecuriteInfo.com` do not answer on questions by email or contact form to exclude some hashes from their databases based on my personal experience.

<!-- Please write a short description, what your PR does here. -->

###  Affected Containers

- rspamd
<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

## Did you run tests?
no, it not necessary for this small change

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->