### PR TITLE
[DB][Web] optimize qhandler by keeping SHA2 in new column qhash

### DIFF
--- a/data/Dockerfiles/dovecot/quarantine_notify.py
+++ b/data/Dockerfiles/dovecot/quarantine_notify.py
@@ -75,7 +75,7 @@ try:
 
   def notify_rcpt(rcpt, msg_count, quarantine_acl, category):
     if category == "add_header": category = "add header"
-    meta_query = query_mysql('SELECT SHA2(CONCAT(id, qid), 256) AS qhash, id, subject, score, sender, created, action FROM quarantine WHERE notified = 0 AND rcpt = "%s" AND score < %f AND (action = "%s" OR "all" = "%s")' % (rcpt, max_score, category, category))
+    meta_query = query_mysql('SELECT `qhash`, id, subject, score, sender, created, action FROM quarantine WHERE notified = 0 AND rcpt = "%s" AND score < %f AND (action = "%s" OR "all" = "%s")' % (rcpt, max_score, category, category))
     print("%s: %d of %d messages qualify for notification" % (rcpt, len(meta_query), msg_count))
     if len(meta_query) == 0:
       return

--- a/data/conf/rspamd/meta_exporter/pipe.php
+++ b/data/conf/rspamd/meta_exporter/pipe.php
@@ -236,6 +236,7 @@ foreach ($rcpt_final_mailboxes as $rcpt_final) {
       ':action' => $action,
       ':fuzzy_hashes' => $fuzzy
     ));
+    $pdo->query("UPDATE `quarantine` SET `qhash` = SHA2(CONCAT(`id`, `qid`), 256) WHERE ISNULL(`qhash`)");
     $stmt = $pdo->prepare('DELETE FROM `quarantine` WHERE `rcpt` = :rcpt AND `id` NOT IN (
       SELECT `id`
       FROM (

--- a/data/conf/rspamd/meta_exporter/pipe.php
+++ b/data/conf/rspamd/meta_exporter/pipe.php
@@ -236,7 +236,9 @@ foreach ($rcpt_final_mailboxes as $rcpt_final) {
       ':action' => $action,
       ':fuzzy_hashes' => $fuzzy
     ));
-    $pdo->query("UPDATE `quarantine` SET `qhash` = SHA2(CONCAT(`id`, `qid`), 256) WHERE ISNULL(`qhash`)");
+    $lastId = $pdo->lastInsertId();
+    $stmt_update = $pdo->prepare("UPDATE `quarantine` SET `qhash` = SHA2(CONCAT(`id`, `qid`), 256) WHERE `id` = :id");
+    $stmt_update->execute(array(':id' => $lastId));
     $stmt = $pdo->prepare('DELETE FROM `quarantine` WHERE `rcpt` = :rcpt AND `id` NOT IN (
       SELECT `id`
       FROM (

--- a/data/web/inc/functions.quarantine.inc.php
+++ b/data/web/inc/functions.quarantine.inc.php
@@ -22,7 +22,7 @@ function quarantine($_action, $_data = null) {
         return false;
       }
       $stmt = $pdo->prepare('SELECT `id` FROM `quarantine` LEFT OUTER JOIN `user_acl` ON `user_acl`.`username` = `rcpt`
-        WHERE SHA2(CONCAT(`id`, `qid`), 256) = :hash
+        WHERE `qhash` = :hash
           AND user_acl.quarantine = 1
           AND rcpt IN (SELECT username FROM mailbox)');
       $stmt->execute(array(':hash' => $hash));
@@ -65,7 +65,7 @@ function quarantine($_action, $_data = null) {
         return false;
       }
       $stmt = $pdo->prepare('SELECT `id` FROM `quarantine` LEFT OUTER JOIN `user_acl` ON `user_acl`.`username` = `rcpt`
-        WHERE SHA2(CONCAT(`id`, `qid`), 256) = :hash
+        WHERE `qhash` = :hash
           AND `user_acl`.`quarantine` = 1
           AND `username` IN (SELECT `username` FROM `mailbox`)');
       $stmt->execute(array(':hash' => $hash));
@@ -833,7 +833,7 @@ function quarantine($_action, $_data = null) {
         )));
         return false;
       }
-      $stmt = $pdo->prepare('SELECT * FROM `quarantine` WHERE SHA2(CONCAT(`id`, `qid`), 256) = :hash');
+      $stmt = $pdo->prepare('SELECT * FROM `quarantine` WHERE `qhash` = :hash');
       $stmt->execute(array(':hash' => $hash));
       return $stmt->fetch(PDO::FETCH_ASSOC);
     break;

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -4,7 +4,7 @@ function init_db_schema()
   try {
     global $pdo;
 
-    $db_version = "27012025_1555";
+    $db_version = "21052025_2215";
 
     $stmt = $pdo->query("SHOW TABLES LIKE 'versions'");
     $num_results = count($stmt->fetchAll(PDO::FETCH_ASSOC));
@@ -345,10 +345,14 @@ function init_db_schema()
           "notified" => "TINYINT(1) NOT NULL DEFAULT '0'",
           "created" => "DATETIME(0) NOT NULL DEFAULT NOW(0)",
           "user" => "VARCHAR(255) NOT NULL DEFAULT 'unknown'",
+          "qhash" => "VARCHAR(255)",
         ),
         "keys" => array(
           "primary" => array(
             "" => array("id")
+          ),
+          "key" => array(
+            "qhash" => array("qhash")
           )
         ),
         "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"
@@ -1482,6 +1486,10 @@ function init_db_schema()
         'msg' => 'db_init_complete'
       );
     }
