### PR TITLE
Make domain description field readonly when no ACL

### DIFF
--- a/data/web/templates/edit/domain.twig
+++ b/data/web/templates/edit/domain.twig
@@ -39,7 +39,7 @@
                   <div class="row mb-2" data-acl="{{ acl.domain_desc }}">
                     <label class="control-label col-sm-2" for="description">{{ lang.edit.description }}</label>
                     <div class="col-sm-10">
-                      <input type="text" class="form-control" name="description" value="{{ result.description }}">
+                      <input type="text" class="form-control" name="description" value="{{ result.description }}"{% if acl.domain_desc == '0' %} readonly{% endif %}>
                     </div>
                   </div>
                   <div class="row mb-4">


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Very small, nitpicky PR to set "readonly" field for the "Description" input field, when user has no permission to change it:
<img width="668" height="375" alt="image" src="https://github.com/user-attachments/assets/210fb3e8-5723-4c96-a82d-1e8450eff63b" />

###  Affected Containers

phpfpm, indirectly

## Did you run tests?

### What did you tested?

1. Removed permission and saw readonly tag being set

### What were the final results? (Awaited, got)

Worked.