### PR TITLE
Update variable name for prometheus-exporter security token

### DIFF
--- a/helper-scripts/docker-compose.override.yml.d/PROMETHEUS_EXPORTER/docker-compose.override.yml
+++ b/helper-scripts/docker-compose.override.yml.d/PROMETHEUS_EXPORTER/docker-compose.override.yml
@@ -7,7 +7,7 @@ services:
       environment:
         MAILCOW_EXPORTER_HOST: "<your-mail-domain>" # Replace with your Mailcow hostname
         MAILCOW_EXPORTER_API_KEY: "<your-API-Key>" # Replace with your API key
-        MAILCOW_EXPORTER_TOKEN: "<your-secure-token>" # Replace with your secure key
+        MAILCOW_EXPORTER_SECURITY_TOKEN: "<your-secure-token>" # Replace with your secure key
         # MAILCOW_EXPORTER_TOKEN_DISABLE: "true" # Uncomment only if it is safe to disable token authentication (e.g., internal network only)
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254

--- a/helper-scripts/docker-compose.override.yml.d/PROMETHEUS_EXPORTER/docker-compose.override.yml
+++ b/helper-scripts/docker-compose.override.yml.d/PROMETHEUS_EXPORTER/docker-compose.override.yml
@@ -8,7 +8,7 @@ services:
         MAILCOW_EXPORTER_HOST: "<your-mail-domain>" # Replace with your Mailcow hostname
         MAILCOW_EXPORTER_API_KEY: "<your-API-Key>" # Replace with your API key
         MAILCOW_EXPORTER_SECURITY_TOKEN: "<your-secure-token>" # Replace with your secure key
-        # MAILCOW_EXPORTER_TOKEN_DISABLE: "true" # Uncomment only if it is safe to disable token authentication (e.g., internal network only)
+        # MAILCOW_EXPORTER_SECURITY_DISABLE_ACCESS_PROTECTION: "true" # Uncomment only if it is safe to disable token authentication (e.g., internal network only)
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       networks:


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

[prometheus-exporter](https://github.com/mailcow/prometheus-exporter) changed the variable `MAILCOW_EXPORTER_TOKEN` to `MAILCOW_EXPORTER_SECURITY_TOKEN`. Same for `MAILCOW_EXPORTER_TOKEN_DISABLE` -> `MAILCOW_EXPORTER_SECURITY_DISABLE_ACCESS_PROTECTION`

This updates the provided helper script.

<!-- Please write a short description, what your PR does here. -->

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->