### PR TITLE
[Helpers] Fix cold-standby digits in compose project names and inclusion of docker-compose.override.yml

### DIFF
--- a/helper-scripts/_cold-standby.sh
+++ b/helper-scripts/_cold-standby.sh
@@ -117,7 +117,7 @@ fi
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${SCRIPT_DIR}/../mailcow.conf"
 COMPOSE_FILE="${SCRIPT_DIR}/../docker-compose.yml"
-CMPS_PRJ=$(echo ${COMPOSE_PROJECT_NAME} | tr -cd 'A-Za-z-_')
+CMPS_PRJ=$(echo ${COMPOSE_PROJECT_NAME} | tr -cd '0-9A-Za-z-_')
 SQLIMAGE=$(grep -iEo '(mysql|mariadb)\:.+' "${COMPOSE_FILE}")
 
 preflight_local_checks
@@ -169,7 +169,7 @@ if ! ssh -o StrictHostKeyChecking=no \
   -i "${REMOTE_SSH_KEY}" \
   ${REMOTE_SSH_HOST} \
   -p ${REMOTE_SSH_PORT} \
-  ${COMPOSE_COMMAND} -f "${SCRIPT_DIR}/../docker-compose.yml" create 2>&1 ; then
+  "cd \"${SCRIPT_DIR}/../\" && ${COMPOSE_COMMAND} create 2>&1" ; then
     >&2 echo -e "\e[31m[ERR]\e[0m - Could not create networks, volumes and containers on remote"
 fi
 
@@ -284,7 +284,7 @@ echo "OK"
     -i "${REMOTE_SSH_KEY}" \
     ${REMOTE_SSH_HOST} \
     -p ${REMOTE_SSH_PORT} \
-    ${COMPOSE_COMMAND} -f "${SCRIPT_DIR}/../docker-compose.yml" pull --quiet 2>&1 ; then
+    "cd \"${SCRIPT_DIR}/../\" && ${COMPOSE_COMMAND} pull --quiet 2>&1" ; then
       >&2 echo -e "\e[31m[ERR]\e[0m - Could not pull images on remote"
   fi
 


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree to them

## What does this PR include?

### In short

- Current script version does not synch volumes to remote cold-storage instance if `COMPOSE_PROJECT_NAME` contains digits
- Current script version does not create volumes from `docker-compose.override.yml` at the remote location because of `-f`-flag usage during `docker compose create`-call.
- PR fixes both issues

### Details

This PR fixes two bugs in `helper-scripts/_cold-standby.sh`:

**Bug 1: Missing digit support in project name sanitization (line 120)**
- The script uses `tr -cd 'A-Za-z-_'` which strips digits from `COMPOSE_PROJECT_NAME` to set `CMPS_PRJ`
- As a result, **NO** volumes are synchronized to the remote cold-storage if e.g.  `COMPOSE_PROJECT_NAME=mailcow02dockerized`, none from `docker-compose.yml` nor from `docker-compose.override.yml`
- This was probably an oversight when the script was created, since `backup_and_restore.sh` already supports digits since commit a71d991c
- Docker compose [specifies](https://docs.docker.com/compose/how-tos/project-name/#set-a-project-name) a project name `must contain only lowercase letters, decimal digits, dashes, and underscores`.
- **Fix**: changed to `tr -cd '0-9A-Za-z-_'` to match backup script behavior

**Bug 2: `docker-compose.override.yml` not read during remote setup (lines 172, 287)**
- The [cold standby documentation](https://docs.mailcow.email/backup_restore/b_n_r-coldstandby/) explicitly states: _`This means we will also transfer volumes you may have added in an override file.`_ - but this is currently broken
- Using `-f` flag with explicit path causes docker compose to ignore `docker-compose.override.yml` ([Docker compose `-f` flag behavior](https://docs.docker.com/reference/cli/docker/compose/))
- Probably introduced in [PR #6203](https://github.com/mailcow/mailcow-dockerized/pull/6203) when adding `docker compose create` command?
- **Fix**: removed `-f` flag and added `cd` command (matching existing pattern at line 296) as this seemed better than conditionally checking for file-existence and adding both via multiple `-f`?

**References:**
- [docker/compose#9399](https://github.com/docker/compose/issues/9399) - Confirms override files are ignored when using `-f`-flag

###  Affected Containers

- None (helper script only)

## Did you run tests?

- Tested locally for `Docker version 28.1.1` and `Docker version 28.4.0` as well as compose plugin versions `v2.39.4` and `v2.35.1`
- in-place replacement on two instances running mailcow `2025-07` and `2025-09b` with success: images and containers from inside the `docker-compose.override.yml`-stack get replicated in the remote cold-standby instance, e.g.:

<img width="977" height="206" alt="image" src="https://github.com/user-attachments/assets/f351614a-ac11-42ae-a0df-7b59e748588e" />

### What did you test?

- Verified `tr -cd '0-9A-Za-z-_'` preserves digits in project names
- Confirmed docker compose behavior with `-f`-flag ignores override file
- Confirmed dropped `-f`-flag includes override file
- `cd && compose` pattern works correctly in ssh remote execution context

### What were the final results? (Awaited, got)

**Expected**: Project names with digits are preserved resulting in synchronized volumes on the remote instance, `docker-compose.override.yml` is respected/ merged on remote systems during `docker compose create`.

**Got**: Both fixes work for me

### CAVEAT

`backup_and_restore.sh` has the same override file issue, but since the [backup documentation](https://docs.mailcow.email/backup_restore/b_n_r-backup/) doesn't mention override file support (which could be included via the `all`-switch?), no changes there.

