### PR TITLE
Optimize phpfpm opcache: more aggressive caching, enable JIT

### DIFF
--- a/data/conf/phpfpm/php-conf.d/opcache-recommended.ini
+++ b/data/conf/phpfpm/php-conf.d/opcache-recommended.ini
@@ -1,4 +1,6 @@
-# opcache
+; NOTE: Restart phpfpm on ANY manual changes to PHP files!
+
+; opcache
 opcache.enable=1
 opcache.enable_cli=1
 opcache.interned_strings_buffer=16
@@ -7,6 +9,7 @@ opcache.memory_consumption=128
 opcache.save_comments=1
 opcache.revalidate_freq=120
 opcache.validate_timestamps=0
-# jit
-opcache.jit = 1255
-opcache.jit_buffer_size = 8M
+
+; JIT
+opcache.jit=1255
+opcache.jit_buffer_size=8M

--- a/data/conf/phpfpm/php-conf.d/opcache-recommended.ini
+++ b/data/conf/phpfpm/php-conf.d/opcache-recommended.ini
@@ -1,7 +1,12 @@
+# opcache
 opcache.enable=1
 opcache.enable_cli=1
 opcache.interned_strings_buffer=16
 opcache.max_accelerated_files=10000
 opcache.memory_consumption=128
 opcache.save_comments=1
-opcache.revalidate_freq=1
+opcache.revalidate_freq=120
+opcache.validate_timestamps=0
+# jit
+opcache.jit = 1255
+opcache.jit_buffer_size = 8M


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This implements two things:
1. More persistent, aggressive caching by using `opcache.validate_timestamps=0`. This results in local PHP files never being re-validated for changes. As there are no manual changes to PHP files expected in production, that should be fine. During updates the phpfpm container will be restarted nonetheless, hence cache cleared.
2. Enabling opcache-jit, which has been introduced back in PHP 8.0. It is compiling frequently used PHP opcodes into machine code and allows for faster execution in subsequent runs.

###  Affected Containers

phpfpm

## Did you run tests?

### What did you tested?

Clicked through UI, noticed some speed improvements and no issues.

### What were the final results? (Awaited, got)

See above.