### PR TITLE
feat: Implement OIDC logout support and configuration options Fixes #5774

### DIFF
--- a/data/conf/sogo/custom-sogo.js
+++ b/data/conf/sogo/custom-sogo.js
@@ -7,13 +7,19 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 // logout function
 function mc_logout() {
-    fetch("/", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded"
-        },
-        body: "logout=1"
-    }).then(() => window.location.href = '/');
+    // Create and submit a logout form to trigger the logout process
+    var form = document.createElement('form');
+    form.method = 'POST';
+    form.action = '/';
+    
+    var logoutInput = document.createElement('input');
+    logoutInput.type = 'hidden';
+    logoutInput.name = 'logout';
+    logoutInput.value = '1';
+    
+    form.appendChild(logoutInput);
+    document.body.appendChild(form);
+    form.submit();
 }
 
 // Custom SOGo JS

--- a/data/web/inc/sessions.inc.php
+++ b/data/web/inc/sessions.inc.php
@@ -110,12 +110,44 @@ if (isset($_POST["logout"])) {
   }
   else {
     $role = $_SESSION["mailcow_cc_role"];
+    
+    // Check if user was authenticated via OIDC and OIDC logout is enabled
+    $oidc_logout_url = null;
+    if (isset($_SESSION['iam_auth_source']) && ($_SESSION['iam_auth_source'] == 'keycloak' || $_SESSION['iam_auth_source'] == 'generic-oidc')) {
+      require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.inc.php';
+      
+      // Determine the schema
+      $schema = 'http';
+      if ((isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == "https") || 
+          isset($_SERVER['HTTPS'])) {
+        $schema = 'https';
+      }
+      
+      // Determine post-logout redirect URI based on role
+      $post_logout_redirect_uri = $schema . '://' . $_SERVER['HTTP_HOST'];
+      if ($role == "admin") {
+        $post_logout_redirect_uri .= '/admin';
+      } elseif ($role == "domainadmin") {
+        $post_logout_redirect_uri .= '/domainadmin';
+      } else {
+        $post_logout_redirect_uri .= '/';
+      }
+
+      $iam_provider = identity_provider('init');
+      $iam_settings = identity_provider('get');
+      $oidc_logout_url = identity_provider('get-logout-url', array('post_logout_redirect_uri' => $post_logout_redirect_uri));
+    }
+    
     session_regenerate_id(true);
     session_unset();
     session_destroy();
     session_write_close();
-    if ($role == "admin") {
-      header("Location: /admin");
+    
+    // Redirect to OIDC logout URL if available, otherwise use standard logout
+    if ($oidc_logout_url) {
+      header("Location: " . $oidc_logout_url);
+    } elseif($role == "admin") {
+        header("Location: /admin");
     }
     elseif ($role == "domainadmin") {
       header("Location: /domainadmin");

--- a/data/web/lang/lang.de-de.json
+++ b/data/web/lang/lang.de-de.json
@@ -241,6 +241,8 @@
         "iam_test_connection": "Verbindung Testen",
         "iam_token_url": "Token Endpunkt",
         "iam_userinfo_url": "User info Endpunkt",
+        "iam_end_session_url": "End-Session-Endpunkt",
+        "iam_end_session_url_info": "URL für RP-Initiated Logout nach OpenID Connect Spezifikation. Leer lassen, um OIDC-Logout zu deaktivieren.",
         "iam_username_field": "Username Feld",
         "iam_binddn": "Bind DN",
         "iam_use_ssl": "Benutze SSL",

--- a/data/web/lang/lang.en-gb.json
+++ b/data/web/lang/lang.en-gb.json
@@ -248,6 +248,8 @@
         "iam_test_connection": "Test Connection",
         "iam_token_url": "Token endpoint",
         "iam_userinfo_url": "User info endpoint",
+        "iam_end_session_url": "End session endpoint",
+        "iam_end_session_url_info": "URL for RP-Initiated Logout according to OpenID Connect specification. Leave empty to disable OIDC logout.",
         "iam_username_field": "Username Field",
         "iam_binddn": "Bind DN",
         "iam_use_ssl": "Use SSL",

--- a/data/web/templates/admin/tab-config-identity-provider.twig
+++ b/data/web/templates/admin/tab-config-identity-provider.twig
@@ -257,6 +257,19 @@
               <input class="form-control" type="number" min="1" name="sync_interval" style="width: 80px;"  {% if iam_settings.sync_interval %}value="{{ iam_settings.sync_interval }}"{% else %}value="15"{% endif %}>
             </div>
           </div>
+          <div class="row mb-2">
+            <div class="col-md-3 d-flex align-items-center justify-content-md-end">
+              <label class="control-label" for="iam_keycloak_end_session_url">{{ lang.admin.iam_end_session_url }}:</label>
+            </div>
+            <div class="col-12 col-md-9 col-lg-4">
+              <input type="text" class="form-control" id="iam_keycloak_end_session_url" name="end_session_url" value="{{ iam_settings.end_session_url }}" placeholder="https://keycloak.example.com/realms/mailcow/protocol/openid-connect/logout">
+              <p class="text-muted">
+                <small>
+                  {{ lang.admin.iam_end_session_url_info }}
+                </small>
+              </p>
+            </div>
+          </div>
           <div class="row mt-4 mb-2">
             <div class="offset-md-3 col-12 col-md-9 d-flex flex-wrap">
               <div class="btn-group mb-2">
@@ -458,6 +471,19 @@
               <div class="form-check form-switch">
                 <input class="form-check-input" type="checkbox" role="switch" name="login_provisioning"  value="1" {% if iam_settings.login_provisioning == 1 %}checked{% endif %}>
               </div>
+            </div>
+          </div>
+          <div class="row mb-4">
+            <div class="col-md-3 d-flex align-items-center justify-content-md-end">
+              <label class="control-label" for="iam_generic_end_session_url">{{ lang.admin.iam_end_session_url }}:</label>
+            </div>
+            <div class="col-12 col-md-9 col-lg-4">
+              <input type="text" class="form-control" id="iam_generic_end_session_url" name="end_session_url" value="{{ iam_settings.end_session_url }}" placeholder="https://auth.example.com/connect/endsession">
+              <p class="text-muted">
+                <small>
+                  {{ lang.admin.iam_end_session_url_info }}
+                </small>
+              </p>
             </div>
           </div>
           <div class="row mt-4 mb-2">


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

This PR implements OIDC (OpenID Connect) logout [Reference](https://openid.net/specs/openid-connect-rpinitiated-1_0.html) support and adds new configuration options for identity providers. This fixes issue #5774.

###  Affected Containers

- php-fpm
- sogo

## Did you run tests?

### What did you tested?

- OIDC authentication flow with logout functionality
- Admin panel identity provider configuration interface

### What were the final results? (Awaited, got)

**Awaited**: Proper OIDC logout functionality that correctly terminates sessions and redirects users.

**Got**: Successfully implemented OIDC logout support with proper session management.