### PR TITLE
Restrict netfilter container to required capabilities instead of running as privileged container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -505,7 +505,6 @@ services:
       image: ghcr.io/mailcow/netfilter:1.63
       stop_grace_period: 30s
       restart: always
-      privileged: true
       environment:
         - TZ=${TZ}
         - IPV4_NETWORK=${IPV4_NETWORK:-172.22.1}
@@ -518,6 +517,10 @@ services:
         - MAILCOW_REPLICA_IP=${MAILCOW_REPLICA_IP:-}
         - DISABLE_NETFILTER_ISOLATION_RULE=${DISABLE_NETFILTER_ISOLATION_RULE:-n}
       network_mode: "host"
+      cap_drop:
+        - ALL
+      cap_add:
+        - NET_ADMIN
       volumes:
         - /lib/modules:/lib/modules:ro
 


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

This PR changes the configuration of the netfilter container to only run with the `NET_ADMIN` capability instead of a privileged container (all capabilities). The only privileged operation performed by the container is manipulation of the iptables/nftables rulesets, which is possible having the `NET_ADMIN` capability (and using the host network stack, which is already the case).

###  Affected Containers

- netfilter-mailcow

## Did you run tests?

### What did you test?

I ran the container and manually created and removed a ban by adding an IP address in the admin interface and later removing it again. After adding / removing I checked in the container logs until the change arrived at the container, then checked that the nftables ruleset was updated accordingly (rule was added/removed).

### What were the final results? (Awaited, got)

The rule was added and later removed as expected. No error show in the netfilter logs.

```
netfilter-mailcow-1  | 2026-02-04 17:06:31 INFO: Using NFTables backend
netfilter-mailcow-1  | 2026-02-04 17:06:31 INFO: Clearing all bans
netfilter-mailcow-1  | 2026-02-04 17:06:31 INFO: Initializing mailcow netfilter chain
netfilter-mailcow-1  | 2026-02-04 17:06:31 INFO: MAILCOW ip chain created successfully.
netfilter-mailcow-1  | 2026-02-04 17:06:31 INFO: MAILCOW ip6 chain created successfully.
netfilter-mailcow-1  | 2026-02-04 17:06:31 INFO: Setting MAILCOW isolation
netfilter-mailcow-1  | 2026-02-04 17:06:31 INFO: Watching Redis channel F2B_CHANNEL
netfilter-mailcow-1  | 2026-02-04 17:06:31 INFO: Allowlist was changed, it has 681 entries
netfilter-mailcow-1  | 2026-02-04 17:10:31 INFO: Denylist was changed, it has 1 entries
netfilter-mailcow-1  | 2026-02-04 17:10:31 CRIT: Added host/network 1.2.3.4 to denylist
netfilter-mailcow-1  | 2026-02-04 17:11:31 INFO: Denylist was changed, it has 0 entries
netfilter-mailcow-1  | 2026-02-04 17:11:31 CRIT: Removed host/network 1.2.3.4 from denylist
```