### PR TITLE
Add hostname fields to all containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
         - ./data/conf/unbound/unbound.conf:/etc/unbound/unbound.conf:ro,Z
       restart: always
       tty: true
+      hostname: unbound
       networks:
         mailcow-network:
           ipv4_address: ${IPV4_NETWORK:-172.22.1}.254
@@ -36,6 +37,7 @@ services:
       restart: always
       ports:
         - "${SQL_PORT:-127.0.0.1:13306}:3306"
+      hostname: mysql
       networks:
         mailcow-network:
           aliases:
@@ -58,6 +60,7 @@ services:
         - REDISMASTERPASS=${REDISMASTERPASS:-}
       sysctls:
         - net.core.somaxconn=4096
+      hostname: redis
       networks:
         mailcow-network:
           ipv4_address: ${IPV4_NETWORK:-172.22.1}.249
@@ -78,6 +81,7 @@ services:
       volumes:
         - ./data/conf/clamav/:/etc/clamav/:Z
         - clamd-db-vol-1:/var/lib/clamav
+      hostname: clamd
       networks:
         mailcow-network:
           aliases:
@@ -108,9 +112,9 @@ services:
         - ./data/conf/rspamd/rspamd.conf.override:/etc/rspamd/rspamd.conf.override:Z
         - rspamd-vol-1:/var/lib/rspamd
       restart: always
-      hostname: rspamd
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
+      hostname: rspamd
       networks:
         mailcow-network:
           aliases:
@@ -194,6 +198,7 @@ services:
         ofelia.job-exec.phpfpm_ldap_sync.schedule: "@every 1m"
         ofelia.job-exec.phpfpm_ldap_sync.no-overlap: "true"
         ofelia.job-exec.phpfpm_ldap_sync.command: "/bin/bash -c \"php /crons/ldap-sync.php || exit 0\""
+      hostname: phpfpm
       networks:
         mailcow-network:
           aliases:
@@ -245,6 +250,7 @@ services:
         ofelia.job-exec.sogo_backup.schedule: "@every 24h"
         ofelia.job-exec.sogo_backup.command: "/bin/bash -c \"[[ $${MASTER} == y ]] && /usr/local/bin/gosu sogo /usr/sbin/sogo-tool backup /sogo_backup ALL || exit 0\""
       restart: always
+      hostname: sogo
       networks:
         mailcow-network:
           ipv4_address: ${IPV4_NETWORK:-172.22.1}.248
@@ -332,6 +338,7 @@ services:
         nofile:
           soft: 20000
           hard: 40000
+      hostname: dovecot
       networks:
         mailcow-network:
           ipv4_address: ${IPV4_NETWORK:-172.22.1}.250
@@ -375,6 +382,7 @@ services:
       restart: always
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
+      hostname: postfix
       networks:
         mailcow-network:
           ipv4_address: ${IPV4_NETWORK:-172.22.1}.253
@@ -398,6 +406,7 @@ services:
       restart: always
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
+      hostname: postfix-tlspol
       networks:
         mailcow-network:
           aliases:
@@ -408,6 +417,7 @@ services:
       restart: always
       environment:
         - TZ=${TZ}
+      hostname: memcached
       networks:
         mailcow-network:
           aliases:
@@ -454,6 +464,7 @@ services:
         - "${HTTPS_BIND:-}:${HTTPS_PORT:-443}:${HTTPS_PORT:-443}"
         - "${HTTP_BIND:-}:${HTTP_PORT:-80}:${HTTP_PORT:-80}"
       restart: always
+      hostname: nginx
       networks:
         mailcow-network:
           aliases:
@@ -496,6 +507,7 @@ services:
         - ./data/assets/ssl-example:/var/lib/ssl-example/:ro,Z
         - mysql-socket-vol-1:/var/run/mysqld/:z
       restart: always
+      hostname: acme
       networks:
         mailcow-network:
           aliases:
@@ -520,6 +532,7 @@ services:
       network_mode: "host"
       volumes:
         - /lib/modules:/lib/modules:ro
+      hostname: netfilter
 
     watchdog-mailcow:
       image: ghcr.io/mailcow/watchdog:2.09
@@ -591,6 +604,7 @@ services:
         - MAILQ_THRESHOLD=${MAILQ_THRESHOLD:-20}
         - MAILQ_CRIT=${MAILQ_CRIT:-30}
         - DEV_MODE=${DEV_MODE:-n}
+      hostname: watchdog
       networks:
         mailcow-network:
           aliases:
@@ -611,6 +625,7 @@ services:
         - REDISPASS=${REDISPASS}
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock:ro
+      hostname: dockerapi
       networks:
         mailcow-network:
           aliases:
@@ -630,6 +645,7 @@ services:
         - OLEFY_MINLENGTH=500
         - OLEFY_DEL_TMP=1
         - SKIP_OLEFY=${SKIP_OLEFY:-n}
+      hostname: olefy
       networks:
         mailcow-network:
           aliases:
@@ -651,6 +667,7 @@ services:
         - label=disable
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock:ro
+      hostname: ofelia
       networks:
         mailcow-network:
           aliases:


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This adds hostnames to all docker containers. It does NOT change the DNS hostnames the services use to communicate between them and are solely for hostname within the containers - as in, they use now static hostnames instead of the docker ID. This might make it easier to identify the container, especially for logging.

Worked fine:
```text
$ for c in $(docker ps -q -a); do docker exec $c hostname; done
watchdog
acme
nginx
ofelia
rspamd
postfix
dovecot
mysql
postfix
clamd
php
redis
sogo
controller
unbound
netfilter
memcached
olefy
```

Closes #4505

###  Affected Containers

All except rspamd. rspamd already had this.

## Did you run tests?

### What did you tested?

Start the stack, check for errors.

### What were the final results? (Awaited, got)

No errors found.