### PR TITLE
Rename password fields for AppPasswords same way for consistency

### DIFF
--- a/data/web/inc/functions.app_passwd.inc.php
+++ b/data/web/inc/functions.app_passwd.inc.php
@@ -95,8 +95,8 @@ function app_passwd($_action, $_data = null) {
         $is_now = app_passwd('details', $id);
         if (!empty($is_now)) {
           $app_name = (!empty($_data['app_name'])) ? $_data['app_name'] : $is_now['name'];
-          $password = (!empty($_data['password'])) ? $_data['password'] : null;
-          $password2 = (!empty($_data['password2'])) ? $_data['password2'] : null;
+          $password = (!empty($_data['app_passwd'])) ? $_data['app_passwd'] : null;
+          $password2 = (!empty($_data['app_passwd2'])) ? $_data['app_passwd2'] : null;
           if (isset($_data['protocols'])) {
             $protocols = (array)$_data['protocols'];
             $imap_access = (in_array('imap_access', $protocols)) ? 1 : 0;

--- a/data/web/templates/edit/app-passwd.twig
+++ b/data/web/templates/edit/app-passwd.twig
@@ -13,15 +13,15 @@
     </div>
   </div>
   <div class="row mb-2">
-    <label class="control-label col-sm-2" for="password">{{ lang.edit.password }} (<a href="#" class="generate_password">{{ lang.edit.generate }}</a>)</label>
+    <label class="control-label col-sm-2" for="app_passwd">{{ lang.edit.password }} (<a href="#" class="generate_password">{{ lang.edit.generate }}</a>)</label>
     <div class="col-sm-10">
-      <input type="password" data-pwgen-field="true" data-hibp="true" class="form-control" name="password" placeholder="" autocomplete="new-password">
+      <input type="password" data-pwgen-field="true" data-hibp="true" class="form-control" name="app_passwd" placeholder="" autocomplete="new-password">
     </div>
   </div>
   <div class="row mb-4">
-    <label class="control-label col-sm-2" for="password2">{{ lang.edit.password_repeat }}</label>
+    <label class="control-label col-sm-2" for="app_passwd2">{{ lang.edit.password_repeat }}</label>
     <div class="col-sm-10">
-      <input type="password" data-pwgen-field="true" class="form-control" name="password2" autocomplete="new-password">
+      <input type="password" data-pwgen-field="true" class="form-control" name="app_passwd2" autocomplete="new-password">
     </div>
   </div>
   <div class="row mb-2">


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This renames the password fields for "App Passwords" to "app_passwd" and "app_passwd2" respectively, just like the add form and the other rest of internal code does.

###  Affected Containers

phpfpm, indirectly.

## Did you run tests?

### What did you tested?

1. Checked if the field names are correct as expected
2. Edit AppPassword and it still worked

### What were the final results? (Awaited, got)

AppPassword edit worked like before