### PR TITLE
fix: less disk writes redis/unbound

### DIFF
--- a/data/conf/redis/redis-conf.sh
+++ b/data/conf/redis/redis-conf.sh
@@ -3,6 +3,7 @@
 cat <<EOF > /redis.conf
 requirepass $REDISPASS
 user quota_notify on nopass ~QW_* -@all +get +hget +ping
+save 43200 1000
 EOF
 
 if [ -n "$REDISMASTERPASS" ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       environment:
         - TZ=${TZ}
         - SKIP_UNBOUND_HEALTHCHECK=${SKIP_UNBOUND_HEALTHCHECK:-n}
+      tmpfs:
+        - /tmp
       volumes:
         - ./data/hooks/unbound:/hooks:Z
         - ./data/conf/unbound/unbound.conf:/etc/unbound/unbound.conf:ro,Z


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

* unbound: mount /tmp to tmpfs to avoid disk writes
* redis: flush to disk every 12 hours, avoid frequent writes

### Short Description

Reduces unnecessary writes to SSD/HDD.

###  Affected Containers

- redis
- unbound

## Did you run tests?

I've tested manually

### What did you tested?

I've tested that unbound healthcheck script still works, and that redis does not write every 5 minutes and has applied the configuration, checked with redis cli.

### What were the final results? (Awaited, got)

Less disk writes, about 5-6 GB/day less.