### PR TITLE
components: upgrade to be compatible with php8.4 + mariadb 11.8

### DIFF
--- a/data/Dockerfiles/dockerapi/modules/DockerApi.py
+++ b/data/Dockerfiles/dockerapi/modules/DockerApi.py
@@ -253,7 +253,7 @@ class DockerApi:
       else:
         res = { 'type': 'error', 'msg': 'mariadb-upgrade: error running command', 'text': sql_return.output.decode('utf-8')}
         return Response(content=json.dumps(res, indent=4), media_type="application/json")
-  # api call: container_post - post_action: exec - cmd: system - task: mariadb-tzinfo-to-sql
+  # api call: container_post - post_action: exec - cmd: system - task: mariadb_tzinfo-to-sql
   def container_post__exec__system__mariadb_tzinfo_to_sql(self, request_json, **kwargs):
     if 'container_id' in kwargs:
       filters = {"id": kwargs['container_id']}

--- a/data/Dockerfiles/dockerapi/modules/DockerApi.py
+++ b/data/Dockerfiles/dockerapi/modules/DockerApi.py
@@ -229,44 +229,44 @@ class DockerApi:
           return df_return.output.decode('utf-8').rstrip()
         else:
           return "0,0,0,0,0,0"
-  # api call: container_post - post_action: exec - cmd: system - task: mysql_upgrade
-  def container_post__exec__system__mysql_upgrade(self, request_json, **kwargs):
+  # api call: container_post - post_action: exec - cmd: system - task: mariadb-upgrade
+  def container_post__exec__system__mariadb_upgrade(self, request_json, **kwargs):
     if 'container_id' in kwargs:
       filters = {"id": kwargs['container_id']}
     elif 'container_name' in kwargs:
       filters = {"name": kwargs['container_name']}
 
     for container in self.sync_docker_client.containers.list(filters=filters):
-      sql_return = container.exec_run(["/bin/bash", "-c", "/usr/bin/mysql_upgrade -uroot -p'" + os.environ['DBROOT'].replace("'", "'\\''") + "'\n"], user='mysql')
+      sql_return = container.exec_run(["/bin/bash", "-c", "/usr/bin/mariadb-upgrade -uroot -p'" + os.environ['DBROOT'].replace("'", "'\\''") + "'\n"], user='mysql')
       if sql_return.exit_code == 0:
         matched = False
         for line in sql_return.output.decode('utf-8').split("\n"):
           if 'is already upgraded to' in line:
             matched = True
         if matched:
-          res = { 'type': 'success', 'msg':'mysql_upgrade: already upgraded', 'text': sql_return.output.decode('utf-8')}
+          res = { 'type': 'success', 'msg':'mariadb-upgrade: already upgraded', 'text': sql_return.output.decode('utf-8')}
           return Response(content=json.dumps(res, indent=4), media_type="application/json")
         else:
           container.restart()
-          res = { 'type': 'warning', 'msg':'mysql_upgrade: upgrade was applied', 'text': sql_return.output.decode('utf-8')}
+          res = { 'type': 'warning', 'msg':'mariadb-upgrade: upgrade was applied', 'text': sql_return.output.decode('utf-8')}
           return Response(content=json.dumps(res, indent=4), media_type="application/json")
       else:
-        res = { 'type': 'error', 'msg': 'mysql_upgrade: error running command', 'text': sql_return.output.decode('utf-8')}
+        res = { 'type': 'error', 'msg': 'mariadb-upgrade: error running command', 'text': sql_return.output.decode('utf-8')}
         return Response(content=json.dumps(res, indent=4), media_type="application/json")
-  # api call: container_post - post_action: exec - cmd: system - task: mysql_tzinfo_to_sql
-  def container_post__exec__system__mysql_tzinfo_to_sql(self, request_json, **kwargs):
+  # api call: container_post - post_action: exec - cmd: system - task: mariadb-tzinfo-to-sql
+  def container_post__exec__system__mariadb_tzinfo_to_sql(self, request_json, **kwargs):
     if 'container_id' in kwargs:
       filters = {"id": kwargs['container_id']}
     elif 'container_name' in kwargs:
       filters = {"name": kwargs['container_name']}
 
     for container in self.sync_docker_client.containers.list(filters=filters):
