### PR TITLE
[Web] Add ACL + global switch to disable external alias goto

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -633,6 +633,18 @@ function logger($_data = false) {
     return true;
   }
 }
+function is_local_mailcow_domain($domain) {
+  // True if domain is a locally managed, active primary or alias domain
+  global $pdo;
+  $domain = idn_to_ascii($domain, 0, INTL_IDNA_VARIANT_UTS46);
+  if (empty($domain)) {
+    return false;
+  }
+  $stmt = $pdo->prepare("SELECT 1 FROM `domain` WHERE `domain` = :d AND `active` = 1
+    UNION SELECT 1 FROM `alias_domain` WHERE `alias_domain` = :d2 AND `active` = 1 LIMIT 1");
+  $stmt->execute(array(':d' => $domain, ':d2' => $domain));
+  return (bool)$stmt->fetchColumn();
+}
 function hasDomainAccess($username, $role, $domain) {
   global $pdo;
   if (empty($domain) || !is_valid_domain_name($domain)) {

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -750,6 +750,18 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               $goto_domain = idn_to_ascii(substr(strstr($goto, '@'), 1), 0, INTL_IDNA_VARIANT_UTS46);
               $goto_local_part = strstr($goto, '@', true);
               $goto = $goto_local_part.'@'.$goto_domain;
+              // Deny external goto domains: global switch (all roles) overrides the per-DA ACL
+              if (($GLOBALS['ALIAS_DISABLE_EXTERNAL_DOMAINS'] === true ||
+                  (isset($_SESSION['acl']['alias_external_goto']) && $_SESSION['acl']['alias_external_goto'] != "1")) &&
+                  !is_local_mailcow_domain($goto_domain)) {
+                $_SESSION['return'][] = array(
+                  'type' => 'danger',
+                  'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
+                  'msg' => array('external_goto_denied', htmlspecialchars($goto))
+                );
+                unset($gotos[$i]);
+                continue;
+              }
               $stmt = $pdo->prepare("SELECT `username` FROM `mailbox`
                 WHERE `kind` REGEXP 'location|thing|group'
                   AND `username`= :goto");
@@ -2711,6 +2723,19 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                     'type' => 'danger',
                     'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
                     'msg' => array('goto_invalid', $goto)
+                  );
+                  unset($gotos[$i]);
+                  continue;
+                }
+                // Deny external goto domains: global switch (all roles) overrides the per-DA ACL
+                $goto_domain = idn_to_ascii(substr(strstr($goto, '@'), 1), 0, INTL_IDNA_VARIANT_UTS46);
+                if (($GLOBALS['ALIAS_DISABLE_EXTERNAL_DOMAINS'] === true ||
+                    (isset($_SESSION['acl']['alias_external_goto']) && $_SESSION['acl']['alias_external_goto'] != "1")) &&
+                    !is_local_mailcow_domain($goto_domain)) {
+                  $_SESSION['return'][] = array(
+                    'type' => 'danger',
+                    'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
+                    'msg' => array('external_goto_denied', htmlspecialchars($goto))
                   );
                   unset($gotos[$i]);
                   continue;

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -4,7 +4,7 @@ function init_db_schema()
   try {
     global $pdo;
 
-    $db_version = "19022026_1220";
+    $db_version = "18082026_1200";
 
     $stmt = $pdo->query("SHOW TABLES LIKE 'versions'");
     $num_results = count($stmt->fetchAll(PDO::FETCH_ASSOC));
@@ -719,7 +719,8 @@ function init_db_schema()
           "alias_domains" => "TINYINT(1) NOT NULL DEFAULT '0'",
           "mailbox_relayhost" => "TINYINT(1) NOT NULL DEFAULT '1'",
           "domain_relayhost" => "TINYINT(1) NOT NULL DEFAULT '1'",
-          "domain_desc" => "TINYINT(1) NOT NULL DEFAULT '0'"
+          "domain_desc" => "TINYINT(1) NOT NULL DEFAULT '0'",
+          "alias_external_goto" => "TINYINT(1) NOT NULL DEFAULT '1'"
         ),
         "keys" => array(
           "primary" => array(

--- a/data/web/inc/vars.inc.php
+++ b/data/web/inc/vars.inc.php
@@ -246,6 +246,10 @@ $PW_RESET_TOKEN_LIMIT = 3;
 // Maximum time in minutes a password reset token is valid
 $PW_RESET_TOKEN_LIFETIME = 15;
 
+// Globally forbid aliases with external (non-local) goto domains for ALL roles (incl. admins),
+// overriding the per-domain-admin da_acl. false = defer to da_acl.
+$ALIAS_DISABLE_EXTERNAL_DOMAINS = false;
+
 // UV flag handling in FIDO2/WebAuthn - defaults to false to allow iOS logins
 // true = required
 // false = preferred

--- a/data/web/lang/lang.de-de.json
+++ b/data/web/lang/lang.de-de.json
@@ -1,6 +1,7 @@
 {
     "acl": {
         "alias_domains": "Alias-Domains hinzufügen",
+        "alias_external_goto": "Aliase mit externen Ziel-Domains erlauben",
         "app_passwds": "App-Passwörter verwalten",
         "bcc_maps": "BCC-Maps",
         "delimiter_action": "Delimiter-Aktionen (tags)",
@@ -443,6 +444,7 @@
         "domain_not_found": "Domain %s nicht gefunden",
         "domain_quota_m_in_use": "Domain-Speicherplatzlimit muss größer oder gleich %d MiB sein",
         "extended_sender_acl_denied": "Keine Rechte zum Setzen von externen Absenderadressen",
+        "external_goto_denied": "Externe Ziel-Adresse %s ist nicht erlaubt",
         "extra_acl_invalid": "Externe Absenderadresse \"%s\" ist ungültig",
         "extra_acl_invalid_domain": "Externe Absenderadresse \"%s\" verwendet eine ungültige Domain",
         "fido2_verification_failed": "FIDO2-Verifizierung fehlgeschlagen: %s",

--- a/data/web/lang/lang.en-gb.json
+++ b/data/web/lang/lang.en-gb.json
@@ -1,6 +1,7 @@
 {
     "acl": {
         "alias_domains": "Add alias domains",
+        "alias_external_goto": "Allow aliases with external goto domains",
         "app_passwds": "Manage app passwords",
         "bcc_maps": "BCC maps",
         "delimiter_action": "Delimiter action",
@@ -444,6 +445,7 @@
         "domain_not_found": "Domain %s not found",
         "domain_quota_m_in_use": "Domain quota must be greater or equal to %s MiB",
         "extended_sender_acl_denied": "missing ACL to set external sender addresses",
+        "external_goto_denied": "External goto address %s is not allowed",
         "extra_acl_invalid": "External sender address \"%s\" is invalid",
         "extra_acl_invalid_domain": "External sender \"%s\" uses an invalid domain",
         "fido2_verification_failed": "FIDO2 verification failed: %s",


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Prevents aliases from targeting external (non local) domains, which commonly breaks SPF.

There are two levels of control:

* Global switch `$ALIAS_DISABLE_EXTERNAL_DOMAINS` in `vars.inc.php` (default `false`). When enabled it applies to all roles including admins and overrides the domain admin ACL.
* New domain admin ACL `alias_external_goto` (default allowed) that lets a super admin restrict individual domain admins. It is rendered automatically in the domain admin edit UI through the existing `da_acl` system.

A domain counts as local only if it exists as an active `domain` or `alias_domain`. The check runs in both alias `add` and `edit` paths, and goto domains are normalised via IDN before the comparison.

### Affected Containers

* php-fpm-mailcow

