### PR TITLE
[DockerAPI] Limit container discovery to mailcow project

### DIFF
--- a/data/Dockerfiles/dockerapi/main.py
+++ b/data/Dockerfiles/dockerapi/main.py
@@ -115,7 +115,12 @@ async def get_containers(all: bool = False):
 
   containers = {}
   try:
-    for container in (await dockerapi.async_docker_client.containers.list(all=all)):
+    # Filter before inspecting containers so unrelated projects cannot delay
+    # mailcow operations when their container metadata is unavailable.
+    container_filters = json.dumps({
+      "label": [f"com.docker.compose.project={os.environ['COMPOSE_PROJECT_NAME']}"]
+    })
+    for container in (await dockerapi.async_docker_client.containers.list(all=all, filters=container_filters)):
       container_info = await container.show()
       containers.update({container_info['Id']: container_info})
     return Response(content=json.dumps(containers, indent=4), media_type="application/json")

--- a/data/Dockerfiles/dockerapi/main.py
+++ b/data/Dockerfiles/dockerapi/main.py
@@ -115,12 +115,15 @@ async def get_containers(all: bool = False):
 
   containers = {}
   try:
-    # Filter before inspecting containers so unrelated projects cannot delay
-    # mailcow operations when their container metadata is unavailable.
-    container_filters = json.dumps({
-      "label": [f"com.docker.compose.project={os.environ['COMPOSE_PROJECT_NAME']}"]
-    })
-    for container in (await dockerapi.async_docker_client.containers.list(all=all, filters=container_filters)):
+    container_list_options = {"all": all}
+    compose_project_name = os.environ.get('COMPOSE_PROJECT_NAME')
+    if compose_project_name:
+      # Filter before inspecting containers so unrelated projects cannot delay
+      # mailcow operations when their container metadata is unavailable.
+      container_list_options["filters"] = json.dumps({
+        "label": [f"com.docker.compose.project={compose_project_name}"]
+      })
+    for container in (await dockerapi.async_docker_client.containers.list(**container_list_options)):
       container_info = await container.show()
       containers.update({container_info['Id']: container_info})
     return Response(content=json.dumps(containers, indent=4), media_type="application/json")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -601,7 +601,7 @@ services:
             - watchdog
 
     dockerapi-mailcow:
-      image: ghcr.io/mailcow/dockerapi:2.12
+      image: ghcr.io/mailcow/dockerapi:2.12a
       security_opt:
         - label=disable
       restart: always
@@ -610,6 +610,7 @@ services:
       environment:
         - DBROOT=${DBROOT}
         - TZ=${TZ}
+        - COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-mailcow-dockerized}
         - REDIS_SLAVEOF_IP=${REDIS_SLAVEOF_IP:-}
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
         - REDISPASS=${REDISPASS}


### PR DESCRIPTION
Fixes #7374.

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Mailbox and domain deletion call the Docker API to discover the Dovecot container before cleaning up mail storage. The `/containers/json` endpoint previously inspected every running container on the Docker host before its callers filtered the response to the current mailcow project.

On the reproducing host, four unrelated containers each took three seconds to inspect. Those sequential timeouts caused the consistent ~12.3-second deletion latency reported in #7374.

This change filters the Docker Engine container list by the current Compose project label before inspecting container metadata. It also passes `COMPOSE_PROJECT_NAME` to `dockerapi-mailcow` and bumps the image patch tag to `2.12a`.

### Affected Containers

- dockerapi-mailcow

## Did you run tests?

Yes.

### What did you test?

- Reproduced mailbox and domain deletion latency through the REST API.
- Timed Docker API container discovery independently from maildir cleanup.
- Built and ran the patched Docker API image against the same Docker host.
- Checked both running-container discovery and `all=true` discovery.
- Repeated mailbox and domain deletion through the normal REST API with the stack routed through the patched Docker API image.

### What were the final results? (Awaited, got)

Expected: Docker API discovery should inspect only containers in the current mailcow Compose project and should not inherit delays from unrelated containers.

Before: discovery returned 21 cross-project containers and took approximately 12.2 seconds.

After: discovery returned only the 9 containers in the mailcow project and completed in approximately 0.10 seconds. The `all=true` path remained project-scoped and completed in approximately 0.11 seconds.

With the patched image, mailbox deletion completed in 0.211 seconds and domain deletion completed in 0.215 seconds. Both requests returned HTTP 200 with success responses, and the mailbox and domain were absent from the database afterward.