-      sql_return = container.exec_run(["/bin/bash", "-c", "/usr/bin/mysql_tzinfo_to_sql /usr/share/zoneinfo | /bin/sed 's/Local time zone must be set--see zic manual page/FCTY/' | /usr/bin/mysql -uroot -p'" + os.environ['DBROOT'].replace("'", "'\\''") + "' mysql \n"], user='mysql')
+      sql_return = container.exec_run(["/bin/bash", "-c", "/usr/bin/mariadb-tzinfo-to-sql /usr/share/zoneinfo | /bin/sed 's/Local time zone must be set--see zic manual page/FCTY/' | /usr/bin/mysql -uroot -p'" + os.environ['DBROOT'].replace("'", "'\\''") + "' mysql \n"], user='mysql')
       if sql_return.exit_code == 0:
-        res = { 'type': 'info', 'msg': 'mysql_tzinfo_to_sql: command completed successfully', 'text': sql_return.output.decode('utf-8')}
+        res = { 'type': 'info', 'msg': 'mariadb-tzinfo-to-sql: command completed successfully', 'text': sql_return.output.decode('utf-8')}
         return Response(content=json.dumps(res, indent=4), media_type="application/json")
       else:
-        res = { 'type': 'error', 'msg': 'mysql_tzinfo_to_sql: error running command', 'text': sql_return.output.decode('utf-8')}
+        res = { 'type': 'error', 'msg': 'mariadb-tzinfo-to-sql: error running command', 'text': sql_return.output.decode('utf-8')}
         return Response(content=json.dumps(res, indent=4), media_type="application/json")
   # api call: container_post - post_action: exec - cmd: reload - task: dovecot
   def container_post__exec__reload__dovecot(self, request_json, **kwargs):

--- a/data/Dockerfiles/phpfpm/Dockerfile
+++ b/data/Dockerfiles/phpfpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-alpine3.21
+FROM php:8.4-fpm-alpine3.23
 
 LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 
@@ -16,11 +16,7 @@ ARG REDIS_PECL_VERSION=6.3.0
 ARG COMPOSER_VERSION=2.10.2
 
 RUN apk add -U --no-cache autoconf \
-  aspell-dev \
-  aspell-libs \
   bash \
-  c-client \
-  cyrus-sasl-dev \
   freetype \
   freetype-dev \
   g++ \
@@ -33,7 +29,6 @@ RUN apk add -U --no-cache autoconf \
   icu-libs \
   imagemagick \
   imagemagick-dev \
-  imap-dev \
   jq \
   libavif \
   libavif-dev \
@@ -72,26 +67,21 @@ RUN apk add -U --no-cache autoconf \
   && pecl clear-cache \
   && docker-php-ext-configure intl \
   && docker-php-ext-configure exif \
-  && docker-php-ext-configure gd --with-freetype=/usr/include/ \  
+  && docker-php-ext-configure gd --with-freetype=/usr/include/ \
     --with-jpeg=/usr/include/ \
     --with-webp \
     --with-xpm \
     --with-avif \
-  && docker-php-ext-install -j 4 exif gd gettext intl ldap opcache pcntl pdo pdo_mysql pspell soap sockets zip bcmath gmp \
-  && docker-php-ext-configure imap --with-imap --with-imap-ssl \
-  && docker-php-ext-install -j 4 imap \
+  && docker-php-ext-install -j 4 exif gd gettext intl ldap opcache pcntl pdo pdo_mysql soap sockets zip bcmath gmp \
   && curl --silent --show-error https://getcomposer.org/installer | php -- --version=${COMPOSER_VERSION} \
   && mv composer.phar /usr/local/bin/composer \
   && chmod +x /usr/local/bin/composer \
   && apk del --purge autoconf \
-    aspell-dev \
-    cyrus-sasl-dev \
     freetype-dev \
     g++ \
     gettext-dev \
     icu-dev \
     imagemagick-dev \
