### PR TITLE
[Web] redirect deep links to the matching login page

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -3503,7 +3503,16 @@ function protect_route($allowed_roles = ['admin', 'domainadmin', 'user'], $redir
     if (isset($redirects['unauthenticated'])) {
       header('Location: ' . $redirects['unauthenticated']);
     } else {
-      header('Location: /');
+      // Send a deep link to the login page for its area instead of the user login at /,
+      // e.g. /admin/dashboard -> /admin rather than /
+      $request_uri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '/';
+      if (strpos($request_uri, '/admin/') === 0) {
+        header('Location: /admin');
+      } elseif (strpos($request_uri, '/domainadmin/') === 0) {
+        header('Location: /domainadmin');
+      } else {
+        header('Location: /');
+      }
     }
     exit();
   }


### PR DESCRIPTION
## What

An unauthenticated request to a deep link like `/admin/dashboard` redirected to `/`
(the **user** login) instead of the **admin** login. `protect_route()` sent every
unauthenticated visitor to `/` regardless of which area the link belonged to.

## Fix

Choose the login page from the request path in the unauthenticated branch of
`protect_route()`:

- `/admin/*`        → `/admin`
- `/domainadmin/*`  → `/domainadmin`
- everything else   → `/` (unchanged)

## Verification (live stack, unauthenticated `curl`)

| deep link | before | after |
|---|---|---|
| `/admin/dashboard` | `/` | `/admin` |
| `/admin/mailbox` | `/` | `/admin` |
| `/domainadmin/mailbox` | `/` | `/domainadmin` |
| `/user` | `/` | `/` (unchanged) |

`php -l` clean.

## Scope

This lands deep links on the correct login page, as the issue asks. It does **not**
implement the reporter's optional "redirect back to the originally requested URL
after login" idea — that's a larger change (persisting and validating a return URL)
and better handled separately.

Fixes #7284
