### PR TITLE
web: rename login placeholder for mailbox to email address

### DIFF
--- a/data/web/lang/lang.de-de.json
+++ b/data/web/lang/lang.de-de.json
@@ -846,7 +846,8 @@
         "password": "Passwort",
         "reset_password": "Passwort zurücksetzen",
         "request_reset_password": "Passwortänderung anfordern",
-        "username": "Benutzername"
+        "username": "Benutzername",
+        "email": "E-Mail-Adresse"
     },
     "mailbox": {
         "action": "Aktion",

--- a/data/web/lang/lang.en-gb.json
+++ b/data/web/lang/lang.en-gb.json
@@ -847,7 +847,8 @@
         "password": "Password",
         "reset_password": "Reset Password",
         "request_reset_password": "Request password change",
-        "username": "Username"
+        "username": "Username",
+        "email": "Email address"
     },
     "mailbox": {
         "action": "Action",

--- a/data/web/templates/user_index.twig
+++ b/data/web/templates/user_index.twig
@@ -48,7 +48,7 @@
             <label class="visually-hidden" for="login_user">{{ lang.login.username }}</label>
             <div class="input-group">
               <div class="input-group-text"><i class="bi bi-person-fill"></i></div>
-              <input name="login_user" autocorrect="off" autocapitalize="none" type="{% if is_mobileconfig %}email{% else %}text{% endif %}" id="login_user" class="form-control" placeholder="{{ lang.login.username }}" required="" autofocus="" autocomplete="username">
+              <input name="login_user" autocorrect="off" autocapitalize="none" type="{% if is_mobileconfig %}email{% else %}text{% endif %}" id="login_user" class="form-control" placeholder="{{ lang.login.email }}" required="" autofocus="" autocomplete="username">
             </div>
           </div>
           <div class="d-flex mt-3">


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This pull request updates the login form and language files to improve clarity for users by changing the placeholder text for the username field to "Email address" and adding the corresponding translations.

**User interface improvements:**

* Updated the login form in `user_index.twig` to use `lang.login.email` as the placeholder for the username/email input, making it clearer that users should enter their email address.

**Localization updates:**

* Added the `email` field to the login section in both the German (`lang.de-de.json`) and British English (`lang.en-gb.json`) language files, ensuring the new placeholder is properly translated into the project main languages. [[1]](diffhunk://#diff-f8069da2883cabd5b2f73e7598f0bfa82352d98177434ec88b26532cf03148e5L849-R850) [[2]](diffhunk://#diff-b7afea61dab8685d5458e20fa96116de21d314b2b7a921b13d15d58aac4667f6L850-R851)

###  Affected Containers

- php-mailcow

## Did you run tests?

Yes, worked, only UI Text change, no function change.