### PR TITLE
[Web] translate password errors in the forced password change modal

### DIFF
--- a/data/web/templates/base.twig
+++ b/data/web/templates/base.twig
@@ -473,6 +473,10 @@ function recursiveBase64StrToArrayBuffer(obj) {
             window.location.reload();
           } else {
             var msg = (data && data[0] && data[0].msg) ? data[0].msg : 'Password change failed.';
+            // the API returns raw language keys, resolve them like the alert box does
+            if (Object.prototype.hasOwnProperty.call(lang_danger, msg)) {
+              msg = lang_danger[msg];
+            }
             $('#changePWAlert').show().text(msg);
           }
         },


### PR DESCRIPTION
## What

When a user is forced to change their password at next login and enters one that
fails the complexity policy, the modal shows the literal string
`password_complexity` instead of a message.

## Why

The forced password change modal is the only password form that posts to the JSON
API (`/api/v1/edit/self`, or `/api/v1/edit/admin` for admins) and renders
`data[0].msg` straight into the alert. The API intentionally returns raw language
keys — every other password form goes through `alertbox_log_parser()`, which
resolves the key against `$lang`. This modal never did.

## Fix

Resolve the key against `lang_danger`, which `base.twig` already exposes for
exactly this purpose (it is `json_encode($lang['danger'])`, see
`footer.inc.php:74`, and is used the same way in `admin.js`). No new machinery, no
API change — the API keeps returning stable keys for external consumers, since the
bug is in the presentation layer.

This also fixes `password_mismatch`, `password_empty` and `access_denied` in the
same modal, and covers the admin path through the same handler.

The lookup is guarded with `hasOwnProperty`: `msg` is dynamic, and a bare
`lang_danger[msg]` would resolve inherited `Object.prototype` members like
`constructor` to a *function*, which jQuery's `.text()` treats as a callback and
invokes.

**No language files are touched.** `prerequisites.inc.php:269` loads
`lang.en-gb.json` as the base and merges the active locale over it, so the four
locales that currently lack `danger.password_complexity` (az, gr, lt, nb) inherit
the English string rather than falling back to the raw key.

## Verification

- `base.twig` parses clean under Twig (with mailcow's custom `query_string` /
  `is_uri` / `rot13` / `formatBytes` extensions registered), before and after.
- Exercised the lookup against the real `danger` section of `lang.en-gb.json`:

| API returns | before | after |
|---|---|---|
| `password_complexity` | `password_complexity` | Password does not meet the policy |
| `password_mismatch` | `password_mismatch` | Confirmation password does not match |
| `password_empty` | `password_empty` | Password must not be empty |
| `access_denied` | `access_denied` | Access denied or invalid form data |
| unknown key | unchanged | unchanged |
| `'Password change failed.'` (JS fallback) | unchanged | unchanged |
| array form (vsprintf) | unchanged | unchanged |

- Confirmed all 33 locale files resolve to a real string via the en-gb base merge.

Fixes #7301
