### PR TITLE
watchdog: use dig instead of check_dns

### DIFF
--- a/data/Dockerfiles/watchdog/Dockerfile
+++ b/data/Dockerfiles/watchdog/Dockerfile
@@ -16,7 +16,6 @@ RUN apk add --update \
   fcgi \
   openssl \
   nagios-plugins-mysql \
-  nagios-plugins-dns \
   nagios-plugins-disk \
   bind-tools \
   redis \
@@ -32,9 +31,11 @@ RUN apk add --update \
   tzdata \
   whois \
   && curl https://raw.githubusercontent.com/mludvig/smtp-cli/v3.10/smtp-cli -o /smtp-cli \
-  && chmod +x smtp-cli
+  && chmod +x smtp-cli \
+  && mkdir /usr/lib/mailcow
 
 COPY watchdog.sh /watchdog.sh
 COPY check_mysql_slavestatus.sh /usr/lib/nagios/plugins/check_mysql_slavestatus.sh
+COPY check_dns.sh /usr/lib/mailcow/check_dns.sh
 
 CMD ["/watchdog.sh"]

--- a/data/Dockerfiles/watchdog/check_dns.sh
+++ b/data/Dockerfiles/watchdog/check_dns.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+while getopts "H:s:" opt; do
+  case "$opt" in
+    H) HOST="$OPTARG" ;;
+    s) SERVER="$OPTARG" ;;
+    *) echo "Usage: $0 -H host -s server"; exit 3 ;;
+  esac
+done
+
+if [ -z "$SERVER" ]; then
+  echo "No DNS Server provided"
+  exit 3
+fi
+
+if [ -z "$HOST" ]; then
+  echo "No host to test provided"
+  exit 3
+fi
+
+# run dig and measure the time it takes to run
+START_TIME=$(date +%s%3N)
+dig_output=$(dig +short +timeout=2 +tries=1 "$HOST" @"$SERVER" 2>/dev/null)
+dig_rc=$?
+dig_output_ips=$(echo "$dig_output" | grep -E '^[0-9.]+$' | sort | paste -sd ',' -)
+END_TIME=$(date +%s%3N)
+ELAPSED_TIME=$((END_TIME - START_TIME))
+
+# validate and perform nagios like output and exit codes
+if [ $dig_rc -ne 0 ] || [ -z "$dig_output" ]; then
+  echo "Domain $HOST was not found by the server"
+  exit 2
+elif [ $dig_rc -eq 0 ]; then
+  echo "DNS OK: $ELAPSED_TIME ms response time. $HOST returns $dig_output_ips"
+  exit 0
+else
+  echo "Unknown error"
+  exit 3
+fi

--- a/data/Dockerfiles/watchdog/watchdog.sh
+++ b/data/Dockerfiles/watchdog/watchdog.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ "${DEV_MODE}" != "n" ]; then
+  echo -e "\e[31mEnabled Debug Mode\e[0m"
+  set -x
+fi
+
 trap "exit" INT TERM
 trap "kill 0" EXIT
 

--- a/data/Dockerfiles/watchdog/watchdog.sh
+++ b/data/Dockerfiles/watchdog/watchdog.sh
@@ -297,7 +297,7 @@ unbound_checks() {
     touch /tmp/unbound-mailcow; echo "$(tail -50 /tmp/unbound-mailcow)" > /tmp/unbound-mailcow
     host_ip=$(get_container_ip unbound-mailcow)
     err_c_cur=${err_count}
-    /usr/lib/nagios/plugins/check_dns -s ${host_ip} -H stackoverflow.com 2>> /tmp/unbound-mailcow 1>&2; err_count=$(( ${err_count} + $? ))
+    /usr/lib/mailcow/check_dns.sh -s ${host_ip} -H stackoverflow.com 2>> /tmp/unbound-mailcow 1>&2; err_count=$(( ${err_count} + $? ))
     DNSSEC=$(dig com +dnssec | egrep 'flags:.+ad')
     if [[ -z ${DNSSEC} ]]; then
       echo "DNSSEC failure" 2>> /tmp/unbound-mailcow 1>&2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -497,7 +497,7 @@ services:
         - /lib/modules:/lib/modules:ro
 
     watchdog-mailcow:
-      image: ghcr.io/mailcow/watchdog:2.08
+      image: ghcr.io/mailcow/watchdog:2.09
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       tmpfs:
@@ -564,6 +564,7 @@ services:
         - OLEFY_THRESHOLD=${OLEFY_THRESHOLD:-5}
         - MAILQ_THRESHOLD=${MAILQ_THRESHOLD:-20}
         - MAILQ_CRIT=${MAILQ_CRIT:-30}
+        - DEV_MODE=${DEV_MODE:-n}
       networks:
         mailcow-network:
           aliases:


### PR DESCRIPTION
This issue is mentioned here: https://github.com/mailcow/mailcow-dockerized/issues/5033 and https://github.com/mailcow/mailcow-dockerized/issues/5121

I think it can occour on low memory servers. I myself experienced the problem when updating my mailcow server from debian 12 to 13 on a 4GB RAM machine. Before it was all fine, after the update check_dns would constantly segfault.

I observed quiete a significant memory usage when running check_dns on another machine.
Therefore using dig in a wrapper script should deliver similar experience and fix the segfault problem.

<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Replace nagios check_dns with dig in a wrapper script to behave pretty much the same.

###  Affected Containers

- watchdog

## Did you run tests?

### What did you tested?

The script itself. Building and using the container

### What were the final results? (Awaited, got)

The segfault problem was gone, and unbound should still be monitored as before.