### PR TITLE
Fix #7150: passwd-verify.lua wipes auth cache during any nginx outage

### DIFF
--- a/data/conf/dovecot/auth/passwd-verify.lua
+++ b/data/conf/dovecot/auth/passwd-verify.lua
@@ -32,8 +32,17 @@ function auth_password_verify(request, password)
   -- Returning PASSDB_RESULT_PASSWORD_MISMATCH will reset the user's auth cache entry.
   -- Returning PASSDB_RESULT_INTERNAL_FAILURE keeps the existing cache entry,
   -- even if the TTL has expired. Useful to avoid cache eviction during backend issues.
+
+  -- On a network-level failure (nginx unreachable, DNS failure, timeout) https.request
+  -- returns nil plus an error string, so c is not a numeric HTTP status code. Treat this
+  -- as a backend outage and keep the cache entry, rather than wiping it as a mismatch.
+  if type(c) ~= "number" then
+    dovecot.i_info("HTTP request to auth backend failed with " .. tostring(c) .. " for user " .. request.user)
+    return dovecot.auth.PASSDB_RESULT_INTERNAL_FAILURE, "Upstream unreachable"
+  end
+
   if c ~= 200 and c ~= 401 then
-    dovecot.i_info("HTTP request failed with " .. c .. " for user " .. request.user)
+    dovecot.i_info("HTTP request failed with " .. tostring(c) .. " for user " .. request.user)
     return dovecot.auth.PASSDB_RESULT_PASSWORD_MISMATCH, "Upstream error"
   end
 


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Fixes #7150.

`passwd-verify.lua` wiped the Dovecot auth cache for affected users whenever
a host reboot, a full-stack snapshot/backup, or any transient Docker network blip.

On a network-level failure, `https.request` returns `nil` plus an error *string*
(e.g. `"host or service not provided, or not known"`), so `c` is not a numeric HTTP
status code. The existing `if c ~= 200 and c ~= 401` check treated this identically
to a credential rejection and returned `PASSDB_RESULT_PASSWORD_MISMATCH`, which clears
the cache entry — causing hard auth failures for reconnecting clients (iOS Mail in
particular, which has no Keychain fallback).

This PR adds a guard ahead of the HTTP-status check: when `c` is not a number, the
request failed at the network level, so it returns `PASSDB_RESULT_INTERNAL_FAILURE`
("Upstream unreachable"), which **keeps** the existing cache entry instead of wiping
it. Genuine HTTP responses (200/401, and 4xx/5xx errors) are handled exactly as before.
The log concatenation is also hardened to `tostring(c)` so it can't error on a
non-string/nil value.

This restores the pre-2025-05 behavior where a brief nginx interruption was benign for
already-authenticated clients.

### Affected Containers

- dovecot-mailcow

## Did you run tests?

Yes — tested on a live mailcow instance by overriding `passwd-verify.lua` and exercising
the real-world scenario that originally surfaced the bug.

### What did you tested?

The Dovecot auth path (`dovecot-mailcow`) through a full-stack restart, using my backup
procedure as the trigger: stop the entire stack, snapshot the volumes, then start the
stack again. This is exactly the kind of operation that leaves `nginx:9082` unreachable
while Dovecot auth workers are still serving reconnecting IMAP clients.

I first noticed the failure on the stock file, then applied the patched
`passwd-verify.lua` as an override and repeated the same backup/restart cycle with active
IMAP clients connected.

### What were the final results? (Awaited, got)

- Stock file, full-stack restart → **awaited:** the documented bug. **got:** confirmed —
  auth cache entries for connected users were wiped and clients hit hard authentication
  failures during the nginx-unavailable window.
- Patched file, same full-stack restart → **awaited:** cache entries retained, clients
  unaffected. **got:** as awaited — no cache wipe, and connected IMAP clients stayed
  authenticated across the entire stop/snapshot/restart cycle, with no re-auth prompts.
- `luac -p data/conf/dovecot/auth/passwd-verify.lua` → **awaited:** no syntax errors.
  **got:** syntax OK.
