### PR TITLE
[Web] Remove Port from HTTP_HOST

### DIFF
--- a/data/web/mta-sts.php
+++ b/data/web/mta-sts.php
@@ -6,7 +6,8 @@ if (!isset($_SERVER['HTTP_HOST']) || strpos($_SERVER['HTTP_HOST'], 'mta-sts.') !
   exit;
 }
 
-$domain = str_replace('mta-sts.', '', $_SERVER['HTTP_HOST']);
+$host = preg_replace('/:[0-9]+$/', '', $_SERVER['HTTP_HOST']);
+$domain = str_replace('mta-sts.', '', $host);
 $mta_sts = mailbox('get', 'mta_sts', $domain);
 
 if (count($mta_sts) == 0 ||


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

When extracting the domain during MTA-STS requests, ports are also removed.
Fixes:
- https://github.com/mailcow/mailcow-dockerized/issues/6739

###  Affected Containers

- PHP-FPM

## Did you run tests?

### What did you tested?

After changing `HTTPS_PORT` in `mailcow.conf`, the MTA-STS `.well-known` txt file was still accessible.