+
+    // fill quarantine.qhash
+    $pdo->query("UPDATE `quarantine` SET `qhash` = SHA2(CONCAT(`id`, `qid`), 256) WHERE ISNULL(`qhash`)");
+
   } catch (PDOException $e) {
     if (php_sapi_name() == "cli") {
       echo "DB initialization failed: " . print_r($e, true) . PHP_EOL;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -251,7 +251,7 @@ services:
             - sogo
 
     dovecot-mailcow:
-      image: ghcr.io/mailcow/dovecot:2.33
+      image: ghcr.io/mailcow/dovecot:2.34
       depends_on:
         - mysql-mailcow
         - netfilter-mailcow


### PR DESCRIPTION
## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

The PR fulfills my feature request #6555 by adding and using a database column `quarantine.qhash` to keep the `SHA2(CONCAT(id, qid), 256)` persistant and avoid having mariadb re-compute that SHA2 for all rows in several situations rg. quarantinee e-mails, which takes about 1 second per 1000 rows on our largest system.

This is my first PR to a public project, sorry for any inconvenience ;-)

###  Affected Containers

- `sogo-mailcow`, through `data/web/inc/init_db.inc.php`
- `php-fpm-mailcow`
- `dovecot-mailcow` through `data/Dockerfiles/dovecot/quarantine_notify.py`
- `rspamd-mailcow` probably not, it does not seem to see `data/conf/rspamd/meta_exporter/pipe.php` though I'm not sure, sorry

## Did you run tests?

### What did you tested?

I very carefully applied the changes to a production system (phew) with some 40+ domains, 120+ maiboxes, 22000 quarantined e-mails, and 180+ GB of mail data overall.

### What were the final results? (Awaited, got)

**Before:** When clicking on a `delete` or `deliver to inbox` link in a quarantine notification mail the UI previously required some 11 seconds (1 per 1000 quarantined e-mails in the database) and sometimes 2 or 3 attempts to load.
Confirming the action took another 11+ seconds and sometimes led to the error message described in #6361.

**After** applying the changes manually, admittedly doing the 3 db scheme changes by hand to avoid leaving the stable 2025-05 branch on a production system, both tasks happen too fast to measure.
