### PR TITLE
[Redis] Update to 7.4.10

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
             - mysql
 
     redis-mailcow:
-      image: redis:7.4.6-alpine
+      image: redis:7.4.10-alpine
       entrypoint: ["/bin/sh","/redis-conf.sh"]
       volumes:
         - redis-vol-1:/data/


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Bumps the Redis image from `7.4.6-alpine` to `7.4.10-alpine`. This pulls in the security fixes from 7.4.8 (`\r\n` error-reply injection), 7.4.9 (CVE-2026-23479, CVE-2026-25243, CVE-2026-23631 – RCE) and 7.4.10 (stream RESTORE NACK use-after-free). Patch-level bump within the 7.4 line, no breaking changes.

###  Affected Containers

- redis-mailcow

## Did you run tests?

### What did you tested?

Pulled `redis:7.4.10-alpine`, recreated `redis-mailcow` and verified persisted data survives the restart (fingerprinted all persistent keys before/after).
