### PR TITLE
[Web] show external sender addresses regardless of authsource

### DIFF
--- a/data/web/templates/edit/mailbox.twig
+++ b/data/web/templates/edit/mailbox.twig
@@ -267,6 +267,7 @@
                       <small class="text-muted">{{ lang.admin.password_reset_info }}</small>
                     </div>
                   </div>
+                  {% endif %}
                   <div data-acl="{{ acl.extend_sender_acl }}" class="row mb-4">
                     <label class="control-label col-sm-2" for="extended_sender_acl">{{ lang.edit.extended_sender_acl }}</label>
                     <div class="col-sm-10">
@@ -279,7 +280,6 @@
                       {% endif %}
                     </div>
                   </div>
-                  {% endif %}
                   <div class="row">
                     <label class="control-label col-sm-2" for="protocol_access">{{ lang.edit.allowed_protocols }}</label>
                     <div class="col-sm-10">


### PR DESCRIPTION
## Description

The `extended_sender_acl` field in the mailbox edit dialog was nested inside the block that hides the **local password** fields for mailboxes backed by an external identity provider:

```twig
{% if not result.authsource or result.authsource == 'mailcow' %}
  ... password / password2 / pw_recovery_email ...
  <div data-acl="{{ acl.extend_sender_acl }}" class="row mb-4">   <-- extended_sender_acl
{% endif %}
```

So for any mailbox with `authsource` of `keycloak`, `generic-oidc` or `ldap`, the "External sender addresses" input was not rendered at all — not even for a full admin — while the underlying `sender_acl` rows (external = 1) stayed active and enforced by Postfix. The addresses could therefore neither be reviewed nor edited from the UI.

Extended sender ACLs have nothing to do with local password management. This moves the field out of that block, leaving it gated only by `acl.extend_sender_acl` as intended.

## Verification

Tested on a live stack (admin session, real browser) against a mailbox with `authsource = generic-oidc` holding an external sender ACL entry:

| | before | after |
|---|---|---|
| `input[name=extended_sender_acl]` present | no | **yes** (value `ext-sender@external-example.com`) |
| local password fields present | no | no (unchanged — still correctly hidden) |

Control: the same mailbox switched back to `authsource = mailcow` rendered the field both before and after, so the only behaviour change is for external-IdP mailboxes.

Also confirmed the field still belongs to the `editmailbox` form and saving works end-to-end: adding a second address through the dialog persisted a new `sender_acl` row with `external = 1`.

Fixes #7365