### PR TITLE
Fix enabling of ipv6 when updating

### DIFF
--- a/_modules/scripts/ipv6_controller.sh
+++ b/_modules/scripts/ipv6_controller.sh
@@ -155,6 +155,7 @@ docker_daemon_edit(){
     fi
 
     if [[ $ans =~ ^[Yy]$ ]]; then
+      mkdir -p "$(dirname "$DOCKER_DAEMON_CONFIG")"
       if [[ -n "$DOCKER_MAJOR" && "$DOCKER_MAJOR" -lt 27 ]]; then
         cat > "$DOCKER_DAEMON_CONFIG" <<EOF
 {


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description
A quick fix in `ipv6_controller.sh` to make sure `/etc/docker` exists before trying to create `daemon.json` as it is not guaranteed to exist by default.

###  Affected Containers
None

## Did you run tests?

### What did you test?
Running `update.sh` with non-existing `/etc/docker` directory and agreeing to create a new configuration file.

### What were the final results? (Awaited, got)
Successfully created the config.