### PR TITLE
[Rspamd] only recreate external_services.conf file if it was deleted

### DIFF
--- a/data/Dockerfiles/rspamd/docker-entrypoint.sh
+++ b/data/Dockerfiles/rspamd/docker-entrypoint.sh
@@ -86,7 +86,8 @@ if [[ "${SKIP_OLEFY}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
     rm /etc/rspamd/local.d/external_services.conf
   fi
 else
-  cat <<EOF > /etc/rspamd/local.d/external_services.conf
+  if [[ ! -f /etc/rspamd/local.d/external_services.conf ]]; then
+    cat <<EOF > /etc/rspamd/local.d/external_services.conf
 oletools {
   # default olefy settings
   servers = "olefy:10055";
@@ -100,6 +101,7 @@ oletools {
   retransmits = 1;
 }
 EOF
+  fi
 fi
 
 # Provide additional lua modules


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR fixes:
- https://github.com/mailcow/mailcow-dockerized/issues/6664

###  Affected Containers

- RSPAMD

## Did you run tests?

### What did you tested?

The file `data/conf/rspamd/local.d/external_services.conf` is only recreated at container start if it is missing.