### PR TITLE
Remove bind-mount options from volume mount mysql-socket-vol-1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       stop_grace_period: 45s
       volumes:
         - mysql-vol-1:/var/lib/mysql/
-        - mysql-socket-vol-1:/var/run/mysqld/:z
+        - mysql-socket-vol-1:/var/run/mysqld/
         - ./data/conf/mysql/:/etc/mysql/conf.d/:ro,Z
       environment:
         - TZ=${TZ}
@@ -134,7 +134,7 @@ services:
         - ./data/web/inc/functions.ratelimit.inc.php:/mailcowauth/functions.ratelimit.inc.php:z
         - ./data/web/inc/functions.acl.inc.php:/mailcowauth/functions.acl.inc.php:z
         - rspamd-vol-1:/var/lib/rspamd
-        - mysql-socket-vol-1:/var/run/mysqld/:z
+        - mysql-socket-vol-1:/var/run/mysqld/
         - ./data/conf/sogo/:/etc/sogo/:z
         - ./data/conf/rspamd/meta_exporter:/meta_exporter:ro,z
         - ./data/conf/phpfpm/crons:/crons:z
@@ -230,7 +230,7 @@ services:
         - ./data/conf/sogo/custom-fulllogo.png:/usr/lib/GNUstep/SOGo/WebServerResources/img/sogo-logo.png:z
         - ./data/conf/sogo/custom-theme.js:/usr/lib/GNUstep/SOGo/WebServerResources/js/theme.js:z
         - ./data/conf/sogo/custom-sogo.js:/usr/lib/GNUstep/SOGo/WebServerResources/js/custom-sogo.js:z
-        - mysql-socket-vol-1:/var/run/mysqld/:z
+        - mysql-socket-vol-1:/var/run/mysqld/
         - sogo-web-vol-1:/sogo_web
         - sogo-userdata-backup-vol-1:/sogo_backup
       labels:
@@ -272,7 +272,7 @@ services:
         - ./data/conf/rspamd/custom/:/etc/rspamd/custom:z
         - ./data/assets/templates:/templates:z
         - rspamd-vol-1:/var/lib/rspamd
-        - mysql-socket-vol-1:/var/run/mysqld/:z
+        - mysql-socket-vol-1:/var/run/mysqld/
       environment:
         - DOVECOT_MASTER_USER=${DOVECOT_MASTER_USER:-}
         - DOVECOT_MASTER_PASS=${DOVECOT_MASTER_PASS:-}
@@ -351,7 +351,7 @@ services:
         - postfix-vol-1:/var/spool/postfix
         - crypt-vol-1:/var/lib/zeyple
         - rspamd-vol-1:/var/lib/rspamd
-        - mysql-socket-vol-1:/var/run/mysqld/:z
+        - mysql-socket-vol-1:/var/run/mysqld/
       environment:
         - LOG_LINES=${LOG_LINES:-9999}
         - TZ=${TZ}
@@ -469,7 +469,7 @@ services:
         - ./data/web/.well-known/acme-challenge:/var/www/acme:z
         - ./data/assets/ssl:/var/lib/acme/:z
         - ./data/assets/ssl-example:/var/lib/ssl-example/:ro,Z
-        - mysql-socket-vol-1:/var/run/mysqld/:z
+        - mysql-socket-vol-1:/var/run/mysqld/
       restart: always
       networks:
         mailcow-network:
@@ -504,7 +504,7 @@ services:
         - /tmp
       volumes:
         - rspamd-vol-1:/var/lib/rspamd
-        - mysql-socket-vol-1:/var/run/mysqld/:z
+        - mysql-socket-vol-1:/var/run/mysqld/
         - postfix-vol-1:/var/spool/postfix
         - ./data/assets/ssl:/etc/ssl/mail/:ro,z
       restart: always


### PR DESCRIPTION
## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

The mysql-socket-vol-1 volume is mounted in several containers using the short volume syntax. The last part of that short syntax holds extra options for bind-type mounts only, for mysql-socket-vol-1 the z option is specified here. Docker compose outputs a warning because this option is only considered with bind-type mounts.

```
WARN[0000] mount of type `volume` should not define `bind` option
```

This PR removes the option to remove these warnings.

###  Affected Containers

- mysql-mailcow
- php-fpm-mailcow
- sogo-mailcow
- dovecot-mailcow
- postfix-mailcow
- acme-mailcow
- watchdog-mailcow

## Did you run tests?

### What did you tested?

Ran `docker compose up -d` to verify the warnings are gone.

### What were the final results? (Awaited, got)

As expected, the warnings are gone.