### PR TITLE
Improve IPv6 handling in acme script

### DIFF
--- a/data/Dockerfiles/acme/functions.sh
+++ b/data/Dockerfiles/acme/functions.sh
@@ -84,7 +84,8 @@ check_domain(){
     if [[ ! -z ${AAAA_DOMAIN} ]] && [[ -z $(echo ${AAAA_DOMAIN} | grep "^\([0-9a-fA-F]\{0,4\}:\)\{1,7\}[0-9a-fA-F]\{0,4\}$") ]]; then
       AAAA_DOMAIN=
     fi
-    if [[ ! -z ${AAAA_DOMAIN} ]]; then
+    # Check for AAAA record first if we have IPv6, but ignore if the IP for v6 did not work properly (=0000:0000:0000:0000:0000:0000:0000:0000)
+    if [[ ! -z ${AAAA_DOMAIN} ]] && [[ ${IPV6:-"0000:0000:0000:0000:0000:0000:0000:0000"} != "0000:0000:0000:0000:0000:0000:0000:0000" ]]; then
       log_f "Found AAAA record for ${DOMAIN}: ${AAAA_DOMAIN} - skipping A record check"
       if [[ $(expand ${IPV6:-"0000:0000:0000:0000:0000:0000:0000:0000"}) == $(expand ${AAAA_DOMAIN}) ]] || [[ ${SKIP_IP_CHECK} == "y" ]] || [[ ${SNAT6_TO_SOURCE} != "n" ]]; then
         if verify_challenge_path "${DOMAIN}" 6; then


### PR DESCRIPTION

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Description

IPv6  can be challenging in docker environments. Past has shown that IPv6 is problematic sometimes. In the ACME handling for Let'sEncrypt certificates there is an issue around for quite some time:

https://github.com/mailcow/mailcow-dockerized/issues/5338
https://github.com/mailcow/mailcow-dockerized/issues/3897
[Community Link ](https://community.mailcow.email/d/3020-problem-with-ipv6-or-aaaa-record-based-http-validation-of-acme-certification)
....

I'm quite sure there are a bit more and I recently run into the same issue I want to propose a fix for it.

The `check_domain()` function in the ACME container first does the IP detection for IPv4 and IPv6. While IPv4 mostly works, IPv6 does not. The simple reason for that is that usually there is no IPv6 network defined inside the docker container. Therefore it can happen that the IPv6 detection fails and the default value becomes true:

https://github.com/mailcow/mailcow-dockerized/blob/2891bbf82ad35a1f8aa3d302c36c7e9e909ccba2/data/Dockerfiles/acme/acme.sh#L216-L217

This is usually fine but the IPv6 is later check again to determine of the certification should run against v4 or v6

https://github.com/mailcow/mailcow-dockerized/blob/2891bbf82ad35a1f8aa3d302c36c7e9e909ccba2/data/Dockerfiles/acme/functions.sh#L87-L88

#### Fix

To fix this issue we simply can check if a AAAA record is present and the IPv6 values does not match the default. In this case we always can fall back to IPv4 which usually works.

###  Affected Containers

- mailcow-acme

## Did you run tests?

### What did you tested?

Tested the modified script. 

Before the fix:

```
acme-mailcow-1  | Fri Sep 19 10:01:37 CEST 2025 - Initializing, please wait...
acme-mailcow-1  | Fri Sep 19 10:01:38 CEST 2025 - Using existing domain rsa key /var/lib/acme/acme/key.pem
acme-mailcow-1  | Fri Sep 19 10:01:38 CEST 2025 - Using existing Lets Encrypt account key /var/lib/acme/acme/account.pem
acme-mailcow-1  | Fri Sep 19 10:01:38 CEST 2025 - Detecting IP addresses...
acme-mailcow-1  | Fri Sep 19 10:01:47 CEST 2025 - OK: AA.BB.CC.DD, 0000:0000:0000:0000:0000:0000:0000:0000
acme-mailcow-1  | Fri Sep 19 10:01:48 CEST 2025 - Validated CAA for parent domain mydomain.org
acme-mailcow-1  | Fri Sep 19 10:01:48 CEST 2025 - Found AAAA record for mail.mydomain.org: AAAA:BBBB:CCCC:DDDD::EEEE - skipping A record check
acme-mailcow-1  | Fri Sep 19 10:01:48 CEST 2025 - Cannot match your IP 0000:0000:0000:0000:0000:0000:0000:0000 against hostname mail.mydomain.org (DNS returned AAAA:BBBB:CCCC:DDDD::EEEE)
```

After the fix:

```
acme-mailcow-1  | Fri Sep 19 10:30:07 CEST 2025 - Initializing, please wait...
acme-mailcow-1  | Fri Sep 19 10:30:08 CEST 2025 - Using existing domain rsa key /var/lib/acme/acme/key.pem
acme-mailcow-1  | Fri Sep 19 10:30:08 CEST 2025 - Using existing Lets Encrypt account key /var/lib/acme/acme/account.pem
acme-mailcow-1  | Fri Sep 19 10:30:08 CEST 2025 - Detecting IP addresses...
acme-mailcow-1  | Fri Sep 19 10:30:17 CEST 2025 - OK: AA.BB.CC.DD, 0000:0000:0000:0000:0000:0000:0000:0000
acme-mailcow-1  | Fri Sep 19 10:30:17 CEST 2025 - Validated CAA for parent domain mydomain.org
acme-mailcow-1  | Fri Sep 19 10:30:17 CEST 2025 - Found A record for mail.mydomain.org: AA.BB.CC.DD
acme-mailcow-1  | Fri Sep 19 10:30:18 CEST 2025 - Confirmed A record AA.BB.CC.DD
```

### What were the final results? (Awaited, got)

I awaited a fallback to IPv4 if the IPv6 detection fails. This was also the result. 