### PR TITLE
[Web] Add show/hide password toggle on login pages

### DIFF
--- a/data/web/templates/admin_index.twig
+++ b/data/web/templates/admin_index.twig
@@ -49,6 +49,7 @@
             <div class="input-group">
               <div class="input-group-text"><i class="bi bi-lock-fill"></i></div>
               <input name="pass_user" type="password" id="pass_user" class="form-control" placeholder="{{ lang.login.password }}" required="" autocomplete="current-password">
+              <button type="button" class="btn btn-outline-secondary" onclick="var i=document.getElementById('pass_user'),ic=this.querySelector('i');if(i.type==='password'){i.type='text';ic.className='bi bi-eye-slash';}else{i.type='password';ic.className='bi bi-eye';}" tabindex="-1" aria-label="Toggle password visibility"><i class="bi bi-eye"></i></button>
             </div>
           </div>
           <div class="d-flex justify-content-between mt-4" style="position: relative">

--- a/data/web/templates/admin_index.twig
+++ b/data/web/templates/admin_index.twig
@@ -49,7 +49,7 @@
             <div class="input-group">
               <div class="input-group-text"><i class="bi bi-lock-fill"></i></div>
               <input name="pass_user" type="password" id="pass_user" class="form-control" placeholder="{{ lang.login.password }}" required="" autocomplete="current-password">
-              <button type="button" class="btn btn-outline-secondary" onclick="var i=document.getElementById('pass_user'),ic=this.querySelector('i');if(i.type==='password'){i.type='text';ic.className='bi bi-eye-slash';}else{i.type='password';ic.className='bi bi-eye';}" tabindex="-1" aria-label="Toggle password visibility"><i class="bi bi-eye"></i></button>
+              <button type="button" class="input-group-text" style="cursor:pointer;" onclick="var i=document.getElementById('pass_user'),ic=this.querySelector('i');if(i.type==='password'){i.type='text';ic.className='bi bi-eye-slash';}else{i.type='password';ic.className='bi bi-eye';}" tabindex="-1" aria-label="Toggle password visibility"><i class="bi bi-eye"></i></button>
             </div>
           </div>
           <div class="d-flex justify-content-between mt-4" style="position: relative">

--- a/data/web/templates/domainadmin_index.twig
+++ b/data/web/templates/domainadmin_index.twig
@@ -49,6 +49,7 @@
             <div class="input-group">
               <div class="input-group-text"><i class="bi bi-lock-fill"></i></div>
               <input name="pass_user" type="password" id="pass_user" class="form-control" placeholder="{{ lang.login.password }}" required="" autocomplete="current-password">
+              <button type="button" class="btn btn-outline-secondary" onclick="var i=document.getElementById('pass_user'),ic=this.querySelector('i');if(i.type==='password'){i.type='text';ic.className='bi bi-eye-slash';}else{i.type='password';ic.className='bi bi-eye';}" tabindex="-1" aria-label="Toggle password visibility"><i class="bi bi-eye"></i></button>
             </div>
           </div>
           <div class="d-flex justify-content-between mt-4" style="position: relative">

--- a/data/web/templates/domainadmin_index.twig
+++ b/data/web/templates/domainadmin_index.twig
@@ -49,7 +49,7 @@
             <div class="input-group">
               <div class="input-group-text"><i class="bi bi-lock-fill"></i></div>
               <input name="pass_user" type="password" id="pass_user" class="form-control" placeholder="{{ lang.login.password }}" required="" autocomplete="current-password">
-              <button type="button" class="btn btn-outline-secondary" onclick="var i=document.getElementById('pass_user'),ic=this.querySelector('i');if(i.type==='password'){i.type='text';ic.className='bi bi-eye-slash';}else{i.type='password';ic.className='bi bi-eye';}" tabindex="-1" aria-label="Toggle password visibility"><i class="bi bi-eye"></i></button>
+              <button type="button" class="input-group-text" style="cursor:pointer;" onclick="var i=document.getElementById('pass_user'),ic=this.querySelector('i');if(i.type==='password'){i.type='text';ic.className='bi bi-eye-slash';}else{i.type='password';ic.className='bi bi-eye';}" tabindex="-1" aria-label="Toggle password visibility"><i class="bi bi-eye"></i></button>
             </div>
           </div>
           <div class="d-flex justify-content-between mt-4" style="position: relative">

--- a/data/web/templates/user_index.twig
+++ b/data/web/templates/user_index.twig
@@ -56,6 +56,7 @@
             <div class="input-group">
               <div class="input-group-text"><i class="bi bi-lock-fill"></i></div>
               <input name="pass_user" type="password" id="pass_user" class="form-control" placeholder="{{ lang.login.password }}" required="" autocomplete="current-password">
+              <button type="button" class="btn btn-outline-secondary" onclick="var i=document.getElementById('pass_user'),ic=this.querySelector('i');if(i.type==='password'){i.type='text';ic.className='bi bi-eye-slash';}else{i.type='password';ic.className='bi bi-eye';}" tabindex="-1" aria-label="Toggle password visibility"><i class="bi bi-eye"></i></button>
             </div>
           </div>
           <div class="mt-2 text-muted" style="font-size: 0.9rem;">

--- a/data/web/templates/user_index.twig
+++ b/data/web/templates/user_index.twig
@@ -56,7 +56,7 @@
             <div class="input-group">
               <div class="input-group-text"><i class="bi bi-lock-fill"></i></div>
               <input name="pass_user" type="password" id="pass_user" class="form-control" placeholder="{{ lang.login.password }}" required="" autocomplete="current-password">
-              <button type="button" class="btn btn-outline-secondary" onclick="var i=document.getElementById('pass_user'),ic=this.querySelector('i');if(i.type==='password'){i.type='text';ic.className='bi bi-eye-slash';}else{i.type='password';ic.className='bi bi-eye';}" tabindex="-1" aria-label="Toggle password visibility"><i class="bi bi-eye"></i></button>
+              <button type="button" class="input-group-text" style="cursor:pointer;" onclick="var i=document.getElementById('pass_user'),ic=this.querySelector('i');if(i.type==='password'){i.type='text';ic.className='bi bi-eye-slash';}else{i.type='password';ic.className='bi bi-eye';}" tabindex="-1" aria-label="Toggle password visibility"><i class="bi bi-eye"></i></button>
             </div>
           </div>
           <div class="mt-2 text-muted" style="font-size: 0.9rem;">


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Adds a show/hide password toggle button (eye icon) to the password field on all three login pages: user, admin, and domain admin.

Clicking the button toggles the field between `type="password"` and `type="text"` and switches between `bi-eye` and `bi-eye-slash` icons accordingly.

The button uses Bootstrap's `input-group-text` class so its border and styling are consistent with the lock icon on the left side of the input group.

Closes #6893

### Affected Containers

- nginx (web UI templates only — no backend changes)

## Did you run tests?

### What did you tested?

Tested all three login pages (user, admin, domain admin) using a standalone HTML preview with Bootstrap 5 and Bootstrap Icons.

### What were the final results? (Awaited, got)

- Awaited: eye icon appears at the right of the password field; clicking it reveals the password and switches to eye-slash icon; clicking again hides it.
- Got: behaviour matches expectation on all three login pages. Button border is visually consistent with the rest of the input group.

<img width="1297" height="1057" alt="CleanShot 2026-03-21 at 16 03 28" src="https://github.com/user-attachments/assets/85e54726-605a-4ae2-ba3b-c8bbb5786c60" />


> The original pull request is https://github.com/mailcow/mailcow-dockerized/pull/7155
> I didn't want this feature to be forgotten.
