### PR TITLE
[Web] Feature disable external alias

### DIFF
--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -13,6 +13,34 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
   // Track mailboxes affected by alias operations for incremental SOGo updates
   $update_sogo_mailboxes = array();
 
+  // check if the passed mail is not managed by us
+  // I assume only a single and valid email gets passed
+  $is_external_mail_domain = function($email) use ($pdo) {
+    // split email and only keep the domain part
+    $domain = idn_to_ascii(substr(strstr($email, '@'), 1), 0, INTL_IDNA_VARIANT_UTS46);
+    error_log($domain);
+
+    // check if the domain exists as domain or alias domain
+    $stmt = $pdo->prepare('
+      SELECT
+        EXISTS ( SELECT 1 FROM domain WHERE domain = :domain AND active = 1)
+        OR
+        EXISTS ( SELECT 1 FROM alias_domain WHERE alias_domain = :alias_domain AND active = 1)
+      AS domain_exists
+    ');
+
+    $stmt->execute([
+      ':domain' => $domain,
+      ':alias_domain' => $domain
+    ]);
+   $result = $stmt->fetch(PDO::FETCH_ASSOC);
+   error_log($email);
+   error_log($result['domain_exists']);
+
+   return ! (bool) $result['domain_exists'];
+  };
+
+
   switch ($_action) {
     case 'add':
       switch ($_type) {
@@ -769,6 +797,17 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                 );
                 unset($gotos[$i]);
                 continue;
+              }
+              if ($GLOBALS['ALIAS_DISABLE_EXTERNAL_DOMAINS'] ) {
+                if ($is_external_mail_domain($gotos[$i])) {
+                  $_SESSION['return'][] = array(
+                    'type' => 'danger',
+                    'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
+                    'msg' => array('external_goto_denied', htmlspecialchars($goto))
+                  );
+                  unset($gotos[$i]);
+                  continue;
+                }
               }
             }
             $gotos = array_unique($gotos);
@@ -2720,6 +2759,17 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                   );
                   unset($gotos[$i]);
                   continue;
+                }
+                if ($GLOBALS['ALIAS_DISABLE_EXTERNAL_DOMAINS'] ) {
+                  if ($is_external_mail_domain($gotos[$i])) {
+                    $_SESSION['return'][] = array(
+                      'type' => 'danger',
+                      'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
+                      'msg' => array('external_goto_denied', htmlspecialchars($goto))
+                    );
+                    unset($gotos[$i]);
+                    continue;
+                  }
                 }
                 // Delete from sender_acl to prevent duplicates
                 $stmt = $pdo->prepare("DELETE FROM `sender_acl` WHERE

--- a/data/web/inc/vars.inc.php
+++ b/data/web/inc/vars.inc.php
@@ -245,6 +245,9 @@ $PW_RESET_TOKEN_LIMIT = 3;
 // Maximum time in minutes a password reset token is valid
 $PW_RESET_TOKEN_LIFETIME = 15;
 
+// disable alias creation for external domains
+$ALIAS_DISABLE_EXTERNAL_DOMAINS = false;
+
 // UV flag handling in FIDO2/WebAuthn - defaults to false to allow iOS logins
 // true = required
 // false = preferred

--- a/data/web/lang/lang.de-de.json
+++ b/data/web/lang/lang.de-de.json
@@ -443,6 +443,7 @@
         "domain_not_found": "Domain %s nicht gefunden",
         "domain_quota_m_in_use": "Domain-Speicherplatzlimit muss größer oder gleich %d MiB sein",
         "extended_sender_acl_denied": "Keine Rechte zum Setzen von externen Absenderadressen",
+        "external_goto_denied": "Externe Ziel-Adresse %s ist nicht erlaubt",
         "extra_acl_invalid": "Externe Absenderadresse \"%s\" ist ungültig",
         "extra_acl_invalid_domain": "Externe Absenderadresse \"%s\" verwendet eine ungültige Domain",
         "fido2_verification_failed": "FIDO2-Verifizierung fehlgeschlagen: %s",

--- a/data/web/lang/lang.en-gb.json
+++ b/data/web/lang/lang.en-gb.json
@@ -444,6 +444,7 @@
         "domain_not_found": "Domain %s not found",
         "domain_quota_m_in_use": "Domain quota must be greater or equal to %s MiB",
         "extended_sender_acl_denied": "missing ACL to set external sender addresses",
+        "external_goto_denied": "External goto address %s is not allowed",
         "extra_acl_invalid": "External sender address \"%s\" is invalid",
         "extra_acl_invalid_domain": "External sender \"%s\" uses an invalid domain",
         "fido2_verification_failed": "FIDO2 verification failed: %s",


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->
Adds a feature flag to be able to prevent the creation of aliases with external targets system wide.

We noticed that our user often do not understand the implications when using external domains in alias targets. For example, it usually leads to broken SPF validation. On bigger installations this even got the mailserver blacklisted by some recieving mailservers as they detected it as spam.

**notes**:  
I started with a quite minimal approach which neverteless already solve our pain point. But if you see the need for improvement or extension of it, i would love to hear your thoughts.

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
- php-fpm-mailcow

## Did you run tests?

Yes, i did manual testing.

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->

I tested the Webinterface, which is the only affected component.

**Tests**
* Made sure the default behaviour is not changed
* I tested the creation of mail aliases
* If `ALIAS_DISABLE_EXTERNAL_DOMAINS` is enabled it works like intended

**prepareation / test setup**  
Domains:
* test-internal.tld
* test-internal-disabled.tld (inactive domain)

Domain Alias:
* test-internal-alias.tld
* test-internal-alias-disabled.tld (inactive domain alias)

### What were the final results? (Awaited, got)

:heavy_check_mark: Default behaviour should not be changed and aliases with external targets should be allowed.  
:heavy_check_mark: When `ALIAS_DISABLE_EXTERNAL_DOMAINS` is enabled, external or inactive domain targets during alias creation or edit are removed and a warning is issued
:heavy_check_mark: Drop mails, marks as ham or spam is not affected


**Test recordings**

<details>

<summary>mailcow-alias-default</summary>

<img width="1715" height="1277" alt="mailcow-alias-default" src="https://github.com/user-attachments/assets/9815c925-f529-4fff-88ca-3cbfff2781a7" />

</details>

<details>

<summary>mailcow-alias-disabled-external</summary>

<img width="1715" height="1277" alt="mailcow-alias-disabled-external" src="https://github.com/user-attachments/assets/b6a80347-3404-4922-993c-7677387d8244" />

</details>

<details>

<summary>mailcow-alias-disabled-external-edit</summary>

<img width="1711" height="1219" alt="mailcow-alias-disabled-external-edit" src="https://github.com/user-attachments/assets/fef71446-bc69-4dca-89d0-d68a3e679c7b" />

</details>

<details>

<summary>mailcow-alias-additional-tests</summary>

<img width="1715" height="1277" alt="mailcow-alias-additional-tests" src="https://github.com/user-attachments/assets/c66569cb-e113-4338-a49a-7c49b3b2aef4" />

</details>

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->