### PR TITLE
[Web] use absolute RHS names in generated DNS zonefile

### DIFF
--- a/data/web/inc/ajax/dns_diagnostics.php
+++ b/data/web/inc/ajax/dns_diagnostics.php
@@ -442,6 +442,16 @@ if (isset($_SESSION['mailcow_cc_role']) && ($_SESSION['mailcow_cc_role'] == "adm
 
       unset($record);
 
+      // Make a hostname RHS absolute so it is not read relative to $ORIGIN.
+      // Already-absolute names, the SRV root target "." and IP addresses are left alone.
+      $absolutize = function($host) {
+        $host = trim($host);
+        if ($host === '' || $host === '.' || substr($host, -1) === '.' || filter_var($host, FILTER_VALIDATE_IP)) {
+          return $host;
+        }
+        return $host . '.';
+      };
+
       $dns_data = sprintf("\$ORIGIN %s.\n", $domain);
       foreach ($records as $record) {
         if ($domain == substr($record[0], -strlen($domain))) {
@@ -462,16 +472,26 @@ if (isset($_SESSION['mailcow_cc_role']) && ($_SESSION['mailcow_cc_role'] == "adm
               $val = str_replace(state_optional, '', $val);
               $val = str_replace(state_good, '', $val);
               if (strlen($val) > 0) {
+                // these are all TXT values, their RHS is a character string, not a name
                 $vals[] = sprintf("%s\tIN\t%s\t%s\n", $label, $record[1], $val);
               }
             }
           }
           else {
+            if ($record[1] == 'MX' || $record[1] == 'CNAME') {
+              $val = $absolutize($val);
+            }
+            elseif ($record[1] == 'SRV') {
+              // format here is "target port"; only the target is a name
+              $parts = explode(' ', $val, 2);
+              $parts[0] = $absolutize($parts[0]);
+              $val = implode(' ', $parts);
+            }
             $vals[] = sprintf("%s\tIN\t%s\t%s\n", $label, $record[1], $val);
           }
 
           foreach ($vals as $val) {
-            $dns_data .= str_replace($domain, $domain . '.', $val);
+            $dns_data .= $val;
           }
         }
       }


### PR DESCRIPTION
## What

The DNS overview page's **Download** button produces a `$ORIGIN` zonefile, but the
right-hand side of `MX`, `CNAME` and `SRV` records was written as a **relative**
name. A target like `mail.example.net` is then interpreted relative to the origin
and expands to `mail.example.net.example.org.` — invalid, exactly as reported.

The only prior attempt at absolutizing was:

```php
$dns_data .= str_replace($domain, $domain . '.', $val);
```

which appended a dot only to targets that happened to contain the *origin* domain —
so any cross-domain target (the common case: mail host on a different domain than
the mail domain) stayed relative. That same `str_replace` also **corrupted TXT
values** containing the origin, e.g. a DMARC `rua=mailto:x@example.org` became
`...@example.org.`.

## Fix

Absolutize the RHS **per record type, at export time only**:
- `MX` / `CNAME` target, and the `SRV` target token → trailing dot
- ports, the SRV root target `.`, IP literals and `TXT` character strings → left as-is

The `$records` array used for the **on-page live DNS validation** is untouched, so
the comparison against `dns_get_record()` output (which returns bare names) still
works. The change is purely in the downloadable zonefile generation.

## Verification

Ran the real endpoint on a live mailcow stack (domain on a different domain than the
mail host, so targets are cross-domain — the reporter's scenario), before and after,
reading the actual base64 zonefile the Download button serves:

**Before**
```
@                  IN MX    mail.local.test
autodiscover       IN CNAME mail.local.test
_autodiscover._tcp IN SRV   mail.local.test 8090
_pop3._tcp         IN SRV   . 0
```
**After**
```
@                  IN MX    mail.local.test.
autodiscover       IN CNAME mail.local.test.
_autodiscover._tcp IN SRV   mail.local.test. 8090
_pop3._tcp         IN SRV   . 0
```

- Every hostname RHS is now absolute; SRV ports preserved; SRV root `.` untouched;
  `TXT`/DKIM values left literal.
- The on-page validation table still renders (HTTP 200, no PHP error).
- `php -l` clean.

## Scope

Limited to trailing dots, as the issue requests. I intentionally did **not** change
the non-standard `MX`/`SRV` RDATA shape (missing MX preference, SRV `target port`
ordering) — that's a separate concern and would alter the on-screen table too.

Fixes #6984