-    imap-dev \
     libavif-dev \
     libjpeg-turbo-dev \
     libmemcached-dev \

--- a/data/Dockerfiles/phpfpm/docker-entrypoint.sh
+++ b/data/Dockerfiles/phpfpm/docker-entrypoint.sh
@@ -29,7 +29,7 @@ session.save_handler = redis
 session.save_path = "tcp://'${REDIS_HOST}':'${REDIS_PORT}'?auth='${REDISPASS}'"
 ' > /usr/local/etc/php/conf.d/session_store.ini
 
-# Check mysql_upgrade (master and slave)
+# Check mariadb-upgrade (master and slave)
 CONTAINER_ID=
 until [[ ! -z "${CONTAINER_ID}" ]] && [[ "${CONTAINER_ID}" =~ ^[[:alnum:]]*$ ]]; do
   CONTAINER_ID=$(curl --silent --insecure https://dockerapi.${COMPOSE_PROJECT_NAME}_mailcow-network/containers/json | jq -r ".[] | {name: .Config.Labels[\"com.docker.compose.service\"], project: .Config.Labels[\"com.docker.compose.project\"], id: .Id}" 2> /dev/null | jq -rc "select( .name | tostring | contains(\"mysql-mailcow\")) | select( .project | tostring | contains(\"${COMPOSE_PROJECT_NAME,,}\")) | .id" 2> /dev/null)
@@ -41,16 +41,16 @@ SQL_LOOP_C=0
 SQL_CHANGED=0
 until [[ ${SQL_UPGRADE_STATUS} == 'success' ]]; do
   if [ ${SQL_LOOP_C} -gt 4 ]; then
-    echo "Tried to upgrade MySQL and failed, giving up after ${SQL_LOOP_C} retries and starting container (oops, not good)"
+    echo "Tried to upgrade MariaDB and failed, giving up after ${SQL_LOOP_C} retries and starting container (oops, not good)"
     break
   fi
-  SQL_FULL_UPGRADE_RETURN=$(curl --silent --insecure -XPOST https://dockerapi.${COMPOSE_PROJECT_NAME}_mailcow-network/containers/${CONTAINER_ID}/exec -d '{"cmd":"system", "task":"mysql_upgrade"}' --silent -H 'Content-type: application/json')
+  SQL_FULL_UPGRADE_RETURN=$(curl --silent --insecure -XPOST https://dockerapi.${COMPOSE_PROJECT_NAME}_mailcow-network/containers/${CONTAINER_ID}/exec -d '{"cmd":"system", "task":"mariadb_upgrade"}' --silent -H 'Content-type: application/json')
   SQL_UPGRADE_STATUS=$(echo ${SQL_FULL_UPGRADE_RETURN} | jq -r .type)
   SQL_LOOP_C=$((SQL_LOOP_C+1))
   echo "SQL upgrade iteration #${SQL_LOOP_C}"
   if [[ ${SQL_UPGRADE_STATUS} == 'warning' ]]; then
     SQL_CHANGED=1
-    echo "MySQL applied an upgrade, debug output:"
+    echo "MariaDB applied an upgrade, debug output:"
     echo ${SQL_FULL_UPGRADE_RETURN}
     sleep 3
     while ! mariadb-admin status --ssl=false --socket=/var/run/mysqld/mysqld.sock -u${DBUSER} -p${DBPASS} --silent; do
@@ -59,10 +59,10 @@ until [[ ${SQL_UPGRADE_STATUS} == 'success' ]]; do
     done
     continue
   elif [[ ${SQL_UPGRADE_STATUS} == 'success' ]]; then
-    echo "MySQL is up-to-date - debug output:"
+    echo "MariaDB is up-to-date - debug output:"
     echo ${SQL_FULL_UPGRADE_RETURN}
   else
-    echo "No valid reponse for mysql_upgrade was received, debug output:"
+    echo "No valid reponse for mariadb-upgrade was received, debug output:"
     echo ${SQL_FULL_UPGRADE_RETURN}
   fi
 done
@@ -83,8 +83,8 @@ fi
 # Check mysql tz import (master and slave)
 TZ_CHECK=$(mariadb --skip-ssl --socket=/var/run/mysqld/mysqld.sock -u ${DBUSER} -p${DBPASS} ${DBNAME} -e "SELECT CONVERT_TZ('2019-11-02 23:33:00','Europe/Berlin','UTC') AS time;" -BN 2> /dev/null)
 if [[ -z ${TZ_CHECK} ]] || [[ "${TZ_CHECK}" == "NULL" ]]; then
-  SQL_FULL_TZINFO_IMPORT_RETURN=$(curl --silent --insecure -XPOST https://dockerapi.${COMPOSE_PROJECT_NAME}_mailcow-network/containers/${CONTAINER_ID}/exec -d '{"cmd":"system", "task":"mysql_tzinfo_to_sql"}' --silent -H 'Content-type: application/json')
-  echo "MySQL mysql_tzinfo_to_sql - debug output:"
+  SQL_FULL_TZINFO_IMPORT_RETURN=$(curl --silent --insecure -XPOST https://dockerapi.${COMPOSE_PROJECT_NAME}_mailcow-network/containers/${CONTAINER_ID}/exec -d '{"cmd":"system", "task":"mariadb-tzinfo-to-sql"}' --silent -H 'Content-type: application/json')
+  echo "MariaDB tzinfo-to-sql - debug output:"
   echo ${SQL_FULL_TZINFO_IMPORT_RETURN}
 fi
 

--- a/data/Dockerfiles/phpfpm/docker-entrypoint.sh
+++ b/data/Dockerfiles/phpfpm/docker-entrypoint.sh
@@ -83,7 +83,7 @@ fi
 # Check mysql tz import (master and slave)
 TZ_CHECK=$(mariadb --skip-ssl --socket=/var/run/mysqld/mysqld.sock -u ${DBUSER} -p${DBPASS} ${DBNAME} -e "SELECT CONVERT_TZ('2019-11-02 23:33:00','Europe/Berlin','UTC') AS time;" -BN 2> /dev/null)
 if [[ -z ${TZ_CHECK} ]] || [[ "${TZ_CHECK}" == "NULL" ]]; then
-  SQL_FULL_TZINFO_IMPORT_RETURN=$(curl --silent --insecure -XPOST https://dockerapi.${COMPOSE_PROJECT_NAME}_mailcow-network/containers/${CONTAINER_ID}/exec -d '{"cmd":"system", "task":"mariadb-tzinfo-to-sql"}' --silent -H 'Content-type: application/json')
+  SQL_FULL_TZINFO_IMPORT_RETURN=$(curl --silent --insecure -XPOST https://dockerapi.${COMPOSE_PROJECT_NAME}_mailcow-network/containers/${CONTAINER_ID}/exec -d '{"cmd":"system", "task":"mariadb_tzinfo-to-sql"}' --silent -H 'Content-type: application/json')
   echo "MariaDB tzinfo-to-sql - debug output:"
   echo ${SQL_FULL_TZINFO_IMPORT_RETURN}
 fi

--- a/data/assets/mysql/docker-entrypoint.sh
+++ b/data/assets/mysql/docker-entrypoint.sh
@@ -114,7 +114,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
 			# sed is for https://bugs.mysql.com/bug.php?id=20545
-			mysql_tzinfo_to_sql /usr/share/zoneinfo | sed 's/Local time zone must be set--see zic manual page/FCTY/' | "${mysql[@]}" mysql
+			mariadb-tzinfo-to-sql /usr/share/zoneinfo | sed 's/Local time zone must be set--see zic manual page/FCTY/' | "${mysql[@]}" mysql
 		fi
 
 		if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
             - unbound
 
     mysql-mailcow:
-      image: mariadb:10.11
+      image: mariadb:11.8
       depends_on:
         - unbound-mailcow
         - netfilter-mailcow
@@ -117,7 +117,7 @@ services:
             - rspamd
 
     php-fpm-mailcow:
-      image: ghcr.io/mailcow/phpfpm:8.2.29-3
+      image: ghcr.io/mailcow/phpfpm:8.4.23
       command: "php-fpm -d date.timezone=${TZ} -d expose_php=0"
       depends_on:
         - redis-mailcow
@@ -601,7 +601,7 @@ services:
             - watchdog
 
     dockerapi-mailcow:
-      image: ghcr.io/mailcow/dockerapi:2.12
+      image: ghcr.io/mailcow/dockerapi:2.13
       security_opt:
         - label=disable
       restart: always


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This pull request updates the stack to use newer versions of core images and aligns MariaDB-related scripts and API endpoints with the MariaDB naming and tools, replacing legacy MySQL references. It also removes some unnecessary dependencies from the PHP-FPM image for a leaner build.

**Major dependency and image updates:**

* Updated `mysql-mailcow` service to use `mariadb:11.8` (was `mariadb:10.11`) in `docker-compose.yml`.
* Updated `php-fpm-mailcow` to use `ghcr.io/mailcow/phpfpm:8.4.23` (was `8.2.29-3`) and the base image in `data/Dockerfiles/phpfpm/Dockerfile` to `php:8.4-fpm-alpine3.23` (was `php:8.2-fpm-alpine3.21`). [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L120-R120) [[2]](diffhunk://#diff-8fb26ba1bfce9795a43cb7207064638cb305adbf17c4cd9aad3fc205c1a55ce3L1-R1)
* Updated `dockerapi-mailcow` to `ghcr.io/mailcow/dockerapi:2.13` (was `2.12`).

**MariaDB migration and naming consistency:**

* Replaced all `mysql_upgrade` and `mysql_tzinfo_to_sql` references with `mariadb-upgrade` and `mariadb-tzinfo-to-sql` respectively in API endpoints (`DockerApi.py`), entrypoint scripts, and logs. This affects upgrade and timezone import routines for better compatibility with MariaDB 11. [[1]](diffhunk://#diff-468ee2c69ed8aa55eaee7233042069d9cc9c786c728665e03e6d9c0576a53380L232-R269) [[2]](diffhunk://#diff-fa09b5967ec6c4a177cfabb685dcf5e0464d3777b2d824667fe15486b7f91776L32-R32) [[3]](diffhunk://#diff-fa09b5967ec6c4a177cfabb685dcf5e0464d3777b2d824667fe15486b7f91776L44-R53) [[4]](diffhunk://#diff-fa09b5967ec6c4a177cfabb685dcf5e0464d3777b2d824667fe15486b7f91776L62-R65) [[5]](diffhunk://#diff-fa09b5967ec6c4a177cfabb685dcf5e0464d3777b2d824667fe15486b7f91776L86-R87) [[6]](diffhunk://#diff-3aab4bb871981e31bd70682c5b62a1ecaae69b127ca610a0f6f96081c2d914efL117-R117)

**PHP-FPM image cleanup:**

* Removed unused dependencies (`aspell-dev`, `aspell-libs`, `c-client`, `cyrus-sasl-dev`, `imap-dev`) and the `imap` PHP extension from the build process, simplifying and reducing the image size. [[1]](diffhunk://#diff-8fb26ba1bfce9795a43cb7207064638cb305adbf17c4cd9aad3fc205c1a55ce3L19-L23) [[2]](diffhunk://#diff-8fb26ba1bfce9795a43cb7207064638cb305adbf17c4cd9aad3fc205c1a55ce3L36) [[3]](diffhunk://#diff-8fb26ba1bfce9795a43cb7207064638cb305adbf17c4cd9aad3fc205c1a55ce3L80-L94)

These changes ensure the stack is up-to-date, more secure, and better aligned with MariaDB best practices.

###  Affected Containers

- mysql-mailcow
- phpfpm-mailcow
- dockerapi-mailcow

## Did you run tests?

### What did you tested?

Normal mailcow UI usage, DB upgrade (after updating mariadb image version)

### What were the final results? (Awaited, got)

Works as expected.

> [!WARNING]
> Be aware that this PR upgrades PHP to 8.4 which may break something deeply. On the first look it looks fine. 