### PR TITLE
postfix-tlspol: upgrade to trixie + 1.11.0 update

### DIFF
--- a/data/Dockerfiles/postfix-tlspol/Dockerfile
+++ b/data/Dockerfiles/postfix-tlspol/Dockerfile
@@ -1,17 +1,17 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26-trixie AS builder
 WORKDIR /src
 
 ENV CGO_ENABLED=0 \
     GO111MODULE=on \
 		NOOPT=1 \
-    VERSION=1.8.22
+    VERSION=1.11.0
 
 RUN git clone --branch v${VERSION} https://github.com/Zuplu/postfix-tlspol && \
     cd /src/postfix-tlspol && \
     scripts/build.sh build-only
 
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 LABEL maintainer="The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/data/Dockerfiles/postfix-tlspol/syslog-ng-redis_slave.conf
+++ b/data/Dockerfiles/postfix-tlspol/syslog-ng-redis_slave.conf
@@ -1,4 +1,4 @@
-@version: 3.38
+@version: 4.8
 @include "scl.conf"
 options {
   chain_hostnames(off);
@@ -7,7 +7,7 @@ options {
   dns_cache(no);
   use_fqdn(no);
   owner("root"); group("adm"); perm(0640);
-  stats_freq(0);
+  stats(freq(0));
   bad_hostname("^gconfd$");
 };
 source s_src {

--- a/data/Dockerfiles/postfix-tlspol/syslog-ng.conf
+++ b/data/Dockerfiles/postfix-tlspol/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.38
+@version: 4.8
 @include "scl.conf"
 options {
   chain_hostnames(off);
@@ -7,7 +7,7 @@ options {
   dns_cache(no);
   use_fqdn(no);
   owner("root"); group("adm"); perm(0640);
-  stats_freq(0);
+  stats(freq(0));
   bad_hostname("^gconfd$");
 };
 source s_src {

--- a/data/conf/postfix/main.cf
+++ b/data/conf/postfix/main.cf
@@ -150,7 +150,7 @@ smtp_sasl_auth_enable = yes
 smtp_sasl_password_maps = proxy:mysql:/opt/postfix/conf/sql/mysql_sasl_passwd_maps_sender_dependent.cf
 smtp_sasl_security_options =
 smtp_sasl_mechanism_filter = plain, login
-smtp_tls_policy_maps = proxy:mysql:/opt/postfix/conf/sql/mysql_tls_policy_override_maps.cf socketmap:inet:postfix-tlspol:8642:QUERY
+smtp_tls_policy_maps = proxy:mysql:/opt/postfix/conf/sql/mysql_tls_policy_override_maps.cf socketmap:inet:postfix-tlspol:8642:QUERYwithTLSRPT
 smtp_header_checks = pcre:/opt/postfix/conf/anonymize_headers.pcre
 mail_name = Postcow
 # local_transport map catches local destinations and prevents routing local dests when the next map would route "*"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -382,7 +382,7 @@ services:
             - postfix
 
     postfix-tlspol-mailcow:
-      image: ghcr.io/mailcow/postfix-tlspol:1.8.23
+      image: ghcr.io/mailcow/postfix-tlspol:1.11.0
       depends_on:
         unbound-mailcow:
           condition: service_healthy


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This pull request updates the `postfix-tlspol` component and related configuration files to use newer versions of dependencies and images, and makes configuration changes to ensure compatibility with these updates. The main focus is on upgrading to version 1.11.0 of `postfix-tlspol` and updating related system and service configurations.

**Dependency and Image Upgrades:**
- Updated the base images in the `Dockerfile` to use `golang:1.26-trixie` for building and `debian:trixie-slim` for runtime, and bumped the `postfix-tlspol` version to 1.11.0.
- Updated the `postfix-tlspol-mailcow` service in `docker-compose.yml` to use image version 1.11.0.

**Configuration Updates for Compatibility:**
- Upgraded `syslog-ng` configuration files to version 4.8, and replaced the deprecated `stats_freq(0)` option with the new `stats(freq(0))` syntax in both `syslog-ng.conf` and `syslog-ng-redis_slave.conf`. [[1]](diffhunk://#diff-614528617a7a48101113f27e3d76258bbc95a0a941bce8effbce2b452d34e4fdL1-R1) [[2]](diffhunk://#diff-614528617a7a48101113f27e3d76258bbc95a0a941bce8effbce2b452d34e4fdL10-R10) [[3]](diffhunk://#diff-91d0a610f54c3b5914100c4481f81454d06ec891f0729a7e303b04ce139792e3L1-R1) [[4]](diffhunk://#diff-91d0a610f54c3b5914100c4481f81454d06ec891f0729a7e303b04ce139792e3L10-R10)
- Changed the `smtp_tls_policy_maps` setting in `postfix/main.cf` to use the `QUERYwithTLSRPT` socketmap, likely reflecting an updated query interface in the new version.

###  Affected Containers

- postfix-mailcow
- postfix-tls-mailcow

## Did you run tests?

### What did you tested?

General mailing + startups, as well as MTA-STS Lookups during mail sending.

### What were the final results? (Awaited, got)

Everything works as expected.