### PR TITLE
Add OIDC-compatible claims to OAuth2 profile response

### DIFF
--- a/data/web/oauth/profile.php
+++ b/data/web/oauth/profile.php
@@ -12,7 +12,7 @@ $mailbox = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!empty($mailbox)) {
   if ($oauth2_server->getScopeUtil()->checkScope('profile', $token['scope'])) {
     $name = trim((string)($mailbox['name'] ?? ''));
-    $name_parts = $name === '' ? array() : preg_split('/\s+/u', $name);
+    $name_parts = $name === '' ? array() : preg_split('/\s+/u', $name, -1, PREG_SPLIT_NO_EMPTY);
     $given_name = $name_parts[0] ?? '';
     $family_name = count($name_parts) > 1 ? implode(' ', array_slice($name_parts, 1)) : '';
     header('Content-Type: application/json');

--- a/data/web/oauth/profile.php
+++ b/data/web/oauth/profile.php
@@ -10,6 +10,7 @@ $stmt = $pdo->prepare("SELECT * FROM `mailbox` WHERE `username` = :username AND 
 $stmt->execute(array(':username' => $token['user_id']));
 $mailbox = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!empty($mailbox)) {
+  // Require profile while allowing additional scopes.
   if ($oauth2_server->getScopeUtil()->checkScope('profile', $token['scope'])) {
     $name = trim((string)($mailbox['name'] ?? ''));
     $name_parts = $name === '' ? array() : preg_split('/\s+/u', $name, -1, PREG_SPLIT_NO_EMPTY);

--- a/data/web/oauth/profile.php
+++ b/data/web/oauth/profile.php
@@ -10,7 +10,11 @@ $stmt = $pdo->prepare("SELECT * FROM `mailbox` WHERE `username` = :username AND 
 $stmt->execute(array(':username' => $token['user_id']));
 $mailbox = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!empty($mailbox)) {
-  if ($token['scope'] == 'profile') {
+  if ($oauth2_server->getScopeUtil()->checkScope('profile', $token['scope'])) {
+    $name = trim((string)($mailbox['name'] ?? ''));
+    $name_parts = $name === '' ? array() : preg_split('/\s+/', $name);
+    $given_name = $name_parts[0] ?? '';
+    $family_name = count($name_parts) > 1 ? implode(' ', array_slice($name_parts, 1)) : '';
     header('Content-Type: application/json');
     echo json_encode(array(
       'success' => true,
@@ -18,8 +22,11 @@ if (!empty($mailbox)) {
       'id' => $token['user_id'],
       'identifier' => $token['user_id'],
       'email' => (!empty($mailbox['username']) ? $mailbox['username'] : ''),
-      'full_name' => (!empty($mailbox['name']) ? $mailbox['name'] : 'mailcow administrative user'),
-      'displayName' => (!empty($mailbox['name']) ? $mailbox['name'] : 'mailcow administrative user'),
+      'email_verified' => true,
+      'full_name' => ($name !== '' ? $name : 'mailcow administrative user'),
+      'displayName' => ($name !== '' ? $name : 'mailcow administrative user'),
+      'given_name' => $given_name,
+      'family_name' => $family_name,
       'created' => (!empty($mailbox['created']) ? $mailbox['created'] : ''),
       'modified' => (!empty($mailbox['modified']) ? $mailbox['modified'] : ''),
       'active' => (!empty($mailbox['active']) ? $mailbox['active'] : ''),

--- a/data/web/oauth/profile.php
+++ b/data/web/oauth/profile.php
@@ -12,7 +12,7 @@ $mailbox = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!empty($mailbox)) {
   if ($oauth2_server->getScopeUtil()->checkScope('profile', $token['scope'])) {
     $name = trim((string)($mailbox['name'] ?? ''));
-    $name_parts = $name === '' ? array() : preg_split('/\s+/', $name);
+    $name_parts = $name === '' ? array() : preg_split('/\s+/u', $name);
     $given_name = $name_parts[0] ?? '';
     $family_name = count($name_parts) > 1 ? implode(' ', array_slice($name_parts, 1)) : '';
     header('Content-Type: application/json');


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Adds `email_verified`, `given_name` and `family_name` to the existing OAuth2 profile response.

The change is backward-compatible and improves compatibility with clients such as WordPress and Dex. It also prepares the profile response for adding the `openid` scope later.

`email_verified` is `true` because the endpoint only returns an active mailbox after successful authentication, and the email address is the mailbox identity provisioned by mailcow.

Closes #6658
Related to #4535

### Affected Containers

- php-fpm-mailcow

## Did you run tests?

### What did you tested?

- PHP syntax validation
- Profile scope handling with `profile`, `openid profile email`, and `email` without `profile`
- Empty, single-part, multi-part, and Unicode-whitespace names

### What were the final results? (Awaited, got)

All checks passed with the expected results.
